### PR TITLE
Bring back tailwind3 cursor behavior

### DIFF
--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -151,7 +151,7 @@ export default function HomeClient() {
       {/* @TODO currentShop is only used for coordinates (and properties to avoid rendering search) */}
       <MapContainer
         dataSet={dataSet}
-        currentShop={currentShop}
+        currentShopCoordinates={[currentShop?.geometry?.coordinates[0], currentShop?.geometry?.coordinates[1]]}
         onShopSelect={(properties, geometry, type) => {
           const shop = {
             properties,

--- a/app/components/MapContainer.tsx
+++ b/app/components/MapContainer.tsx
@@ -8,11 +8,11 @@ interface MapContainerProps {
     type: string
     features: TShop[]
   }
-  currentShop: TShop
+  currentShopCoordinates: [number, number]
   onShopSelect: (properties: Record<string, any>, geometry: Record<string, any>, type: string) => void
 }
 
-export default function MapContainer({ dataSet, currentShop, onShopSelect }: MapContainerProps) {
+export default function MapContainer({ dataSet, currentShopCoordinates, onShopSelect }: MapContainerProps) {
   const mapRef = useRef<MapRef | null>(null)
   const layerId = 'myPoint'
 
@@ -34,10 +34,10 @@ export default function MapContainer({ dataSet, currentShop, onShopSelect }: Map
   } as const
 
   const panToCurrentShop = () => {
-    if (currentShop?.properties && currentShop?.geometry?.coordinates) {
+    if (currentShopCoordinates?.every(element => Boolean(element))) {
       if (mapRef.current) {
         mapRef.current.flyTo({
-          center: [currentShop.geometry.coordinates[0], currentShop.geometry.coordinates[1]],
+          center: [currentShopCoordinates[0], currentShopCoordinates[1]],
           zoom: mapRef.current.getZoom(),
           bearing: 0,
           pitch: 0,
@@ -48,7 +48,7 @@ export default function MapContainer({ dataSet, currentShop, onShopSelect }: Map
     }
   }
 
-  useEffect(panToCurrentShop, [currentShop])
+  useEffect(panToCurrentShop, [currentShopCoordinates])
 
   const handleMapClick = (event: MapMouseEvent) => {
     const map = mapRef.current?.getMap()

--- a/app/components/SearchFAB.tsx
+++ b/app/components/SearchFAB.tsx
@@ -8,7 +8,7 @@ export default function SearchFAB({ handleClick }: IProps) {
   return (
     <button
       aria-label="Search shops"
-      className="absolute bottom-[10%] right-[5%] bg-yellow-300 hover:bg-yellow-400 rounded-full h-16 w-16 flex justify-center items-center cursor-pointer"
+      className="absolute bottom-[10%] right-[5%] bg-yellow-300 hover:bg-yellow-400 rounded-full h-16 w-16 flex justify-center items-center"
       onClick={handleClick}
     >
       <MagnifyingGlassIcon className="h-8 w-8" />

--- a/app/globals.css
+++ b/app/globals.css
@@ -20,6 +20,13 @@ body {
   @apply bg-gray-50;
 }
 
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}
+
 .mapboxgl-ctrl,
 .mapboxgl-ctrl-attrib,
 .mapboxgl-ctrl-attrib-inner {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -52,7 +52,7 @@ export default function Settings() {
                 {isLoading ? <LoadingState /> : <div className="text-gray-900">{unitFromLocalStorage}</div>}
                 <button
                   aria-label="Update distance units"
-                  className="font-semibold text-slate-700 hover:text-slate-600"
+                  className="font-semibold text-slate-700 hover:text-slate-500"
                   onClick={() => setDistanceUnitsDialogIsOpen(true)}
                   type="button"
                 >


### PR DESCRIPTION
https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor

I didn't notice this when I made the upgrade to Tailwind V4 (#100). Plus a fun refactor where HomeClient sends less data to MapContainer