### PR TITLE
Only highlight the selected shop at shared addresses

### DIFF
--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -128,7 +128,7 @@ export default function HomeClient() {
     const newData = {
       ...dataSet,
       features: dataSet.features.map((f: TShop) => {
-        const isSelected = f.properties.address === currentShop.properties?.address
+        const isSelected = (f.properties.address === currentShop.properties?.address && f.properties.name === currentShop.properties?.name)
         return {
           ...f,
           properties: {

--- a/app/components/NearbyShops.tsx
+++ b/app/components/NearbyShops.tsx
@@ -49,7 +49,8 @@ export default function NearbyShops({ handleClick, shop }: IProps) {
 
     return coffeeShops.features
       .filter((s: TShop) => {
-        const isDifferentShop = s.properties.address !== shop.properties.address
+        const isDifferentShop =
+          s.properties.address !== shop.properties.address || s.properties.name !== shop.properties.name
         const distance = haversineDistance(s.geometry.coordinates, shop.geometry.coordinates)
         return isDifferentShop && distance < 1000
       })


### PR DESCRIPTION
Resolves #103 

Also solves the bonus issue mentioned – shops with same address will show up in nearby shops list

https://github.com/user-attachments/assets/2d41d002-cc2c-4d46-883e-b2a1654758bf


A better, long-term solution would be to check shop IDs instead of combining their name + address

