### PR TITLE
Add 'Add to Calendar' button to event details

### DIFF
--- a/app/components/EventDetails.tsx
+++ b/app/components/EventDetails.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { Calendar, SquareArrowOutUpRight, MapPin, Share2 } from 'lucide-react'
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react'
+import { Calendar, CalendarPlus, SquareArrowOutUpRight, MapPin, Share2 } from 'lucide-react'
 import { useCopyToClipboard, useAnalytics } from '@/hooks'
 import { isPast } from '@/app/utils/utils'
+import { buildGoogleCalendarUrl, downloadICS } from '@/app/utils/calendar'
 import { EventCardData } from './EventCard'
 import CopyLinkToast from './CopyLinkToast'
 
@@ -84,6 +86,22 @@ export const EventDetails = ({ event }: EventDetailsProps) => {
         url: event.url,
       },
     })
+  }
+
+  const handleAddToCalendar = (target: 'google' | 'ics') => {
+    plausible('EventDetailsAddToCalendar', {
+      props: {
+        eventTitle: event.title,
+        eventId: event.id,
+        target,
+      },
+    })
+
+    if (target === 'google') {
+      window.open(buildGoogleCalendarUrl(event), '_blank', 'noopener,noreferrer')
+    } else {
+      downloadICS(event)
+    }
   }
 
   return (
@@ -197,6 +215,32 @@ export const EventDetails = ({ event }: EventDetailsProps) => {
       {/* Fixed Bottom Section */}
       <div className="absolute bottom-0 left-0 right-0 p-6 bg-neutral-50 border-t border-gray-100">
         <div className="flex flex-col gap-4">
+          {event.event_date && !eventIsPast && (
+            <Menu as="div" className="relative">
+              <MenuButton className="w-full bg-white text-slate-900 font-bold py-3.5 rounded-full shadow-sm hover:shadow-md hover:bg-stone-50 active:scale-[0.98] transition-all border border-stone-200 flex items-center justify-center gap-2">
+                <CalendarPlus className="w-5 h-5" />
+                Add to Calendar
+              </MenuButton>
+              <MenuItems className="absolute bottom-full left-0 right-0 mb-2 bg-white rounded-2xl shadow-lg border border-stone-200 overflow-hidden focus:outline-none z-10">
+                <MenuItem>
+                  <button
+                    onClick={() => handleAddToCalendar('google')}
+                    className="w-full text-left px-5 py-3.5 text-slate-900 font-medium hover:bg-stone-50 data-[focus]:bg-stone-50 transition-colors"
+                  >
+                    Google Calendar
+                  </button>
+                </MenuItem>
+                <MenuItem>
+                  <button
+                    onClick={() => handleAddToCalendar('ics')}
+                    className="w-full text-left px-5 py-3.5 text-slate-900 font-medium hover:bg-stone-50 data-[focus]:bg-stone-50 transition-colors border-t border-stone-100"
+                  >
+                    Apple / Outlook (.ics)
+                  </button>
+                </MenuItem>
+              </MenuItems>
+            </Menu>
+          )}
           <div className="flex gap-2">
             {event.url && (
               <a

--- a/app/utils/calendar.ts
+++ b/app/utils/calendar.ts
@@ -1,0 +1,102 @@
+import { EventCardData } from '@/app/components/EventCard'
+
+/**
+ * Calendar export helpers for events.
+ *
+ * Events only carry a date (no time), so they are treated as all-day events.
+ * All-day calendar entries use an exclusive end date, so DTEND / the Google
+ * `dates` end value is the day after the event.
+ */
+
+const toCalDate = (ymd: string) => ymd.replace(/-/g, '')
+
+const nextDay = (ymd: string) => {
+  const [y, m, d] = ymd.split('-').map(Number)
+  const date = new Date(Date.UTC(y, m - 1, d + 1))
+  return date.toISOString().slice(0, 10).replace(/-/g, '')
+}
+
+const buildLocation = (event: EventCardData) =>
+  event.shop ? `${event.shop.name}, ${event.shop.neighborhood}, Pittsburgh, PA` : ''
+
+const buildDescription = (event: EventCardData) =>
+  [event.description, event.url].filter(Boolean).join('\n\n')
+
+/**
+ * Builds a Google Calendar "create event" URL for an all-day event.
+ */
+export const buildGoogleCalendarUrl = (event: EventCardData): string => {
+  if (!event.event_date) return ''
+
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.title,
+    dates: `${toCalDate(event.event_date)}/${nextDay(event.event_date)}`,
+  })
+
+  const details = buildDescription(event)
+  if (details) params.set('details', details)
+
+  const location = buildLocation(event)
+  if (location) params.set('location', location)
+
+  return `https://calendar.google.com/calendar/render?${params.toString()}`
+}
+
+// Per RFC 5545, long lines fold and certain characters in text values must be escaped.
+const escapeICS = (value: string) =>
+  value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\n/g, '\\n')
+
+/**
+ * Builds the contents of an .ics file for an all-day event.
+ */
+export const buildICS = (event: EventCardData): string => {
+  if (!event.event_date) return ''
+
+  const stamp = new Date().toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z'
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//pgh.coffee//Events//EN',
+    'BEGIN:VEVENT',
+    `UID:${event.id}@pgh.coffee`,
+    `DTSTAMP:${stamp}`,
+    `DTSTART;VALUE=DATE:${toCalDate(event.event_date)}`,
+    `DTEND;VALUE=DATE:${nextDay(event.event_date)}`,
+    `SUMMARY:${escapeICS(event.title)}`,
+  ]
+
+  const details = buildDescription(event)
+  if (details) lines.push(`DESCRIPTION:${escapeICS(details)}`)
+
+  const location = buildLocation(event)
+  if (location) lines.push(`LOCATION:${escapeICS(location)}`)
+
+  if (event.url) lines.push(`URL:${event.url}`)
+
+  lines.push('END:VEVENT', 'END:VCALENDAR')
+
+  return lines.join('\r\n')
+}
+
+/**
+ * Triggers a browser download of the event as an .ics file.
+ */
+export const downloadICS = (event: EventCardData): void => {
+  const ics = buildICS(event)
+  if (!ics) return
+
+  const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `${event.title.replace(/[^a-z0-9]+/gi, '-').toLowerCase()}.ics`
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## What

Adds an **Add to Calendar** button to the event detail panel. Users can export an event to Google Calendar (opens a prefilled "create event" page) or download an `.ics` file for Apple Calendar / Outlook.

## Details

- New `app/utils/calendar.ts` with `buildGoogleCalendarUrl`, `buildICS`, and `downloadICS`.
- Events carry only a date (no time), so entries are created as **all-day** events using an exclusive end date (the day after), per RFC 5545 / Google's date format.
- ICS text values are escaped per spec. Location is built from shop name + neighborhood + Pittsburgh, PA; description includes the event URL.
- Button appears in the fixed bottom section, only for events with a date that aren't in the past.
- Clicks fire a `EventDetailsAddToCalendar` Plausible event with the chosen target.

## Note

There's no event *time* in the data model, so everything is all-day. Adding start/end times later would require switching the calendar util to `DATE-TIME` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)