### PR TITLE
Code-split and defer map mount

### DIFF
--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -6,7 +6,7 @@ import { useAnalytics } from '@/hooks'
 import { TShop } from '@/types/shop-types'
 import Panel from '@/app/components/Panel'
 import ShopSearch from './ShopSearch'
-import MapContainer from './MapContainer'
+import MapContainerLazy from './MapContainerLazy'
 import { ExploreContent } from './ExploreContent'
 import { useURLShopSync, useURLEventSync, useURLNewsSync, useMediaQuery } from '@/hooks'
 import useShopsStore from '@/stores/coffeeShopsStore'
@@ -114,7 +114,7 @@ export default function HomeClient() {
   return (
     <div className="relative w-full h-full">
       {!largeViewport && !presented && <SearchFAB handleClick={() => setPresented(true)} />}
-      <MapContainer
+      <MapContainerLazy
         currentShopCoordinates={[currentShop?.geometry?.coordinates[0], currentShop?.geometry?.coordinates[1]]}
       />
       <Panel shop={currentShop} presented={presented} onPresentedChange={setPresented}>

--- a/app/components/MapContainerLazy.tsx
+++ b/app/components/MapContainerLazy.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useEffect, useState } from 'react'
+
+// Code-split MapContainer (and the heavy mapbox-gl/react-map-gl payload it pulls
+// in) out of the initial bundle. ssr: false because the map is client-only.
+const MapContainer = dynamic(() => import('./MapContainer'), {
+  ssr: false,
+  loading: () => <MapPlaceholder />,
+})
+
+// Matches MapContainer's outer layout exactly so deferring the mount doesn't
+// shift the panel or cause a layout jump (CLS). Dark fill mirrors the
+// mapbox dark-v11 style so the swap-in is visually seamless.
+function MapPlaceholder() {
+  return (
+    <div
+      data-testid="map-placeholder"
+      aria-hidden="true"
+      className="w-full lg:w-2/3 overflow-hidden bg-[#191a1a] animate-pulse"
+    />
+  )
+}
+
+interface MapContainerLazyProps {
+  currentShopCoordinates: [number, number]
+}
+
+/**
+ * Defers mounting the map until after the first paint so mapbox-gl's parse +
+ * init cost (~2.8s of main-thread blocking) lands outside the critical
+ * render path. The panel and explore content paint first; the map mounts on
+ * the first idle callback (or a short timeout fallback on browsers without
+ * requestIdleCallback).
+ */
+export default function MapContainerLazy(props: MapContainerLazyProps) {
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    const ric = window.requestIdleCallback
+    if (typeof ric === 'function') {
+      const handle = ric(() => setReady(true), { timeout: 2000 })
+      return () => window.cancelIdleCallback?.(handle)
+    }
+    const timer = window.setTimeout(() => setReady(true), 200)
+    return () => window.clearTimeout(timer)
+  }, [])
+
+  if (!ready) return <MapPlaceholder />
+
+  return <MapContainer {...props} />
+}

--- a/app/components/MapContainerLazy.tsx
+++ b/app/components/MapContainerLazy.tsx
@@ -3,8 +3,6 @@
 import dynamic from 'next/dynamic'
 import { useEffect, useState } from 'react'
 
