### PR TITLE
Sort upcoming events soonest-first

### DIFF
--- a/app/components/Events.tsx
+++ b/app/components/Events.tsx
@@ -16,7 +16,14 @@ export const Events = () => {
     fetchEvents().then(setEvents)
   }, [])
 
-  const upcomingEvents = events.filter(e => !e.event_date || !isPast(e.event_date))
+  const upcomingEvents = events
+    .filter(e => !e.event_date || !isPast(e.event_date))
+    // Soonest first; undated events sort to the end
+    .sort((a, b) => {
+      if (!a.event_date) return 1
+      if (!b.event_date) return -1
+      return a.event_date.localeCompare(b.event_date)
+    })
   const pastEvents = events.filter(e => e.event_date && isPast(e.event_date))
 
   return (


### PR DESCRIPTION
## What
On the events list (`/?events`), the **Upcoming** section was showing the farthest-out event at the top and the soonest at the bottom.

## Why
The `/api/events` route orders rows by `event_date` descending. That's correct for the **Past** section (most recent first), but reverses the desired order for upcoming events.

## Change
Sort the upcoming list ascending in `Events.tsx` so the soonest event appears at the top. Undated upcoming events sort to the end. Past events are unchanged.