### PR TITLE
Store neighborhood as search param

### DIFF
--- a/app/components/ShopCard.tsx
+++ b/app/components/ShopCard.tsx
@@ -24,6 +24,12 @@ export default function ShopCard(props: IProps) {
   }
 
   const handleNeighborhoodClick = () => {
+    const url = new URL(window.location.href)
+    const params = new URLSearchParams(url.search)
+    params.set('neigborhood', props.shop.neighborhood.toLowerCase())
+    url.search = params.toString()
+    history.replaceState({}, '', url.toString())
+
     props.onShopClick(props.shop.neighborhood)
     plausible('NeighborhoodClick', { props: {} })
   }

--- a/app/components/ShopCard.tsx
+++ b/app/components/ShopCard.tsx
@@ -26,7 +26,7 @@ export default function ShopCard(props: IProps) {
   const handleNeighborhoodClick = () => {
     const url = new URL(window.location.href)
     const params = new URLSearchParams(url.search)
-    params.set('neigborhood', props.shop.neighborhood.toLowerCase())
+    params.set('neighborhood', props.shop.neighborhood.toLowerCase())
     url.search = params.toString()
     history.replaceState({}, '', url.toString())
 

--- a/app/components/ShopCard.tsx
+++ b/app/components/ShopCard.tsx
@@ -24,11 +24,13 @@ export default function ShopCard(props: IProps) {
   }
 
   const handleNeighborhoodClick = () => {
-    const url = new URL(window.location.href)
-    const params = new URLSearchParams(url.search)
-    params.set('neighborhood', props.shop.neighborhood.toLowerCase())
-    url.search = params.toString()
-    history.replaceState({}, '', url.toString())
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href)
+      const params = new URLSearchParams(url.search)
+      params.set('neighborhood', props.shop.neighborhood.toLowerCase())
+      url.search = params.toString()
+      history.replaceState({}, '', url.toString())
+    }
 
     props.onShopClick(props.shop.neighborhood)
     plausible('NeighborhoodClick', { props: {} })

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import CoffeeShops from '@/data/coffee_shops.json'
 import Footer from '@/app/components/Footer'
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 
-export default function Home() {
+export default function Home({searchParams}) {
   const [filter, setFilter] = useState('')
 
   const handleQueryString = useMemo(() => {
@@ -15,6 +15,11 @@ export default function Home() {
       const myParam = params.get('neighborhood')
       if (myParam) {
         setFilter(myParam)
+      }
+    }
+    if (typeof window === 'undefined') {
+      if (searchParams) {
+          setFilter(searchParams.neighborhood)
       }
     }
   }, [])

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import ShopCard from '@/app/components/ShopCard'
 import CoffeeShops from '@/data/coffee_shops.json'
 import Footer from '@/app/components/Footer'
@@ -8,6 +8,14 @@ import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 
 export default function Home() {
   const [filter, setFilter] = useState('')
+
+  const handleQueryString = useMemo(() => {
+    const params = new URLSearchParams(window.location.search)
+    const myParam = params.get('neighborhood')
+    if (myParam) {
+      setFilter(myParam)
+    }
+  }, [])
 
   const coffeeShops = [...CoffeeShops]
   coffeeShops.sort((a, b) => a.neighborhood.localeCompare(b.neighborhood))

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,15 @@ export default function Home() {
     setFilter(e.target.value)
   }
 
+  const handleFilterClear = () => {
+    setFilter('')
+    const url = new URL(window.location.href)
+    const params = new URLSearchParams(url.search)
+    params.delete('neighborhood')
+    url.search = params.toString()
+    history.replaceState({}, '', url.toString())
+  }
+
   const meetsFilterCriteria = (shop: any) => {
     const shopCardText = `${shop.neighborhood.toLowerCase()} ${shop.name.toLowerCase()}`
     return shopCardText.includes(filter.toLowerCase())
@@ -49,7 +58,7 @@ export default function Home() {
               placeholder="Search for a shop"
               value={filter}
             />
-            <button className="inline ml-2 p-1 text-gray-500 hover:text-gray-600" onClick={() => setFilter('')}>
+            <button className="inline ml-2 p-1 text-gray-500 hover:text-gray-600" onClick={handleFilterClear}>
               ×
             </button>
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import CoffeeShops from '@/data/coffee_shops.json'
 import Footer from '@/app/components/Footer'
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 
-export default function Home({searchParams}) {
+export default function Home({searchParams}: {searchParams: any}) {
   const [filter, setFilter] = useState('')
 
   const handleQueryString = useMemo(() => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,10 +10,12 @@ export default function Home() {
   const [filter, setFilter] = useState('')
 
   const handleQueryString = useMemo(() => {
-    const params = new URLSearchParams(window.location.search)
-    const myParam = params.get('neighborhood')
-    if (myParam) {
-      setFilter(myParam)
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search)
+      const myParam = params.get('neighborhood')
+      if (myParam) {
+        setFilter(myParam)
+      }
     }
   }, [])
 
@@ -26,11 +28,13 @@ export default function Home() {
 
   const handleFilterClear = () => {
     setFilter('')
-    const url = new URL(window.location.href)
-    const params = new URLSearchParams(url.search)
-    params.delete('neighborhood')
-    url.search = params.toString()
-    history.replaceState({}, '', url.toString())
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href)
+      const params = new URLSearchParams(url.search)
+      params.delete('neighborhood')
+      url.search = params.toString()
+      history.replaceState({}, '', url.toString())
+    }
   }
 
   const meetsFilterCriteria = (shop: any) => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import CoffeeShops from '@/data/coffee_shops.json'
 import Footer from '@/app/components/Footer'
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 
-export default function Home({searchParams}: {searchParams: any}) {
+export default function Home({ searchParams }: { searchParams: any }) {
   const [filter, setFilter] = useState('')
 
   const handleQueryString = useMemo(() => {
@@ -16,10 +16,9 @@ export default function Home({searchParams}: {searchParams: any}) {
       if (myParam) {
         setFilter(myParam)
       }
-    }
-    if (typeof window === 'undefined') {
+    } else {
       if (searchParams) {
-          setFilter(searchParams.neighborhood)
+        setFilter(searchParams.neighborhood)
       }
     }
   }, [])


### PR DESCRIPTION
Stores the neighborhood filter as a search param. This allows users to share URLs with filters applied e.g. `pgh.coffee/?neighborhood=central+lawrenceville`