### PR TITLE
Show roaster link in news details

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This repository contains the source code for pgh.coffee — a website focused on
 - [Getting Started](#getting-started)
 - [Tests](#tests)
 - [API Documentation](#api-documentation)
-  - [Endpoints](#endpoints)
 - [License](#license)
 - [Acknowledgments](#acknowledgments)
 
@@ -63,97 +62,9 @@ npm run test
 
 ## API Documentation
 
-If you're interested in the dataset, pgh.coffee provides a public API that you can use to access information about coffee shops in Pittsburgh.
+If you’re interested in the dataset, pgh.coffee provides a public API that you can use to access information about coffee shops in Pittsburgh.
 
-### Endpoints
-
-
-- **Get coffee shops (GeoJSON)**  
-  URL: [`https://pgh.coffee/api/shops/geojson`](https://pgh.coffee/api/shops/geojson)  
-  Description: Returns the dataset of all coffee shops in GeoJSON format, including their names, addresses, and locations.
-
-Here’s an example of what the JSON response will look like:
-
-```json
-{
-  "type": "FeatureCollection",
-  "features": [
-    {
-      "type": "Feature",
-      "properties": {
-        "name": "61B Cafe",
-        "neighborhood": "Regent Square",
-        "website": "",
-        "address": "1108 S Braddock Ave, Pittsburgh, PA 15218",
-        "roaster": "",
-        "photo": "https://uljutxoijtvtcxvatqso.supabase.co/storage/v1/object/public/shop-photos/regent_square/61b_cafe.jpg"
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-79.893948, 40.432417]
-      }
-    },
-    ...
-  ]
-}
-```
-
-- **Get single coffee shop (GeoJSON)**  
-  URL: `https://pgh.coffee/api/shops/[shop-details]`  
-  Description: Returns GeoJSON data for a single shop.  
-  - `shop-details` is a combination of the shop's name and neighborhood, separated by an **underscore** (`_`).  
-  - Spaces in names are replaced using **URL encoding** (e.g., a space becomes `%20`).  
-
-For example:  
-- The endpoint for **Ka-Fair** in **Morningside** would be:  
-  `https://pgh.coffee/api/shops/Ka-Fair_Morningside`.  
-- The endpoint for **De Fer Coffee & Tea** in **Downtown** would be:  
-  `https://pgh.coffee/api/shops/De%20Fer%20Coffee%20&%20Tea_Downtown`.  
-
-
-
-Here’s an example of what the JSON response will look like for Ka-Fair:
-
-```json
-{
-  "type": "Feature",
-  "properties": {
-    "name": "Ka-Fair",
-    "neighborhood": "Morningside",
-    "address": "1806 Chislett St, Pittsburgh, PA 15206",
-    "photo": "",
-    "website": "https://kafaircakery.wixsite.com/kafair"
-  },
-  "geometry": {
-    "type": "Point",
-    "coordinates": [-79.9253955, 40.4855015]
-  }
-}
-```
-
-- **Get coffee shops (JSON)**  
-  URL: [`https://pgh.coffee/api/shops`](https://pgh.coffee/api/shops)  
-  Description: Returns the dataset of all coffee shops in a standard JSON format, including their names, addresses, and locations (without GeoJSON structure).
-
-Here’s an example of what the JSON response will look like:
-
-
-```json
-[
-  {
-    "name": "61B Cafe",
-    "neighborhood": "Regent Square",
-    "website": "",
-    "address": "1108 S Braddock Ave, Pittsburgh, PA 15218",
-    "roaster": "",
-    "longitude": -79.893948,
-    "latitude": 40.432417,
-    "photo": "https://uljutxoijtvtcxvatqso.supabase.co/storage/v1/object/public/shop-photos/regent_square/61b_cafe.jpg",
-    "uuid": "78e3178d-b181-4f7f-a719-84b1f5288395"
-  },
-  ...
-]
-```
+Full API documentation, including endpoints and response schemas, is available at [pgh.coffee/api-docs](https://pgh.coffee/api-docs).
 
 ## License
 

--- a/app/api/updates/[id]/route.ts
+++ b/app/api/updates/[id]/route.ts
@@ -9,7 +9,7 @@ const supabase = createClient(supabaseUrl, supabaseAnonKey)
 const fetchUpdate = async (id: string) => {
   const { data, error } = await supabase
     .from('updates')
-    .select('*, shop:shops(*, company:company_id(*))')
+    .select('*, shop:shops(*, company:company_id(*)), roaster:roaster_id(id, name, slug)')
     .eq('id', id)
     .single()
 

--- a/app/components/EventCard.tsx
+++ b/app/components/EventCard.tsx
@@ -3,6 +3,7 @@
 import { MapPinIcon } from '@heroicons/react/24/outline'
 import { useAnalytics } from '@/hooks'
 import { isPast } from '@/app/utils/utils'
+import { RoasterRef } from '@/types/shop-types'
 import usePanelStore from '@/stores/panelStore'
 import { EventDetails } from './EventDetails'
 
@@ -41,10 +42,7 @@ export type EventCardData = {
     name: string
     neighborhood: string
   }
-  roaster?: {
-    name: string
-    slug: string
-  }
+  roaster?: Pick<RoasterRef, 'name' | 'slug'>
 }
 
 interface EventCardProps {

--- a/app/components/NewsDetails.tsx
+++ b/app/components/NewsDetails.tsx
@@ -62,6 +62,20 @@ export const NewsDetails = ({ id }: { id: string }) => {
     }
   }
 
+  const handleRoasterClick = () => {
+    if (!news?.roaster) return
+    plausible('NewsDetailsRoasterClick', {
+      props: { newsId: news.id, newsTitle: news.title, roasterSlug: news.roaster.slug },
+    })
+    const url = new URL(window.location.href)
+    const params = new URLSearchParams(url.search)
+    params.delete('news')
+    params.set('roaster', news.roaster.slug)
+    url.search = params.toString()
+    window.history.pushState(null, '', url.toString())
+    window.dispatchEvent(new PopStateEvent('popstate'))
+  }
+
   const handleExternalLink = () => {
     if (!news?.url) return
     plausible('NewsExternalLinkClick', {
@@ -159,6 +173,26 @@ export const NewsDetails = ({ id }: { id: string }) => {
                   {news.shop.neighborhood && (
                     <div className="text-sm text-gray-500 mt-0.5">{news.shop.neighborhood}</div>
                   )}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Roaster */}
+          {news.roaster && (
+            <div className="flex items-start gap-3">
+              <div className="bg-yellow-100 p-2.5 rounded-lg">
+                <svg className="w-4 h-4 text-yellow-500" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 6h.008v.008H6V6Z" />
+                </svg>
+              </div>
+              <div>
+                <span className="block text-[10px] font-semibold text-yellow-500 uppercase tracking-wider mb-1">
+                  Roaster
+                </span>
+                <button onClick={handleRoasterClick} className="text-left hover:opacity-80 transition-opacity">
+                  <div className="text-slate-900 font-bold text-[15px]">{news.roaster.name}</div>
                 </button>
               </div>
             </div>

--- a/types/news-types.ts
+++ b/types/news-types.ts
@@ -1,4 +1,4 @@
-import { DbShop } from './shop-types'
+import { DbShop, RoasterRef } from './shop-types'
 
 export type TagKey =
   | 'opening'
@@ -20,6 +20,8 @@ export type NewsItem = {
   event_date?: string | null
   shop_id?: string
   shop?: DbShop
+  roaster_id?: string | null
+  roaster?: RoasterRef | null
 }
 
 export const TAG_LABELS: Record<TagKey, string> = {

--- a/types/shop-types.ts
+++ b/types/shop-types.ts
@@ -56,6 +56,12 @@ export interface TShop {
   }
 }
 
+export interface RoasterRef {
+  id: string
+  name: string
+  slug: string
+}
+
 export interface TList {
   id: string
   title: string


### PR DESCRIPTION
## Summary
- Adds a \"Roaster\" metadata row to `NewsDetails`, mirroring the existing shop location link pattern
- Clicking the roaster navigates to `?roaster={slug}` (clearing `?news=`) and fires a `NewsDetailsRoasterClick` analytics event
- Expands the `/api/updates/[id]` Supabase query to join roaster data via `roaster:roaster_id(id, name, slug)`
- Extracts a shared `RoasterRef` type into `shop-types.ts`, used by both `NewsItem` and `EventCardData`



https://github.com/user-attachments/assets/c4f88bab-bdb9-47e8-8f77-566102e1c36c



