### PR TITLE
Fix button types, aria-labels, and keyboard accessibility

### DIFF
--- a/app/components/AmenityFilterList.tsx
+++ b/app/components/AmenityFilterList.tsx
@@ -53,10 +53,11 @@ export const AmenityFilterList = () => {
       ))}
       {!isExpanded && (
         <button
+          type="button"
           className="inline-flex items-center gap-1.5 rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-700 hover:bg-stone-200"
           onClick={() => setIsExpanded(true)}
         >
-          <Plus className="w-5 h-5" />
+          <Plus className="size-5" />
           More
         </button>
       )}

--- a/app/components/Explore/EventsCTA.tsx
+++ b/app/components/Explore/EventsCTA.tsx
@@ -13,12 +13,12 @@ const EventCardSkeleton = () => (
   <div className="flex w-full bg-white rounded-xl border border-stone-200 overflow-hidden shadow-sm animate-pulse">
     <div className="w-14 flex flex-col items-center justify-center py-4 shrink-0 bg-stone-200">
       <div className="h-2 w-6 bg-stone-300 rounded mb-1" />
-      <div className="h-6 w-6 bg-stone-300 rounded" />
+      <div className="size-6 bg-stone-300 rounded" />
     </div>
     <div className="flex-1 p-4">
       <div className="h-5 w-3/4 bg-stone-200 rounded mb-2" />
       <div className="flex items-center gap-1 mb-2">
-        <div className="h-3 w-3 bg-stone-200 rounded" />
+        <div className="size-3 bg-stone-200 rounded" />
         <div className="h-3 w-24 bg-stone-200 rounded" />
         <div className="h-3 w-16 bg-stone-100 rounded ml-2" />
       </div>
@@ -64,12 +64,13 @@ export const EventsCTA = () => {
       <div className="flex items-center justify-between">
         <h3 className="flex-1 text-xs font-semibold uppercase tracking-wider text-stone-500">Upcoming events</h3>
         <button
+          type="button"
           className="flex gap-0.5 items-center text-sm font-medium transition-colors hover:opacity-80"
           style={{ color: 'lab(45 10 50)' }}
           onClick={openEvents}
         >
           View all
-          <ChevronRight className="h-5 w-5" />
+          <ChevronRight className="size-5" />
         </button>
       </div>
 

--- a/app/components/Explore/NewsCTA.tsx
+++ b/app/components/Explore/NewsCTA.tsx
@@ -58,12 +58,13 @@ export const NewsCTA = () => {
           Latest news
         </h3>
         <button
+          type="button"
           className="flex gap-0.5 items-center text-sm font-medium transition-colors hover:opacity-80"
           style={{ color: 'lab(45 10 50)' }}
           onClick={openNews}
         >
           View all
-          <ChevronRight className="h-5 w-5"/>
+          <ChevronRight className="size-5"/>
         </button>
       </div>
 

--- a/app/components/IssueForm.tsx
+++ b/app/components/IssueForm.tsx
@@ -91,7 +91,6 @@ export default function IssueForm({ shop, onSuccess }: IProps) {
             <input
               id="name"
               name="name"
-              aria-label="Name"
               type="text"
               defaultValue={shop.properties.name}
               className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
@@ -105,7 +104,6 @@ export default function IssueForm({ shop, onSuccess }: IProps) {
             <input
               id="address"
               name="address"
-              aria-label="Address"
               type="text"
               defaultValue={shop.properties.address}
               className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
@@ -119,7 +117,6 @@ export default function IssueForm({ shop, onSuccess }: IProps) {
             <input
               id="neighborhood"
               name="neighborhood"
-              aria-label="Neighborhood"
               type="text"
               defaultValue={shop.properties.neighborhood}
               className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
@@ -133,7 +130,6 @@ export default function IssueForm({ shop, onSuccess }: IProps) {
             <input
               id="website"
               name="website"
-              aria-label="Website"
               type="text"
               defaultValue={shop.properties.website}
               className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"

--- a/app/components/IssueForm.tsx
+++ b/app/components/IssueForm.tsx
@@ -91,6 +91,7 @@ export default function IssueForm({ shop, onSuccess }: IProps) {
             <input
               id="name"
               name="name"
+              aria-label="Name"
               type="text"
               defaultValue={shop.properties.name}
               className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
@@ -104,6 +105,7 @@ export default function IssueForm({ shop, onSuccess }: IProps) {
             <input
               id="address"
               name="address"
+              aria-label="Address"
               type="text"
               defaultValue={shop.properties.address}
               className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
@@ -117,6 +119,7 @@ export default function IssueForm({ shop, onSuccess }: IProps) {
             <input
               id="neighborhood"
               name="neighborhood"
+              aria-label="Neighborhood"
               type="text"
               defaultValue={shop.properties.neighborhood}
               className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
@@ -130,6 +133,7 @@ export default function IssueForm({ shop, onSuccess }: IProps) {
             <input
               id="website"
               name="website"
+              aria-label="Website"
               type="text"
               defaultValue={shop.properties.website}
               className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
@@ -147,7 +151,7 @@ export default function IssueForm({ shop, onSuccess }: IProps) {
               isSubmitting ? 'bg-yellow-100 cursor-not-allowed' : 'bg-yellow-300 hover:bg-yellow-400'
             }`}
           >
-            {isSubmitting ? 'Submitting...' : 'Submit'}
+            {isSubmitting ? 'Submitting…' : 'Submit'}
           </button>
         </form>
       </div>

--- a/app/components/NewsCard.tsx
+++ b/app/components/NewsCard.tsx
@@ -20,6 +20,7 @@ export const NewsCard = ({ item }: NewsCardProps) => {
   const plausible = useAnalytics()
   const primaryTag = item.tags?.[0] ?? 'news'
   const styles = getTagStyle(primaryTag)
+  const hasShop = !!(item.shop_id && item.shop)
 
   const handleCardClick = () => {
     if (item.id) {
@@ -38,35 +39,44 @@ export const NewsCard = ({ item }: NewsCardProps) => {
   }
 
   return (
-    <article
-      onClick={handleCardClick}
-      className="bg-white border border-gray-100 shadow-sm rounded-lg overflow-hidden flex flex-col transition-all hover:shadow-md cursor-pointer"
-    >
+    <div className={`bg-white border border-gray-100 shadow-sm rounded-lg overflow-hidden flex flex-col transition-all hover:shadow-md`}>
       <div className={`p-5 border-l-[2px] ${styles.border}`}>
         <div className="mb-2">
           <TagBadge tag={primaryTag} variant="compact" />
         </div>
 
-        <h3 className="text-xl font-bold mb-2 leading-tight text-gray-900">{item.title}</h3>
+        <button
+          type="button"
+          onClick={handleCardClick}
+          className="text-left w-full cursor-pointer"
+        >
+          <h3 className="text-xl font-bold mb-2 leading-tight text-gray-900">{item.title}</h3>
 
-        {item.description && (
-          <p className="text-gray-500 text-sm leading-relaxed mb-4 line-clamp-1">{item.description}</p>
-        )}
-
-        <span className="inline-flex items-center text-xs font-bold text-gray-900 hover:opacity-70 transition-opacity">
-          {item.shop_id && item.shop ? (
-            <span onClick={handleShopClick} className="inline-flex items-center">
-              View {item.shop.name}
-              <ArrowRightIcon className="ml-1 h-3 w-3" />
-            </span>
-          ) : (
-            <>
-              Read more
-              <ArrowRightIcon className="ml-1 h-3 w-3" />
-            </>
+          {item.description && (
+            <p className="text-gray-500 text-sm leading-relaxed mb-4 line-clamp-1">{item.description}</p>
           )}
-        </span>
+        </button>
+
+        {hasShop ? (
+          <button
+            type="button"
+            onClick={handleShopClick}
+            className="inline-flex items-center text-xs font-bold text-gray-900 hover:opacity-70 transition-opacity"
+          >
+            View {item.shop!.name}
+            <ArrowRightIcon className="ml-1 size-3" />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={handleCardClick}
+            className="inline-flex items-center text-xs font-bold text-gray-900 hover:opacity-70 transition-opacity"
+          >
+            Read more
+            <ArrowRightIcon className="ml-1 size-3" />
+          </button>
+        )}
       </div>
-    </article>
+    </div>
   )
 }

--- a/app/components/NewsCard.tsx
+++ b/app/components/NewsCard.tsx
@@ -39,7 +39,7 @@ export const NewsCard = ({ item }: NewsCardProps) => {
   }
 
   return (
-    <div className={`bg-white border border-gray-100 shadow-sm rounded-lg overflow-hidden flex flex-col transition-all hover:shadow-md`}>
+    <article className="bg-white border border-gray-100 shadow-sm rounded-lg overflow-hidden flex flex-col transition-all hover:shadow-md">
       <div className={`p-5 border-l-[2px] ${styles.border}`}>
         <div className="mb-2">
           <TagBadge tag={primaryTag} variant="compact" />
@@ -77,6 +77,6 @@ export const NewsCard = ({ item }: NewsCardProps) => {
           </button>
         )}
       </div>
-    </div>
+    </article>
   )
 }

--- a/app/components/ReportIssueButton.tsx
+++ b/app/components/ReportIssueButton.tsx
@@ -7,10 +7,11 @@ interface ReportIssueButtonProps {
 export default function ReportIssueButton({ onClick }: ReportIssueButtonProps) {
   return (
     <button
+      type="button"
       onClick={onClick}
       className="inline-flex items-center gap-1.5 bg-white hover:bg-stone-50 text-stone-800 px-4 py-2.5 rounded-3xl text-sm font-medium border border-stone-200 transition-colors"
     >
-      <Flag className="w-4 h-4" />
+      <Flag className="size-4" />
       Report
     </button>
   )

--- a/app/components/SearchBar.tsx
+++ b/app/components/SearchBar.tsx
@@ -11,10 +11,11 @@ export default function SearchBar() {
 
   return (
     <div className="flex absolute shadow-md items-center px-2 bg-white top-8 lg:top-3 z-10 h-10 w-[90%] left-1/2 -translate-x-1/2 rounded-xl">
-      <button onClick={() => usePanelStore.getState().back()}>
-        {panelMode !== 'explore' && <ArrowLeftIcon className="h-4 w-4 mr-auto" />}
+      <button type="button" aria-label="Back" onClick={() => usePanelStore.getState().back()}>
+        {panelMode !== 'explore' && <ArrowLeftIcon className="size-4 mr-auto" />}
       </button>
       <input
+        aria-label="Search for a shop or neighborhood"
         className="h-[24px] flex-1 bg-transparent border-none focus:outline-none focus:ring-0"
         value={searchValue}
         onChange={e => setSearchValue(e.target.value)}

--- a/app/components/SearchBar.tsx
+++ b/app/components/SearchBar.tsx
@@ -11,9 +11,11 @@ export default function SearchBar() {
 
   return (
     <div className="flex absolute shadow-md items-center px-2 bg-white top-8 lg:top-3 z-10 h-10 w-[90%] left-1/2 -translate-x-1/2 rounded-xl">
-      <button type="button" aria-label="Back" onClick={() => usePanelStore.getState().back()}>
-        {panelMode !== 'explore' && <ArrowLeftIcon className="size-4 mr-auto" />}
-      </button>
+      {panelMode !== 'explore' && (
+        <button type="button" aria-label="Back" onClick={() => usePanelStore.getState().back()}>
+          <ArrowLeftIcon className="size-4 mr-auto" />
+        </button>
+      )}
       <input
         aria-label="Search for a shop or neighborhood"
         className="h-[24px] flex-1 bg-transparent border-none focus:outline-none focus:ring-0"

--- a/app/components/SearchFAB.tsx
+++ b/app/components/SearchFAB.tsx
@@ -17,11 +17,12 @@ export default function SearchFAB({ handleClick }: IProps) {
 
   return (
     <button
+      type="button"
       aria-label="Search shops"
-      className="absolute bottom-[15%] right-[5%] bg-yellow-300 hover:bg-yellow-400 rounded-full h-18 w-18 flex justify-center items-center z-10"
+      className="absolute bottom-[15%] right-[5%] bg-yellow-300 hover:bg-yellow-400 rounded-full size-18 flex justify-center items-center z-10"
       onClick={handleFABClick}
     >
-      <MagnifyingGlassIcon className="h-8 w-8" />
+      <MagnifyingGlassIcon className="size-8" />
     </button>
   )
 }

--- a/app/components/SearchFAB.tsx
+++ b/app/components/SearchFAB.tsx
@@ -19,7 +19,7 @@ export default function SearchFAB({ handleClick }: IProps) {
     <button
       type="button"
       aria-label="Search shops"
-      className="absolute bottom-[15%] right-[5%] bg-yellow-300 hover:bg-yellow-400 rounded-full size-18 flex justify-center items-center z-10"
+      className="absolute bottom-[15%] right-[5%] bg-yellow-300 hover:bg-yellow-400 rounded-full size-16 flex justify-center items-center z-10"
       onClick={handleFABClick}
     >
       <MagnifyingGlassIcon className="size-8" />

--- a/app/components/ShareButton.tsx
+++ b/app/components/ShareButton.tsx
@@ -10,10 +10,11 @@ export default function ShareButton() {
   return (
     <>
       <button
+        type="button"
         onClick={copyCurrentUrl}
         className="inline-flex items-center gap-1.5 bg-white hover:bg-stone-50 text-stone-800 px-4 py-2.5 rounded-3xl text-sm font-medium border border-stone-200 transition-colors"
       >
-        <Share2 className="w-4 h-4" />
+        <Share2 className="size-4" />
         Share
       </button>
       <CopyLinkToast isOpen={showToast} onClose={closeToast} />

--- a/app/components/ShopAmenities.tsx
+++ b/app/components/ShopAmenities.tsx
@@ -40,7 +40,7 @@ export default function ShopAmenities({ amenities, shopId }: IProps) {
 
       <p className="text-xs text-gray-700">
         Missing something?{' '}
-        <button aria-label="Report amenity" className="text-amber-700" onClick={handleOnClick}>
+        <button type="button" aria-label="Report amenity" className="text-amber-700" onClick={handleOnClick}>
           Let me know
         </button>
       </p>

--- a/app/components/submit/SubmitForm.tsx
+++ b/app/components/submit/SubmitForm.tsx
@@ -75,7 +75,6 @@ export default function SubmitForm() {
             <input
               id="name"
               name="name"
-              aria-label="Shop name"
               required
               type="text"
               className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
@@ -89,7 +88,6 @@ export default function SubmitForm() {
             <input
               id="address"
               name="address"
-              aria-label="Address"
               required
               type="text"
               className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
@@ -144,7 +142,6 @@ export default function SubmitForm() {
               <input
                 id="website"
                 name="website"
-                aria-label="Website"
                 type="url"
                 className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
               />

--- a/app/components/submit/SubmitForm.tsx
+++ b/app/components/submit/SubmitForm.tsx
@@ -75,6 +75,7 @@ export default function SubmitForm() {
             <input
               id="name"
               name="name"
+              aria-label="Shop name"
               required
               type="text"
               className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
@@ -88,6 +89,7 @@ export default function SubmitForm() {
             <input
               id="address"
               name="address"
+              aria-label="Address"
               required
               type="text"
               className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
@@ -142,6 +144,7 @@ export default function SubmitForm() {
               <input
                 id="website"
                 name="website"
+                aria-label="Website"
                 type="url"
                 className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
               />
@@ -149,7 +152,7 @@ export default function SubmitForm() {
           </div>
 
           <div className="flex items-start gap-2 bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-            <InfoIcon aria-hidden="true" className="w-4 h-4 shrink-0 mt-0.5 text-yellow-400" />
+            <InfoIcon aria-hidden="true" className="size-4 shrink-0 mt-0.5 text-yellow-400" />
             <p className="text-sm text-slate-600">
               I currently only list shops located within Allegheny County, but I&apos;m tracking interest in the greater Pittsburgh area for future expansion. Chains or franchises headquartered elsewhere
               are not included to maintain the focus on local independent businesses.
@@ -163,7 +166,7 @@ export default function SubmitForm() {
               isSubmitting ? 'bg-yellow-100 cursor-not-allowed' : 'bg-yellow-300 hover:bg-yellow-400'
             }`}
           >
-            {isSubmitting ? 'Submitting...' : 'Submit shop'}
+            {isSubmitting ? 'Submitting…' : 'Submit shop'}
           </button>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- Add `type="button"` to buttons missing it across multiple components
- Fix `NewsCard`: remove click handler from `<article>`, replace with proper `<button>` elements for the title and "Read more"/"View shop" actions
- Fix ghost back button in `SearchBar`: was always rendered but only showed an icon conditionally — now only renders when not in explore mode
- Add `aria-label` to the back button and search input in `SearchBar`
- Replace `h-X w-X` pairs with `size-X` Tailwind shorthand throughout
- Replace `...` with `…` (typographic ellipsis) in form submit buttons