### PR TITLE
Clicking a shop's address will open Google Maps

### DIFF
--- a/app/components/PanelContent.tsx
+++ b/app/components/PanelContent.tsx
@@ -25,10 +25,10 @@ export default function PanelContent(props: IProps) {
             <ArrowTopRightOnSquareIcon className="ml-1 h-4 w-4 inline" aria-hidden="true" />
           </a>
         )}
-        <address className="mt-1 text-sm text-gray-900">{props.shop.properties.address}</address>
-        <p className="mt-1 text-sm text-gray-900">
-          {props.shop.properties.neighborhood}
-        </p>
+        <a href={`geo:${props.shop.geometry.coordinates[0]},${props.shop.geometry.coordinates[1]}`}>
+          <address className="mt-1 text-sm text-gray-900">{props.shop.properties.address}</address>
+        </a>
+        <p className="mt-1 text-sm text-gray-900">{props.shop.properties.neighborhood}</p>
       </div>
       <NearbyShops shop={props.shop} handleClick={props.handleNearbyShopClick} />
     </>

--- a/app/components/PanelContent.tsx
+++ b/app/components/PanelContent.tsx
@@ -25,7 +25,11 @@ export default function PanelContent(props: IProps) {
             <ArrowTopRightOnSquareIcon className="ml-1 h-4 w-4 inline" aria-hidden="true" />
           </a>
         )}
-        <a href={`geo:${props.shop.geometry.coordinates[0]},${props.shop.geometry.coordinates[1]}`}>
+        <a
+          href={`https://www.google.com/maps?q=${props.shop.geometry.coordinates[1]},${props.shop.geometry.coordinates[0]}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <address className="mt-1 text-sm text-gray-900">{props.shop.properties.address}</address>
         </a>
         <p className="mt-1 text-sm text-gray-900">{props.shop.properties.neighborhood}</p>


### PR DESCRIPTION
I wanted to use [geo:uri](https://www.rfc-editor.org/rfc/rfc5870) for this, but it doesn't seem to have widespread adoption. I'd love for users to be able to get directions in the map app of their choice, but Google Maps is better than nothing.