### PR TITLE
Surface submission errors in AmenityReportModal

### DIFF
--- a/app/components/AmenityReportModal.tsx
+++ b/app/components/AmenityReportModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 import { Checkbox, Dialog, DialogPanel, DialogTitle } from '@headlessui/react'
 import { amenityMap } from './AmenityChip'
@@ -16,6 +16,10 @@ interface Props {
 export default function AmenityReportModal({ isOpen, onClose, onSuccess, amenities, shopId }: Props) {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (isOpen) setError(null)
+  }, [isOpen])
 
   return (
     <Dialog open={isOpen} onClose={onClose} className="relative z-50">
@@ -85,7 +89,7 @@ export default function AmenityReportModal({ isOpen, onClose, onSuccess, ameniti
             ))}
           </div>
           {error && (
-            <p className="mt-4 text-sm text-red-600">{error}</p>
+            <p role="alert" className="mt-4 text-sm text-red-600">{error}</p>
           )}
           <button
             type="submit"

--- a/app/components/AmenityReportModal.tsx
+++ b/app/components/AmenityReportModal.tsx
@@ -15,6 +15,7 @@ interface Props {
 
 export default function AmenityReportModal({ isOpen, onClose, onSuccess, amenities, shopId }: Props) {
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   return (
     <Dialog open={isOpen} onClose={onClose} className="relative z-50">
@@ -27,6 +28,7 @@ export default function AmenityReportModal({ isOpen, onClose, onSuccess, ameniti
             const formData = new FormData(e.currentTarget)
             const selected = formData.getAll('amenities') as string[]
             setIsSubmitting(true)
+            setError(null)
             try {
               const res = await fetch('/api/shops/report-amenities', {
                 method: 'POST',
@@ -38,6 +40,7 @@ export default function AmenityReportModal({ isOpen, onClose, onSuccess, ameniti
               onClose()
             } catch (err) {
               console.error('Error submitting amenity report:', err)
+              setError('Something went wrong submitting your update. Please try again.')
             } finally {
               setIsSubmitting(false)
             }
@@ -81,6 +84,9 @@ export default function AmenityReportModal({ isOpen, onClose, onSuccess, ameniti
               </div>
             ))}
           </div>
+          {error && (
+            <p className="mt-4 text-sm text-red-600">{error}</p>
+          )}
           <button
             type="submit"
             disabled={isSubmitting}

--- a/tests/unit/AmenityReportModal.test.tsx
+++ b/tests/unit/AmenityReportModal.test.tsx
@@ -29,7 +29,8 @@ describe('AmenityReportModal', () => {
 
   it('pre-checks amenities already associated with the shop', () => {
     render(<AmenityReportModal {...defaultProps} />)
-    expect(screen.getAllByRole('checkbox')[0]).toHaveAttribute('aria-checked', 'true')
+    const checked = screen.getAllByRole('checkbox').filter(cb => cb.getAttribute('aria-checked') === 'true')
+    expect(checked).toHaveLength(defaultProps.amenities.length)
   })
 
   it('submits the currently selected amenities and calls onSuccess/onClose', async () => {
@@ -58,11 +59,27 @@ describe('AmenityReportModal', () => {
     fireEvent.click(screen.getByRole('button', { name: /^submit$/i }))
 
     await waitFor(() => {
-      expect(screen.getByText(/something went wrong submitting your update/i)).toBeInTheDocument()
+      expect(screen.getByRole('alert')).toHaveTextContent(/something went wrong submitting your update/i)
     })
 
     expect(defaultProps.onSuccess).not.toHaveBeenCalled()
     expect(defaultProps.onClose).not.toHaveBeenCalled()
+  })
+
+  it('clears the error when the modal is closed and reopened', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false } as Response)
+
+    const { rerender } = render(<AmenityReportModal {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+
+    rerender(<AmenityReportModal {...defaultProps} isOpen={false} />)
+    rerender(<AmenityReportModal {...defaultProps} isOpen={true} />)
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
   it('shows an error message when the request throws', async () => {

--- a/tests/unit/AmenityReportModal.test.tsx
+++ b/tests/unit/AmenityReportModal.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import AmenityReportModal from '@/app/components/AmenityReportModal'
+
+describe('AmenityReportModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onSuccess: vi.fn(),
+    amenities: ['free_wifi'],
+    shopId: 'shop-uuid-123',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('does not render when isOpen is false', () => {
+    render(<AmenityReportModal {...defaultProps} isOpen={false} />)
+    expect(screen.queryByText("What's here?")).not.toBeInTheDocument()
+  })
+
+  it('renders the modal with amenity checkboxes', () => {
+    render(<AmenityReportModal {...defaultProps} />)
+    expect(screen.getByText("What's here?")).toBeInTheDocument()
+    expect(screen.getAllByRole('checkbox').length).toBeGreaterThan(0)
+  })
+
+  it('pre-checks amenities already associated with the shop', () => {
+    render(<AmenityReportModal {...defaultProps} />)
+    // amenityMap is rendered in declaration order; free_wifi is first
+    expect(screen.getAllByRole('checkbox')[0]).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('submits the currently selected amenities and calls onSuccess/onClose', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response)
+
+    render(<AmenityReportModal {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/shops/report-amenities', expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ shop_id: 'shop-uuid-123', amenities: ['free_wifi'] }),
+      }))
+    })
+
+    await waitFor(() => {
+      expect(defaultProps.onSuccess).toHaveBeenCalled()
+      expect(defaultProps.onClose).toHaveBeenCalled()
+    })
+  })
+
+  it('shows an error message and does not close when the request fails', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false } as Response)
+
+    render(<AmenityReportModal {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/something went wrong submitting your update/i)).toBeInTheDocument()
+    })
+
+    expect(defaultProps.onSuccess).not.toHaveBeenCalled()
+    expect(defaultProps.onClose).not.toHaveBeenCalled()
+  })
+
+  it('shows an error message when the request throws', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'))
+
+    render(<AmenityReportModal {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/something went wrong submitting your update/i)).toBeInTheDocument()
+    })
+  })
+
+  it('re-enables the submit button after a failed submission', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false } as Response)
+
+    render(<AmenityReportModal {...defaultProps} />)
+    const button = screen.getByRole('button', { name: /^submit$/i })
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(button).not.toBeDisabled()
+    })
+  })
+})

--- a/tests/unit/AmenityReportModal.test.tsx
+++ b/tests/unit/AmenityReportModal.test.tsx
@@ -29,7 +29,6 @@ describe('AmenityReportModal', () => {
 
   it('pre-checks amenities already associated with the shop', () => {
     render(<AmenityReportModal {...defaultProps} />)
-    // amenityMap is rendered in declaration order; free_wifi is first
     expect(screen.getAllByRole('checkbox')[0]).toHaveAttribute('aria-checked', 'true')
   })
 


### PR DESCRIPTION
## Summary

A failed or thrown error while submitting `AmenityReportModal` left the user with no feedback. With this PR, it shows "Something went wrong submitting your update. Please try again." and keeps modal open so the user can retry

<!--
| Before | After |
|--------|-------|
| img    | img   |
-->

Before:

https://github.com/user-attachments/assets/4ea7e7cd-9b95-482c-8c4b-bab279b8fc7e


After:


https://github.com/user-attachments/assets/483590f8-273d-4cfe-9c59-3af6b88d8a29


