### PR TITLE
Fix #41

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -80,14 +80,11 @@ export default function Mappy() {
 
   const handleClose = () => {
     setIsOpen(false)
-
-    setTimeout(() => {
-      setCurrentShop({} as TShop)
-      setDataSet(shopGeoJSON)
-    }, 700)
+    setDataSet(shopGeoJSON)
   }
 
   const handleSearchClick = () => {
+    setCurrentShop({} as TShop)
     setIsOpen(true)
   }
 


### PR DESCRIPTION
Removes the duct tape solution of using a timeout to handle clearing the currentShop. Instead, make opening the search panel responsible for setting the current shop to an empty object. This resolves the flicker when closing the drawer and no fixes #41.