-// Code-split MapContainer (and the heavy mapbox-gl/react-map-gl payload it pulls
-// in) out of the initial bundle. ssr: false because the map is client-only.
 const MapContainer = dynamic(() => import('./MapContainer'), {
   ssr: false,
   loading: () => <MapPlaceholder />,
@@ -27,13 +25,6 @@ interface MapContainerLazyProps {
   currentShopCoordinates: [number, number]
 }
 
-/**
- * Defers mounting the map until after the first paint so mapbox-gl's parse +
- * init cost (~2.8s of main-thread blocking) lands outside the critical
- * render path. The panel and explore content paint first; the map mounts on
- * the first idle callback (or a short timeout fallback on browsers without
- * requestIdleCallback).
- */
 export default function MapContainerLazy(props: MapContainerLazyProps) {
   const [ready, setReady] = useState(false)
 

--- a/tests/unit/MapContainerLazy.test.tsx
+++ b/tests/unit/MapContainerLazy.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import MapContainerLazy from '@/app/components/MapContainerLazy'
+
+// Stand in for the real (mapbox-gl-heavy) MapContainer so the dynamic import
+// resolves instantly and we can assert on mount timing without loading mapbox.
+vi.mock('@/app/components/MapContainer', () => ({
+  default: () => <div data-testid="map-real">map</div>,
+}))
+
+// Capture the idle callback so the test controls when "first paint" idle fires.
+let idleCb: (() => void) | null = null
+
+beforeEach(() => {
+  idleCb = null
+  vi.stubGlobal('requestIdleCallback', (cb: () => void) => {
+    idleCb = cb
+    return 1
+  })
+  vi.stubGlobal('cancelIdleCallback', vi.fn())
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('MapContainerLazy', () => {
+  it('renders only the placeholder before the idle callback fires', () => {
+    render(<MapContainerLazy currentShopCoordinates={[0, 0]} />)
+
+    expect(screen.getByTestId('map-placeholder')).toBeInTheDocument()
+    expect(screen.queryByTestId('map-real')).not.toBeInTheDocument()
+  })
+
+  it('mounts the map once the browser is idle', async () => {
+    render(<MapContainerLazy currentShopCoordinates={[0, 0]} />)
+
+    expect(idleCb).toBeTypeOf('function')
+    idleCb!()
+
+    await waitFor(() => expect(screen.getByTestId('map-real')).toBeInTheDocument())
+    expect(screen.queryByTestId('map-placeholder')).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/MapContainerLazy.test.tsx
+++ b/tests/unit/MapContainerLazy.test.tsx
@@ -2,19 +2,17 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import MapContainerLazy from '@/app/components/MapContainerLazy'
 
-// Stand in for the real (mapbox-gl-heavy) MapContainer so the dynamic import
-// resolves instantly and we can assert on mount timing without loading mapbox.
 vi.mock('@/app/components/MapContainer', () => ({
   default: () => <div data-testid="map-real">map</div>,
 }))
 
 // Capture the idle callback so the test controls when "first paint" idle fires.
-let idleCb: (() => void) | null = null
+let idleCallback: (() => void) | null = null
 
 beforeEach(() => {
-  idleCb = null
+  idleCallback = null
   vi.stubGlobal('requestIdleCallback', (cb: () => void) => {
-    idleCb = cb
+    idleCallback = cb
     return 1
   })
   vi.stubGlobal('cancelIdleCallback', vi.fn())
@@ -35,8 +33,8 @@ describe('MapContainerLazy', () => {
   it('mounts the map once the browser is idle', async () => {
     render(<MapContainerLazy currentShopCoordinates={[0, 0]} />)
 
-    expect(idleCb).toBeTypeOf('function')
-    idleCb!()
+    expect(idleCallback).toBeTypeOf('function')
+    idleCallback!()
 
     await waitFor(() => expect(screen.getByTestId('map-real')).toBeInTheDocument())
     expect(screen.queryByTestId('map-placeholder')).not.toBeInTheDocument()


### PR DESCRIPTION
## What this does

- Code-splits `MapContainer` (and its `mapbox-gl` / `react-map-gl` payload) out of the eager homepage chunk via `next/dynamic` (`ssr: false`).
- Defers mounting the map until after first paint using `requestIdleCallback` (with a `setTimeout(200ms)` fallback).
- Renders a layout-matched, dark-filled placeholder so deferring the mount causes **no layout shift**.
- `HomeClient` swaps `MapContainer` → `MapContainerLazy` (one import + one tag).

## What this does NOT do — read before reviewing

**This does not improve Total Blocking Time.** A Lighthouse run on the deploy preview shows TBT still at ~5,830 ms.

Why: TBT is the sum of long-task time between FCP and TTI. `requestIdleCallback` fires almost immediately on this page (or at its 2s timeout) — well before TTI (~16s) — so mapbox-gl's parse + map init still runs *inside* the scored window. Deferring the mount to idle moves the work slightly later but does not remove it from the TBT window. So the headline map-blocking problem is **not** solved here.

## Why ship it anyway

- **CLS stays 0** — the placeholder holds the map's space; this is a real (small) safety win.
- Eager route JS drops 13.8 kB → 5.67 kB; the map payload moves to an async chunk.
- It's low-risk and functionally identical once the map mounts.
- It establishes the lazy-mount scaffolding that the *actual* TBT fix will build on (see below).

## Follow-up work (separate PRs)

1. **Reduce TBT (the map-blocking problem):** either gate the map mount on first user interaction (removes map cost from initial load, at the UX cost of a placeholder until interaction) and/or apply mapbox init tuning (`antialias:false`, `fadeDuration:0`, `projection:'mercator'`, `optimizeForTerrain:false`, defer rendering all shop circles until idle). This wrapper is where that change lands.
2. **Reduce TTFB** ("reduce initial server response time", ~2.5s on the preview) — a *separate* problem from TBT; fixing it will not affect TBT.

## Tests

- `tests/unit/MapContainerLazy.test.tsx`: placeholder renders before idle; map mounts once `requestIdleCallback` fires.
- Full suite: 174 passed / 7 skipped. Lint clean (pre-existing `<img>` warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
