### PR TITLE
Fix page title not updating on client-side navigation

### DIFF
--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -109,6 +109,14 @@ export default function HomeClient() {
     }
   }, [presented, largeViewport])
 
+  useEffect(() => {
+    if (currentShop?.properties?.name && currentShop?.properties?.neighborhood) {
+      document.title = `${currentShop.properties.name} | ${currentShop.properties.neighborhood} | pgh.coffee`
+    } else {
+      document.title = 'PGH Coffee'
+    }
+  }, [currentShop])
+
   useHighlightCurrentShop({ currentShop, displayedShops, setDisplayedShops })
 
   return (


### PR DESCRIPTION
## Summary
- Page title (e.g. "Commonplace") was not resetting when navigating away from a shop via client-side navigation
- Root cause: `panelStore.back()` uses `window.history.replaceState()` which bypasses Next.js routing, so `generateMetadata` never re-runs
- Adds a single `useEffect` in `HomeClient` that reactively derives the document title from `currentShop` state, covering all navigation paths

## Test plan
- [ ] Navigate to a shop page (e.g. Commonplace) and verify the title updates to "Commonplace | neighborhood | pgh.coffee"
- [ ] Press back / navigate to explore and verify the title resets to "PGH Coffee"
- [ ] Navigate to events, news, roasters, etc. and verify the title stays "PGH Coffee"

🤖 Generated with [Claude Code](https://claude.com/claude-code)