### PR TITLE
Use native share menu on mobile

### DIFF
--- a/hooks/useCopyToClipboard.ts
+++ b/hooks/useCopyToClipboard.ts
@@ -6,6 +6,17 @@ export function useCopyToClipboard() {
   const [showToast, setShowToast] = useState(false)
 
   const copyCurrentUrl = useCallback(async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({ url: window.location.href })
+      } catch (err) {
+        if (err instanceof Error && err.name !== 'AbortError') {
+          console.error('Failed to share:', err)
+        }
+      }
+      return
+    }
+
     try {
       await navigator.clipboard.writeText(window.location.href)
       setShowToast(true)

--- a/hooks/useCopyToClipboard.ts
+++ b/hooks/useCopyToClipboard.ts
@@ -6,7 +6,8 @@ export function useCopyToClipboard() {
   const [showToast, setShowToast] = useState(false)
 
   const copyCurrentUrl = useCallback(async () => {
-    if (navigator.share) {
+    const isMobile = window.matchMedia('(pointer: coarse)').matches
+    if (isMobile && navigator.share) {
       try {
         await navigator.share({ url: window.location.href })
       } catch (err) {


### PR DESCRIPTION
## Summary

- On mobile browsers that support the Web Share API (`navigator.share`), the Share button now opens the native share sheet instead of copying to clipboard and showing a toast
- On desktop (where `navigator.share` is unavailable), behavior is unchanged: copies the URL and shows the toast confirmation

## Test plan

- [ ] On a mobile device/emulator, tap Share — native share sheet should appear
- [ ] On desktop, click Share — URL should copy to clipboard and toast should appear
- [ ] Dismissing the native share sheet (AbortError) should not log an error