### PR TITLE
Add error boundaries for root and account routes

### DIFF
--- a/app/account/error.tsx
+++ b/app/account/error.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useEffect } from 'react'
+import { AlertTriangle } from 'lucide-react'
+
+export default function AccountError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6 md:p-8">
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <AlertTriangle className="h-12 w-12 text-gray-300 mb-4" />
+        <h3 className="text-lg font-medium text-gray-900 mb-2">Something went wrong</h3>
+        <p className="text-gray-500 max-w-sm mb-6">
+          We couldn&apos;t load this part of your account. Please try again.
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          className="inline-flex items-center gap-2 rounded-lg py-3 px-4 text-sm font-semibold text-black bg-yellow-300 hover:bg-yellow-400"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import { Coffee } from 'lucide-react'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="min-h-[60vh] flex flex-col items-center justify-center text-center px-4">
+      <Coffee className="h-12 w-12 text-gray-300 mb-4" />
+      <h2 className="text-lg font-medium text-gray-900 mb-2">Something went wrong</h2>
+      <p className="text-gray-500 max-w-sm mb-6">
+        We hit a snag loading this page. Please try again.
+      </p>
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={reset}
+          className="inline-flex items-center gap-2 rounded-lg py-3 px-4 text-sm font-semibold text-black bg-yellow-300 hover:bg-yellow-400"
+        >
+          Try again
+        </button>
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 rounded-lg py-3 px-4 text-sm font-semibold text-gray-700 bg-gray-100 hover:bg-gray-200"
+        >
+          Go home
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/tests/unit/ErrorBoundaries.test.tsx
+++ b/tests/unit/ErrorBoundaries.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import RootError from '@/app/error'
+import AccountError from '@/app/account/error'
+
+describe('Root error boundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('shows a message and calls reset when "Try again" is clicked', () => {
+    const reset = vi.fn()
+    render(<RootError error={new Error('boom')} reset={reset} />)
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(reset).toHaveBeenCalledOnce()
+  })
+
+  it('links back to the home page', () => {
+    render(<RootError error={new Error('boom')} reset={vi.fn()} />)
+
+    expect(screen.getByRole('link', { name: /go home/i })).toHaveAttribute('href', '/')
+  })
+})
+
+describe('Account error boundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('shows a message and calls reset when "Try again" is clicked', () => {
+    const reset = vi.fn()
+    render(<AccountError error={new Error('boom')} reset={reset} />)
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(reset).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
Adds Next.js App Router error boundaries so unhandled render errors show a friendly recovery UI instead of a blank page.

`app/account/page.tsx`
| Before | After |
|--------|-------|
| <img width="968" height="217" alt="image" src="https://github.com/user-attachments/assets/75e2d3d1-f678-4c9d-9cf0-6b4d914e7acc" />    | <img width="1443" height="623" alt="image" src="https://github.com/user-attachments/assets/ee858e07-17ae-452c-b81e-3b7ce473d5de" />   |

`app/page.tsx`
| Before | After |
|--------|-------|
| <img width="898" height="184" alt="image" src="https://github.com/user-attachments/assets/76171b7f-c196-4fef-89b5-9f9294ab7163" />    | <img width="1436" height="747" alt="image" src="https://github.com/user-attachments/assets/d5a8dd98-6070-4d4d-a667-5025cc86ef1c" />  |

