### PR TITLE
Register a service worker for PWA support

### DIFF
--- a/app/components/ServiceWorkerRegister.tsx
+++ b/app/components/ServiceWorkerRegister.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export function ServiceWorkerRegister() {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') return
+    if (!('serviceWorker' in navigator)) return
+
+    navigator.serviceWorker.register('/sw.js').catch((error) => {
+      console.error('Service worker registration failed:', error)
+    })
+  }, [])
+
+  return null
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from 'next/font/google'
 import './globals.css'
 import Nav from '@/app/components/Nav'
 import { FaroInit } from '@/app/components/FaroInit'
+import { ServiceWorkerRegister } from '@/app/components/ServiceWorkerRegister'
 import { AuthProvider } from '@/app/components/AuthProvider'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -42,6 +43,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className={inter.className}>
         <AuthProvider>
           <FaroInit />
+          <ServiceWorkerRegister />
           <Nav />
           <main>{children}</main>
         </AuthProvider>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,39 @@
+const CACHE_NAME = 'pgh-coffee-v1'
+const OFFLINE_URLS = ['/']
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_URLS)),
+  )
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))),
+      )
+      .then(() => self.clients.claim()),
+  )
+})
+
+// Network-first for navigations so users always get fresh content when online,
+// falling back to the cached shell when offline.
+self.addEventListener('fetch', (event) => {
+  const { request } = event
+  if (request.method !== 'GET') return
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const copy = response.clone()
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, copy))
+          return response
+        })
+        .catch(() => caches.match(request).then((cached) => cached || caches.match('/'))),
+    )
+  }
+})

--- a/public/sw.js
+++ b/public/sw.js
@@ -20,20 +20,29 @@ self.addEventListener('activate', (event) => {
 })
 
 // Network-first for navigations so users always get fresh content when online,
-// falling back to the cached shell when offline.
+// falling back to the cached app shell when offline. Only the shell ('/') is
+// cached so we never persist authenticated or route-specific HTML.
 self.addEventListener('fetch', (event) => {
   const { request } = event
-  if (request.method !== 'GET') return
+  if (request.method !== 'GET' || request.mode !== 'navigate') return
 
-  if (request.mode === 'navigate') {
-    event.respondWith(
-      fetch(request)
-        .then((response) => {
+  const url = new URL(request.url)
+  const isShell = url.origin === self.location.origin && url.pathname === '/'
+
+  event.respondWith(
+    fetch(request)
+      .then((response) => {
+        if (isShell) {
           const copy = response.clone()
-          caches.open(CACHE_NAME).then((cache) => cache.put(request, copy))
-          return response
-        })
-        .catch(() => caches.match(request).then((cached) => cached || caches.match('/'))),
-    )
-  }
+          event.waitUntil(
+            caches
+              .open(CACHE_NAME)
+              .then((cache) => cache.put('/', copy))
+              .catch(() => {}),
+          )
+        }
+        return response
+      })
+      .catch(() => caches.match('/')),
+  )
 })


### PR DESCRIPTION
## Why

Lighthouse's PWA audit flagged that the site **does not register a service worker that controls the page and `start_url`**, which blocks offline support, install-to-homescreen, and push notifications.

## What

- **`public/sw.js`** — a service worker that caches the app shell (`/`) on install and uses a network-first strategy for navigations, falling back to the cached shell when offline. Cleans up stale caches on activation and calls `clients.claim()` so it controls the page immediately.
- **`app/components/ServiceWorkerRegister.tsx`** — a client component that registers `/sw.js` (production only, with a `serviceWorker in navigator` guard), mirroring the existing `FaroInit` pattern.
- Wired into `app/layout.tsx`.

The manifest already exposes `start_url: '/'`, so registering an SW that caches and serves `/` satisfies the audit.

## Testing

- `npm run build`, `npm run lint`, and `npm test` all pass.
- The SW only registers when `NODE_ENV === 'production'`, so verify the Lighthouse fix against `npm run build && npm start` rather than the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)