### PR TITLE
Add Plausible

### DIFF
--- a/app/components/ShopCard.tsx
+++ b/app/components/ShopCard.tsx
@@ -20,12 +20,12 @@ export default function ShopCard(props: IProps) {
 
   const handleCardClick = () => {
     setIsOpen(true)
-    plausible('CardClick')
+    plausible('CardClick', { props: {} })
   }
 
   const handleNeighborhoodClick = () => {
     props.onShopClick(props.shop.neighborhood)
-    plausible('NeighborhoodClick')
+    plausible('NeighborhoodClick', { props: {} })
   }
 
   return (

--- a/app/components/ShopCard.tsx
+++ b/app/components/ShopCard.tsx
@@ -20,12 +20,12 @@ export default function ShopCard(props: IProps) {
 
   const handleCardClick = () => {
     setIsOpen(true)
-    plausible('CardClick', {props: { shopName: props.shop.name }})
+    plausible('CardClick')
   }
 
   const handleNeighborhoodClick = () => {
     props.onShopClick(props.shop.neighborhood)
-    plausible('NeighborhoodClick', {props: { neighborhood: props.shop.neighborhood }})
+    plausible('NeighborhoodClick')
   }
 
   return (

--- a/app/components/ShopCard.tsx
+++ b/app/components/ShopCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { usePlausible } from 'next-plausible'
 import { TShop } from '@/types/shop-types'
 import ShopPanel from '@/app/components/ShopPanel'
 
@@ -10,18 +11,29 @@ interface IProps {
 }
 
 export default function ShopCard(props: IProps) {
+  const plausible = usePlausible()
   let [isOpen, setIsOpen] = useState(false)
 
   const handleClose = () => {
     setIsOpen(false)
   }
 
+  const handleCardClick = () => {
+    setIsOpen(true)
+    plausible('CardClick', {props: { shopName: props.shop.name }})
+  }
+
+  const handleNeighborhoodClick = () => {
+    props.onShopClick(props.shop.neighborhood)
+    plausible('NeighborhoodClick', {props: { neighborhood: props.shop.neighborhood }})
+  }
+
   return (
     <>
       <div className="relative rounded overflow-hidden shadow-md">
           <div className="px-6 py-4">
-            <button className="font-medium text-xl mb-1 text-left block hover:underline" onClick={() => setIsOpen(true)}>{props.shop.name}</button>
-            <button className="w-fit mb-1 text-left text-gray-700 border border-transparent hover:border-black hover:border-dashed hover:cursor-pointer" onClick={() => props.onShopClick(props.shop.neighborhood)}>{props.shop.neighborhood}</button>
+            <button className="font-medium text-xl mb-1 text-left block hover:underline" onClick={handleCardClick}>{props.shop.name}</button>
+            <button className="w-fit mb-1 text-left text-gray-700 border border-transparent hover:border-black hover:border-dashed hover:cursor-pointer" onClick={handleNeighborhoodClick}>{props.shop.neighborhood}</button>
             <address className="text-gray-700">{props.shop.address}</address>
           </div>
     </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import PlausibleProvider from 'next-plausible'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
@@ -16,7 +17,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      {/* <Nav /> */}
+      <head>
+        <PlausibleProvider domain="pgh.coffee" />
+      </head>
       <body className={inter.className}>{children}</body>
     </html>
   )

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,11 +18,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <PlausibleProvider
-          domain="pgh.coffee"
-          taggedEvents
-          trackOutboundLinks
-        />
+        <PlausibleProvider domain="pgh.coffee" trackOutboundLinks />
       </head>
       <body className={inter.className}>{children}</body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,7 +18,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <PlausibleProvider domain="pgh.coffee" />
+        <PlausibleProvider
+          domain="pgh.coffee"
+          taggedEvents
+          trackOutboundLinks
+        />
       </head>
       <body className={inter.className}>{children}</body>
     </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,17 @@
+[[redirects]]
+  from = "/js/script.js"
+  to = "https://plausible.io/js/script.js"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/js/script.outbound-links.js"
+  to = "https://plausible.io/js/script.outbound-links.js"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/api/event"
+  to = "https://plausible.io/api/event"
+  status = 200
+  force = true

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,4 @@
 const { withPlausibleProxy } = require('next-plausible')
 
 
-module.exports = withPlausibleProxy()({
-  // ...your next js config, if any
-  // Important! it is mandatory to pass a config object, even if empty
-})
+module.exports = withPlausibleProxy()({ })

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,3 @@
 const { withPlausibleProxy } = require('next-plausible')
 
-
 module.exports = withPlausibleProxy()({ })

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,7 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {}
+const { withPlausibleProxy } = require('next-plausible')
 
-module.exports = nextConfig
+
+module.exports = withPlausibleProxy()({
+  // ...your next js config, if any
+  // Important! it is mandatory to pass a config object, even if empty
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@headlessui/react": "^1.7.18",
         "@heroicons/react": "^2.1.1",
         "next": "^14.2.3",
+        "next-plausible": "^3.12.1",
         "react": "^18",
         "react-dom": "^18"
       },
@@ -3001,6 +3002,19 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-plausible": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.12.1.tgz",
+      "integrity": "sha512-DcQxB/oE8gOLuIU0SBbzN0dYYNibOXgKfnzPkO9SXug6B4Y95eT41JgbN3gjlcsqHWaDWJu/s3928O7ilo2sTg==",
+      "funding": {
+        "url": "https://github.com/4lejandrito/next-plausible?sponsor=1"
+      },
+      "peerDependencies": {
+        "next": "^11.1.0 || ^12.0.0 || ^13.0.0 || ^14.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -6510,6 +6524,12 @@
         "postcss": "8.4.31",
         "styled-jsx": "5.1.1"
       }
+    },
+    "next-plausible": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.12.1.tgz",
+      "integrity": "sha512-DcQxB/oE8gOLuIU0SBbzN0dYYNibOXgKfnzPkO9SXug6B4Y95eT41JgbN3gjlcsqHWaDWJu/s3928O7ilo2sTg==",
+      "requires": {}
     },
     "node-releases": {
       "version": "2.0.13",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@headlessui/react": "^1.7.18",
     "@heroicons/react": "^2.1.1",
     "next": "^14.2.3",
+    "next-plausible": "^3.12.1",
     "react": "^18",
     "react-dom": "^18"
   },


### PR DESCRIPTION
Adds [Plausible](https://plausible.io/ ) for analytics that will mostly be used for my own vanity. Tracks page views and generic card and neighborhood click events. I still need to find a way to get specific data about _which_ card or neighborhood was clicked (ideally without going to the next Plausible tier with [custom properties](https://plausible.io/docs/custom-props/introduction))