### PR TITLE
FAB position is based on safe-area-insert, not static number

### DIFF
--- a/app/components/SearchFAB.tsx
+++ b/app/components/SearchFAB.tsx
@@ -18,7 +18,7 @@ export default function SearchFAB({ handleClick }: IProps) {
   return (
     <button
       aria-label="Search shops"
-      className="absolute bottom-[15%] right-[5%] bg-yellow-300 hover:bg-yellow-400 rounded-full h-18 w-18 flex justify-center items-center z-10"
+      className="absolute bottom-[calc(env(safe-area-inset-bottom)+3rem)] right-[5%] bg-yellow-300 hover:bg-yellow-400 rounded-full h-18 w-18 flex justify-center items-center z-10"
       onClick={handleFABClick}
     >
       <MagnifyingGlassIcon className="h-8 w-8" />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,6 +31,7 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: '#FDE047',
+  viewportFit: 'cover',
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
The old static position didn't place nice when the site was saved as a PWA. It left the FAB floating awkwardly high.

Before:
<img width="364" height="819" alt="image" src="https://github.com/user-attachments/assets/a4b4a460-25dc-44d8-b536-f6afb02414e0" />
<img width="414" height="841" alt="image" src="https://github.com/user-attachments/assets/b1c65407-03f3-4578-a3a0-01991a47d535" />



After:
<img width="375" height="825" alt="image" src="https://github.com/user-attachments/assets/6fa1a369-5a36-4da5-819d-a7d51530fab4" />

<img width="422" height="848" alt="image" src="https://github.com/user-attachments/assets/56dce5f1-7149-449c-a4e5-b4cadc10da08" />
