### PR TITLE
Distinguish favorites fetch errors from the empty state

### DIFF
--- a/app/account/components/Favorites.tsx
+++ b/app/account/components/Favorites.tsx
@@ -16,6 +16,7 @@ interface Favorite {
 export default function Favorites() {
   const [favorites, setFavorites] = useState<Favorite[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
 
   const hasFavorites = favorites && favorites.length > 0
 
@@ -31,14 +32,29 @@ export default function Favorites() {
         setFavorites(Array.isArray(data) ? data : [])
         setLoading(false)
       })
-      .catch((error) => {
-        console.error('Failed to fetch favorites:', error)
-        setFavorites([])
+      .catch((err) => {
+        console.error('Failed to fetch favorites:', err)
+        setError(true)
         setLoading(false)
       })
   }, [])
 
   if (loading) return <div>Loading...</div>
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6 md:p-8">
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <Heart className="h-12 w-12 text-gray-300 mb-4" />
+          <h3 className="text-lg font-medium text-gray-900 mb-2">Couldn&apos;t load your favorites</h3>
+          <p className="text-gray-500 max-w-sm">
+            Something went wrong while loading your favorites. Please try refreshing the page.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div>
       {hasFavorites ? (

--- a/tests/unit/AccountFavorites.test.tsx
+++ b/tests/unit/AccountFavorites.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import Favorites from '@/app/account/components/Favorites'
+
+vi.mock('@/hooks', () => ({
+  useShopSelection: () => ({ handleShopSelect: vi.fn() }),
+  useAnalytics: () => vi.fn(),
+}))
+
+vi.mock('@/stores/coffeeShopsStore', () => ({
+  __esModule: true,
+  default: () => ({
+    setHoveredShop: vi.fn(),
+  }),
+}))
+
+const mockShop = {
+  uuid: 'shop-uuid-1',
+  name: 'Test Coffee Shop',
+  neighborhood: 'Downtown',
+  address: '123 Main St',
+  company: null,
+  photo: null,
+  photos: null,
+  website: 'https://example.com',
+  latitude: 40.4363,
+  longitude: -79.925,
+}
+
+describe('Account Favorites', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('shows a loading state initially', () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => {}))
+    render(<Favorites />)
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('shows the empty state when there are no favorites', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    } as Response)
+
+    render(<Favorites />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No favorites yet')).toBeInTheDocument()
+    })
+  })
+
+  it('renders a ShopCard for each favorite', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([
+        { id: 'fav-1', created_at: '2024-01-01T00:00:00Z', shop: mockShop },
+      ]),
+    } as Response)
+
+    render(<Favorites />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Coffee Shop')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('No favorites yet')).not.toBeInTheDocument()
+  })
+
+  it('shows an error state distinct from the empty state when the fetch fails', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: 'Error fetching favorites' }),
+    } as Response)
+
+    render(<Favorites />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Couldn't load your favorites")).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('No favorites yet')).not.toBeInTheDocument()
+  })
+
+  it('shows an error state when the request throws', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'))
+
+    render(<Favorites />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Couldn't load your favorites")).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Account `Favorites` rendered "No favorites yet" both when a user genuinely has zero favorites and when `/api/favorites` fails to load — indistinguishable, and misleading (looks like your favorites disappeared)
- Now shows a distinct "Couldn't load your favorites" state on a failed/thrown fetch

Found while doing overnight test-hardening work (see #248).

## Test plan
- [x] `npx vitest run tests/unit/AccountFavorites.test.tsx` passes
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean