### PR TITLE
SEO metadata + JSON-LD for events and news

### DIFF
--- a/app/(map)/events/[slug]/page.tsx
+++ b/app/(map)/events/[slug]/page.tsx
@@ -1,16 +1,27 @@
+import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import { extractUuidPrefix } from '@/app/utils/slug'
-import { getEventByIdPrefix } from '@/app/utils/events'
+import { getEventForSeo, buildEventMetadata, buildEventJsonLd, jsonLdToString } from '@/app/utils/seo'
 
 type Props = {
   params: Promise<{ slug: string }>
 }
 
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const event = await getEventForSeo((await params).slug)
+  return event ? buildEventMetadata(event) : {}
+}
+
 export default async function EventPage({ params }: Props) {
-  const prefix = extractUuidPrefix((await params).slug)
-  const event = prefix ? await getEventByIdPrefix(prefix) : null
+  const event = await getEventForSeo((await params).slug)
 
   if (!event) notFound()
 
-  return null
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLdToString(buildEventJsonLd(event)) }} />
+      {/* EventDetails renders its own <h1> after client-side fetch; this keeps a
+          server-rendered heading for crawlers. */}
+      <h1 className="sr-only">{event.title}</h1>
+    </>
+  )
 }

--- a/app/(map)/news/[slug]/page.tsx
+++ b/app/(map)/news/[slug]/page.tsx
@@ -1,16 +1,27 @@
+import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import { extractUuidPrefix } from '@/app/utils/slug'
-import { getUpdateByIdPrefix } from '@/app/utils/updates'
+import { getUpdateForSeo, buildNewsMetadata, buildNewsJsonLd, jsonLdToString } from '@/app/utils/seo'
 
 type Props = {
   params: Promise<{ slug: string }>
 }
 
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const update = await getUpdateForSeo((await params).slug)
+  return update ? buildNewsMetadata(update) : {}
+}
+
 export default async function NewsPage({ params }: Props) {
-  const prefix = extractUuidPrefix((await params).slug)
-  const update = prefix ? await getUpdateByIdPrefix(prefix) : null
+  const update = await getUpdateForSeo((await params).slug)
 
   if (!update) notFound()
 
-  return null
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLdToString(buildNewsJsonLd(update)) }} />
+      {/* NewsDetails renders its own <h1> after client-side fetch; this keeps a
+          server-rendered heading for crawlers. */}
+      <h1 className="sr-only">{update.title}</h1>
+    </>
+  )
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,8 +1,20 @@
 import type { MetadataRoute } from 'next'
-import { SITE_URL, buildShopUrl, getAllShopsForSeo } from '@/app/utils/seo'
+import {
+  SITE_URL,
+  buildShopUrl,
+  buildEventUrl,
+  buildNewsUrl,
+  getAllShopsForSeo,
+  getAllEventsForSeo,
+  getAllUpdatesForSeo,
+} from '@/app/utils/seo'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const shops = await getAllShopsForSeo()
+  const [shops, events, updates] = await Promise.all([
+    getAllShopsForSeo(),
+    getAllEventsForSeo(),
+    getAllUpdatesForSeo(),
+  ])
 
   const staticPages: MetadataRoute.Sitemap = [
     { url: SITE_URL },
@@ -10,9 +22,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${SITE_URL}/submit-a-shop` },
   ]
 
-  const shopPages: MetadataRoute.Sitemap = shops.map(shop => ({
-    url: buildShopUrl(shop),
-  }))
+  const shopPages: MetadataRoute.Sitemap = shops.map(shop => ({ url: buildShopUrl(shop) }))
+  const eventPages: MetadataRoute.Sitemap = events.map(event => ({ url: buildEventUrl(event) }))
+  const newsPages: MetadataRoute.Sitemap = updates.map(update => ({ url: buildNewsUrl(update) }))
 
-  return [...staticPages, ...shopPages]
+  return [...staticPages, ...shopPages, ...eventPages, ...newsPages]
 }

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -1,11 +1,14 @@
 import { cache } from 'react'
 import { createClient } from '@supabase/supabase-js'
 import type { Metadata } from 'next'
-import type { CafeOrCoffeeShopLeaf, CollectionPageLeaf, OrganizationLeaf, WebSite, WithContext } from 'schema-dts'
+import type { CafeOrCoffeeShopLeaf, CollectionPageLeaf, Event, NewsArticle, OrganizationLeaf, Place, WebSite, WithContext } from 'schema-dts'
 import { DbShop } from '@/types/shop-types'
 import { logger } from '@/lib/logger'
 import { buildShopSlug, extractUuidPrefix } from '@/app/utils/shopSlug'
 import { getShopByUuidPrefix } from '@/app/utils/shops'
+import { buildContentSlug } from '@/app/utils/slug'
+import { getEventByIdPrefix } from '@/app/utils/events'
+import { getUpdateByIdPrefix } from '@/app/utils/updates'
 
 export const SITE_URL = 'https://pgh.coffee'
 export const SITE_NAME = 'pgh.coffee'
@@ -223,5 +226,186 @@ export function buildShopListJsonLd(shops: ShopListEntry[]): WithContext<Collect
         url: buildShopUrl(shop),
       })),
     },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Events & news (updates)
+// ---------------------------------------------------------------------------
+
+export interface SeoShopRef {
+  name: string
+  neighborhood?: string | null
+  address?: string | null
+  latitude?: number | null
+  longitude?: number | null
+}
+
+export interface SeoEvent {
+  id: string
+  title: string
+  description?: string | null
+  url?: string | null
+  event_date?: string | null
+  shop?: SeoShopRef | null
+}
+
+export interface SeoUpdate {
+  id: string
+  title: string
+  description?: string | null
+  url?: string | null
+  post_date?: string | null
+}
+
+export interface ContentListEntry {
+  id: string
+  title: string
+}
+
+export function buildEventPath(event: ContentListEntry): string {
+  return `/events/${buildContentSlug(event)}`
+}
+
+export function buildEventUrl(event: ContentListEntry): string {
+  return `${SITE_URL}${buildEventPath(event)}`
+}
+
+export function buildNewsPath(update: ContentListEntry): string {
+  return `/news/${buildContentSlug(update)}`
+}
+
+export function buildNewsUrl(update: ContentListEntry): string {
+  return `${SITE_URL}${buildNewsPath(update)}`
+}
+
+/**
+ * Resolves the event for a `/events/{slug}` page from its id prefix. Wrapped in
+ * cache() so generateMetadata and the page body share one query per request.
+ */
+export const getEventForSeo = cache(async (slug: string): Promise<SeoEvent | null> => {
+  const prefix = extractUuidPrefix(slug)
+  return prefix ? await getEventByIdPrefix(prefix) : null
+})
+
+/** Same as getEventForSeo, for `/news/{slug}` pages. */
+export const getUpdateForSeo = cache(async (slug: string): Promise<SeoUpdate | null> => {
+  const prefix = extractUuidPrefix(slug)
+  return prefix ? await getUpdateByIdPrefix(prefix) : null
+})
+
+export const getAllEventsForSeo = cache(async (): Promise<ContentListEntry[]> => {
+  const supabase = getSupabase()
+  const { data, error } = await supabase.from('events').select('id, title').order('event_date', { ascending: false })
+
+  if (error || !data) {
+    if (error) logger.error('Error fetching events for SEO', { error: error.message })
+    return []
+  }
+
+  return data as ContentListEntry[]
+})
+
+export const getAllUpdatesForSeo = cache(async (): Promise<ContentListEntry[]> => {
+  const supabase = getSupabase()
+  const { data, error } = await supabase.from('updates').select('id, title').order('post_date', { ascending: false })
+
+  if (error || !data) {
+    if (error) logger.error('Error fetching updates for SEO', { error: error.message })
+    return []
+  }
+
+  return data as ContentListEntry[]
+})
+
+export function buildEventMetadata(event: SeoEvent): Metadata {
+  const title = `${event.title} | pgh.coffee`
+  const description =
+    event.description?.trim() ||
+    `${event.title}${event.shop ? ` at ${event.shop.name}` : ''} — a coffee event in Pittsburgh.`
+  const path = buildEventPath(event)
+
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    openGraph: { title, description, type: 'article', url: path },
+    twitter: { card: 'summary', title, description },
+  }
+}
+
+function buildEventPlace(shop: SeoShopRef): Place {
+  const parsed = shop.address ? parseAddress(shop.address) : null
+
+  return {
+    '@type': 'Place',
+    name: shop.name,
+    ...(parsed
+      ? {
+          address: {
+            '@type': 'PostalAddress',
+            streetAddress: parsed.streetAddress,
+            addressLocality: parsed.addressLocality,
+            addressRegion: parsed.addressRegion,
+            postalCode: parsed.postalCode,
+            addressCountry: 'US',
+          },
+        }
+      : shop.address
+        ? { address: shop.address }
+        : {}),
+    ...(shop.latitude != null && shop.longitude != null
+      ? { geo: { '@type': 'GeoCoordinates', latitude: shop.latitude, longitude: shop.longitude } }
+      : {}),
+  }
+}
+
+/**
+ * Builds Event JSON-LD from real event data only. Fields without source data
+ * (endDate, offers, performer) are omitted rather than guessed.
+ */
+export function buildEventJsonLd(event: SeoEvent): WithContext<Event> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    name: event.title,
+    url: buildEventUrl(event),
+    ...(event.event_date ? { startDate: event.event_date } : {}),
+    ...(event.description ? { description: event.description } : {}),
+    ...(event.shop ? { location: buildEventPlace(event.shop) } : {}),
+  }
+}
+
+export function buildNewsMetadata(update: SeoUpdate): Metadata {
+  const title = `${update.title} | pgh.coffee`
+  const description = update.description?.trim() || `${update.title} — Pittsburgh coffee news.`
+  const path = buildNewsPath(update)
+
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    openGraph: { title, description, type: 'article', url: path },
+    twitter: { card: 'summary', title, description },
+  }
+}
+
+/**
+ * Builds NewsArticle JSON-LD from real update data only. The canonical
+ * `/news/{slug}` URL is used for both url and mainEntityOfPage; the external
+ * source link (update.url) is intentionally not the canonical.
+ */
+export function buildNewsJsonLd(update: SeoUpdate): WithContext<NewsArticle> {
+  const url = buildNewsUrl(update)
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'NewsArticle',
+    headline: update.title,
+    url,
+    mainEntityOfPage: url,
+    publisher: { '@type': 'Organization', name: SITE_NAME, url: SITE_URL },
+    ...(update.post_date ? { datePublished: update.post_date } : {}),
+    ...(update.description ? { description: update.description } : {}),
   }
 }

--- a/tests/unit/contentSeo.test.ts
+++ b/tests/unit/contentSeo.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect, vi } from 'vitest'
+
+// seo.ts transitively creates Supabase clients at module load; these tests only
+// exercise pure builders, so stub the client (matching seo.test.ts).
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({}),
+}))
+
+import {
+  buildEventPath,
+  buildEventUrl,
+  buildNewsUrl,
+  buildEventMetadata,
+  buildEventJsonLd,
+  buildNewsMetadata,
+  buildNewsJsonLd,
+  jsonLdToString,
+  type SeoEvent,
+  type SeoUpdate,
+} from '@/app/utils/seo'
+
+const baseEvent: SeoEvent = {
+  id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  title: 'Latte Art Throwdown',
+  description: 'A friendly competition.',
+  url: 'https://example.com/throwdown',
+  event_date: '2026-07-01',
+  shop: {
+    name: '61B Cafe',
+    neighborhood: 'Regent Square',
+    address: '1108 S Braddock Ave, Pittsburgh, PA 15218',
+    latitude: 40.432417,
+    longitude: -79.893948,
+  },
+}
+
+const baseUpdate: SeoUpdate = {
+  id: 'deadbeef-0000-1111-2222-333344445555',
+  title: 'New Roaster Opens in Lawrenceville',
+  description: 'Details inside.',
+  url: 'https://example.com/source',
+  post_date: '2026-06-10',
+}
+
+describe('event/news URL builders', () => {
+  test('build /events and /news paths with the title-id8 slug', () => {
+    expect(buildEventPath(baseEvent)).toBe('/events/latte-art-throwdown-a1b2c3d4')
+    expect(buildEventUrl(baseEvent)).toBe('https://pgh.coffee/events/latte-art-throwdown-a1b2c3d4')
+    expect(buildNewsUrl(baseUpdate)).toBe('https://pgh.coffee/news/new-roaster-opens-in-lawrenceville-deadbeef')
+  })
+})
+
+describe('buildEventMetadata', () => {
+  test('sets a canonical and og:url pointing at the event path', () => {
+    const meta = buildEventMetadata(baseEvent)
+    expect(meta.alternates?.canonical).toBe('/events/latte-art-throwdown-a1b2c3d4')
+    expect(meta.openGraph?.url).toBe('/events/latte-art-throwdown-a1b2c3d4')
+  })
+
+  test('falls back to a generated description that names the shop when none is set', () => {
+    const meta = buildEventMetadata({ ...baseEvent, description: null })
+    expect(meta.description).toBe('Latte Art Throwdown at 61B Cafe — a coffee event in Pittsburgh.')
+  })
+})
+
+describe('buildEventJsonLd', () => {
+  test('includes startDate and a Place location with parsed address + geo', () => {
+    const jsonLd = buildEventJsonLd(baseEvent)
+    expect(jsonLd['@type']).toBe('Event')
+    expect(jsonLd.startDate).toBe('2026-07-01')
+    const place = jsonLd.location as { '@type': string; name: string; address: { postalCode: string }; geo: { latitude: number } }
+    expect(place['@type']).toBe('Place')
+    expect(place.name).toBe('61B Cafe')
+    expect(place.address.postalCode).toBe('15218')
+    expect(place.geo.latitude).toBe(40.432417)
+    expect(() => JSON.parse(jsonLdToString(jsonLd))).not.toThrow()
+  })
+
+  test('omits startDate and location when there is no date or shop', () => {
+    const jsonLd = buildEventJsonLd({ id: baseEvent.id, title: baseEvent.title })
+    expect(jsonLd.startDate).toBeUndefined()
+    expect(jsonLd.location).toBeUndefined()
+  })
+})
+
+describe('buildNewsMetadata / buildNewsJsonLd', () => {
+  test('metadata canonicalizes to the news path', () => {
+    expect(buildNewsMetadata(baseUpdate).alternates?.canonical).toBe(
+      '/news/new-roaster-opens-in-lawrenceville-deadbeef',
+    )
+  })
+
+  test('NewsArticle uses the canonical url for url + mainEntityOfPage, not the source link', () => {
+    const jsonLd = buildNewsJsonLd(baseUpdate)
+    const canonical = 'https://pgh.coffee/news/new-roaster-opens-in-lawrenceville-deadbeef'
+    expect(jsonLd['@type']).toBe('NewsArticle')
+    expect(jsonLd.headline).toBe(baseUpdate.title)
+    expect(jsonLd.url).toBe(canonical)
+    expect(jsonLd.mainEntityOfPage).toBe(canonical)
+    expect(jsonLd.datePublished).toBe('2026-06-10')
+  })
+
+  test('omits datePublished when post_date is missing', () => {
+    expect(buildNewsJsonLd({ id: baseUpdate.id, title: baseUpdate.title }).datePublished).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Applies the shop SEO treatment (#245) to the events and news pages introduced by the routing PR (#254). Each `/events/{slug}` and `/news/{slug}` page now ships real metadata and structured data, the same way `/shops/{slug}` does.

- **Per-item metadata**: title, description (with a sensible generated fallback), canonical, and Open Graph / Twitter cards — `buildEventMetadata` / `buildNewsMetadata`.
- **JSON-LD**:
  - `Event` per event — `startDate`, `description`, `url`, and a `Place` location carrying the shop's parsed `PostalAddress` + `GeoCoordinates` when available (`buildEventJsonLd`).
  - `NewsArticle` per update — `headline`, `datePublished`, `description`, `publisher` (Organization). `url`/`mainEntityOfPage` point at the canonical `/news/{slug}`, **not** the external source link (`buildNewsJsonLd`).
  - Built from real fields only; anything without source data (event `endDate`/`offers`, article author, etc.) is omitted rather than guessed.
- **Sitemap**: `sitemap.xml` now includes every event and news URL alongside shops and static pages.
- **Heading**: a server-rendered `sr-only` `<h1>` on each page (the panel's own `<h1>` only appears after client fetch).

Data is fetched server-side via `cache()`-wrapped `getEventForSeo` / `getUpdateForSeo` so `generateMetadata` and the page body share one query per request, and JSON-LD is `<`-escaped via the existing `jsonLdToString`.

## Depends on #245 **and** #254

This is the first change that needs both:

- **#254** (`restructure/events-news-url-paths`) — the real `/events/{slug}` & `/news/{slug}` routes and the `by-slug` resolution this hangs SEO off of.
- **#245** (`overnight/seo-2026-06-15`) — the SEO foundation (`seo.ts` helpers, `schema-dts`, `metadataBase`, `jsonLdToString`/`parseAddress`).

The PR is **based on #254** (as requested) with **#245 merged in** to bring in that foundation — so the diff against #254 includes #245's commits until both land. The new work is isolated in the final commit, `Add SEO metadata and JSON-LD for events and news`.

**Merge order:** #246 → #245 + #254 (either order) → this.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 159 passed (new: `tests/unit/contentSeo.test.ts` — event/news URL builders, canonical metadata, JSON-LD field omission, NewsArticle canonical-vs-source-link)
- [x] `npm run build` succeeds; `/events/[slug]`, `/news/[slug]`, `/sitemap.xml` build as expected routes
- [x] `npm run lint` clean (no new warnings)
- [ ] Manual check of rendered `<head>` metadata + JSON-LD on a deployed preview (Rich Results Test / OG debugger) — not done in this environment
