### PR TITLE
Improve homepage meta description and add OpenGraph metadata

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,7 +12,11 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
   if (!shopParam || typeof shopParam !== 'string') {
     return {
       title: 'PGH Coffee',
-      description: 'Coffee shops in Pittsburgh, PA',
+      description: 'Explore independent coffee shops across Pittsburgh\'s neighborhoods — find your next favorite spot on the map.',
+      openGraph: {
+        title: 'PGH Coffee',
+        description: 'Explore independent coffee shops across Pittsburgh\'s neighborhoods — find your next favorite spot on the map.',
+      },
     }
   }
 
@@ -21,7 +25,11 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
   if (!name || !neighborhood) {
     return {
       title: 'PGH Coffee',
-      description: 'Coffee shops in Pittsburgh, PA',
+      description: 'Explore independent coffee shops across Pittsburgh\'s neighborhoods — find your next favorite spot on the map.',
+      openGraph: {
+        title: 'PGH Coffee',
+        description: 'Explore independent coffee shops across Pittsburgh\'s neighborhoods — find your next favorite spot on the map.',
+      },
     }
   }
 


### PR DESCRIPTION
## Summary
- Rewrites the homepage meta description to be more specific and compelling
- Adds `openGraph` metadata to reinforce the description signal for search engines and link previews

## Test plan
- [ ] Verify meta description tag in page source after deploy
- [ ] Check Open Graph preview using a link unfurl tool