### PR TITLE
Reset quick actions scroll when shop changes

### DIFF
--- a/app/components/QuickActionsBar.tsx
+++ b/app/components/QuickActionsBar.tsx
@@ -22,7 +22,7 @@ export default function QuickActionsBar({ shop }: QuickActionsBarProps) {
   const coordinates = shop.geometry?.coordinates
 
   useEffect(() => {
-    scrollRef.current?.scrollTo({ left: 0 })
+    if (scrollRef.current) scrollRef.current.scrollLeft = 0
   }, [uuid])
 
   function handleIssueSuccess() {

--- a/app/components/QuickActionsBar.tsx
+++ b/app/components/QuickActionsBar.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { TShop } from '@/types/shop-types'
 import DirectionsButton from './DirectionsButton'
 import WebsiteButton from './WebsiteButton'
@@ -16,9 +16,14 @@ interface QuickActionsBarProps {
 export default function QuickActionsBar({ shop }: QuickActionsBarProps) {
   const [showIssueModal, setShowIssueModal] = useState(false)
   const [showSuccessDialog, setShowSuccessDialog] = useState(false)
+  const scrollRef = useRef<HTMLDivElement>(null)
 
   const { website, uuid, name } = shop.properties
   const coordinates = shop.geometry?.coordinates
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ left: 0 })
+  }, [uuid])
 
   function handleIssueSuccess() {
     setShowIssueModal(false)
@@ -27,7 +32,7 @@ export default function QuickActionsBar({ shop }: QuickActionsBarProps) {
 
   return (
     <>
-      <div className="flex gap-2 px-4 sm:px-6 py-4 bg-white border-b border-stone-200 overflow-x-auto [&>button]:shrink-0">
+      <div ref={scrollRef} className="flex gap-2 px-4 sm:px-6 py-4 bg-white border-b border-stone-200 overflow-x-auto [&>button]:shrink-0">
         <FavoriteButton shopUUID={uuid} shopName={name} />
         <ShareButton />
         <DirectionsButton coordinates={coordinates} />


### PR DESCRIPTION
## Summary

Fixes #208. Opening a shop, scrolling the quick-actions row horizontally, then opening a nearby shop left the actions scrolled to the same position instead of resetting to the start.

`QuickActionsBar` is rendered as a single reused instance across shop selections, so its scrollable row retained its `scrollLeft`. This adds a ref to the row and resets it to `0` whenever the shop's `uuid` changes.

## Test plan

- [ ] Open a shop, scroll the quick actions to the right, open a nearby shop — actions should be scrolled back to the start.