### PR TITLE
Search can handle diacritical marks

### DIFF
--- a/app/components/ShopSearch.tsx
+++ b/app/components/ShopSearch.tsx
@@ -14,7 +14,10 @@ export default function ShopSearch(props: IProps) {
 
   const meetsFilterCriteria = (shop: TShop) => {
     if (filter) {
-      const shopCardText = `${shop.properties.neighborhood.toLowerCase()} ${shop.properties.name.toLowerCase()}`
+      const shopCardText = `${shop.properties.neighborhood.toLowerCase()} ${shop.properties.name
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')}`
       return shopCardText.includes(filter.toLowerCase())
     }
   }
@@ -69,7 +72,7 @@ export default function ShopSearch(props: IProps) {
                 key={shop.properties.name + shop.properties.address}
                 className="relative mb-4 rounded overflow-hidden shadow-md hover:cursor-pointer"
                 onClick={() => handleCardClick(shop)}
-                onKeyPress={(event) => handleKeyPress(event, shop)}
+                onKeyPress={event => handleKeyPress(event, shop)}
                 tabIndex={0}
                 role="button"
               >


### PR DESCRIPTION
Addresses #65 

Before:
<img width="621" alt="image" src="https://github.com/user-attachments/assets/fc49c053-ea30-4c55-83d1-5bb689fd29f3">


After:
<img width="667" alt="image" src="https://github.com/user-attachments/assets/fb015c9a-2ac8-49a5-b7f5-bc8ad8065a2f">
