### PR TITLE
Replace inline API docs with link to api-docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This repository contains the source code for pgh.coffee — a website focused on
 - [Getting Started](#getting-started)
 - [Tests](#tests)
 - [API Documentation](#api-documentation)
-  - [Endpoints](#endpoints)
 - [License](#license)
 - [Acknowledgments](#acknowledgments)
 
@@ -63,97 +62,9 @@ npm run test
 
 ## API Documentation
 
-If you're interested in the dataset, pgh.coffee provides a public API that you can use to access information about coffee shops in Pittsburgh.
+If you’re interested in the dataset, pgh.coffee provides a public API that you can use to access information about coffee shops in Pittsburgh.
 
-### Endpoints
-
-
-- **Get coffee shops (GeoJSON)**  
-  URL: [`https://pgh.coffee/api/shops/geojson`](https://pgh.coffee/api/shops/geojson)  
-  Description: Returns the dataset of all coffee shops in GeoJSON format, including their names, addresses, and locations.
-
-Here’s an example of what the JSON response will look like:
-
-```json
-{
-  "type": "FeatureCollection",
-  "features": [
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "61B Cafe",
-        "neighborhood": "Regent Square",
-        "website": "",
-        "address": "1108 S Braddock Ave, Pittsburgh, PA 15218",
-        "roaster": "",
-        "photo": "https://uljutxoijtvtcxvatqso.supabase.co/storage/v1/object/public/shop-photos/regent_square/61b_cafe.jpg"
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-79.893948, 40.432417]
-      }
-    },
-    ...
-  ]
-}
-```
-
-- **Get single coffee shop (GeoJSON)**  
-  URL: `https://pgh.coffee/api/shops/[shop-details]`  
-  Description: Returns GeoJSON data for a single shop.  
-  - `shop-details` is a combination of the shop's name and neighborhood, separated by an **underscore** (`_`).  
-  - Spaces in names are replaced using **URL encoding** (e.g., a space becomes `%20`).  
-
-For example:  
-- The endpoint for **Ka-Fair** in **Morningside** would be:  
-  `https://pgh.coffee/api/shops/Ka-Fair_Morningside`.  
-- The endpoint for **De Fer Coffee & Tea** in **Downtown** would be:  
-  `https://pgh.coffee/api/shops/De%20Fer%20Coffee%20&%20Tea_Downtown`.  
-
-
-
-Here’s an example of what the JSON response will look like for Ka-Fair:
-
-```json
-{
-  "type": "Feature",
-  "properties": {
-    "name": "Ka-Fair",
-    "neighborhood": "Morningside",
-    "address": "1806 Chislett St, Pittsburgh, PA 15206",
-    "photo": "",
-    "website": "https://kafaircakery.wixsite.com/kafair"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [-79.9253955, 40.4855015]
-  }
-}
-```
-
-- **Get coffee shops (JSON)**  
-  URL: [`https://pgh.coffee/api/shops`](https://pgh.coffee/api/shops)  
-  Description: Returns the dataset of all coffee shops in a standard JSON format, including their names, addresses, and locations (without GeoJSON structure).
-
-Here’s an example of what the JSON response will look like:
-
-
-```json
-[
-  {
-    "name": "61B Cafe",
-    "neighborhood": "Regent Square",
-    "website": "",
-    "address": "1108 S Braddock Ave, Pittsburgh, PA 15218",
-    "roaster": "",
-    "longitude": -79.893948,
-    "latitude": 40.432417,
-    "photo": "https://uljutxoijtvtcxvatqso.supabase.co/storage/v1/object/public/shop-photos/regent_square/61b_cafe.jpg",
-    "uuid": "78e3178d-b181-4f7f-a719-84b1f5288395"
-  },
-  ...
-]
-```
+Full API documentation, including endpoints and response schemas, is available at [pgh.coffee/api-docs](https://pgh.coffee/api-docs).
 
 ## License
 


### PR DESCRIPTION
## Summary
- Removes the verbose API endpoint documentation and JSON response examples from the README
- Replaces it with a single link to https://pgh.coffee/api-docs where the full documentation lives