### PR TITLE
Clicking search icon before data loads crashes app

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,8 +101,10 @@ export default function Home() {
   }
 
   const handleSearchClick = () => {
-    setCurrentShop({} as TShop)
-    setIsOpen(true)
+    if (Object.keys(coffeeShops).length) {
+      setCurrentShop({} as TShop)
+      setIsOpen(true)
+    }
   }
 
   const handleNearbyShopClick = (shopFromShopPanel: TShop) => {

--- a/stores/coffeeShopsStore.ts
+++ b/stores/coffeeShopsStore.ts
@@ -11,7 +11,7 @@ interface CoffeeShopsState {
 const useCoffeeShopsStore = create<CoffeeShopsState>()(
   devtools(
     (set) => ({
-      coffeeShops: [],
+      coffeeShops: {},
 
       setCoffeeShops: (data: TShop[]) => set({ coffeeShops: data }),
 


### PR DESCRIPTION
If the user attempts to open the search panel before the GET request finished, they'll see this error: `Application error: a client-side exception has occurred (see the browser console for more information).` This is due to `dataSet.features` being undefined, which causes `.map` to throw a type error.

By ensuring `coffeeShops` isn't an empty object, we know the API request has finished and we have the data we expect. 