### PR TITLE
Added Parisi Cafe in Swissvale

### DIFF
--- a/data/coffee_shops.json
+++ b/data/coffee_shops.json
@@ -287,7 +287,7 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Cafe Americano", 
+        "name": "Cafe Americano",
         "neighborhood": "Castle Shannon",
         "website": "",
         "address": "300 Mt Lebanon Blvd, Pittsburgh, PA 15234",
@@ -1882,6 +1882,21 @@
         "type": "Point",
         "coordinates": [-80.004435, 40.4337496666667]
       }
+    },
+    {
+      "type": "Feature",
+      "properties":{
+        "name": "Parisi Cafe",
+        "neighborhood": "Swissvale",
+        "website":"https://www.parisicafepittsburgh.com/",
+        "address": "7107 Harrison Ave, Swissvale, PA 15218",
+        "roaster": ""
+      },
+      "geometry":{
+        "type":"Point",
+        "coordinates":[-79.8992489, 40.4221095]
+      }
     }
+
   ]
 }

--- a/data/neighborhoods.json
+++ b/data/neighborhoods.json
@@ -324,6 +324,10 @@
     "value": "swisshelm_park"
   },
   {
+    "name": "Swissvale",
+    "value": "swissvale"
+  },
+  {
     "name": "Terrace Village",
     "value": "terrace_village"
   },


### PR DESCRIPTION
Added content to the data files to  add the[ Parisi Cafe in Swissvale](https://www.parisicafepittsburgh.com/) to coffee_shops.json and Swissvale itself to the neightborhoods.json.

I followed the conventions of the files, let me know if I missed something.

One caveat: the application built without issue but I do not have a map API key so I was not able to fully test.  Since it's just a data change I didn't worry about it but if you'd prefer kick it back and I'll test again.