### PR TITLE
Refresh company page visuals

### DIFF
--- a/app/components/Company.tsx
+++ b/app/components/Company.tsx
@@ -25,7 +25,7 @@ const groupByNeighborhood = (features: TShop[]): [string, TShop[]][] => {
 }
 
 export const Company = ({ slug }: { slug: string }) => {
-  const { setOverrideShops } = useShopsStore()
+  const { setOverrideShops, setSearchValue } = useShopsStore()
   const [company, setCompany] = useState<TCompany | null>(null)
   const [loading, setLoading] = useState(true)
 
@@ -154,11 +154,16 @@ export const Company = ({ slug }: { slug: string }) => {
           <h2 className="text-xs font-semibold uppercase tracking-wider text-gray-500">Locations</h2>
           {grouped.map(([neighborhood, shops]) => (
             <div key={neighborhood}>
-              <div className="flex items-center gap-1.5 mt-4 text-gray-900">
-                <MapPinIcon className="h-4 w-4 text-gray-400" />
-                <h3 className="text-sm font-medium">{neighborhood}</h3>
+              <button
+                type="button"
+                onClick={() => setSearchValue(neighborhood)}
+                aria-label={`Show all shops in ${neighborhood}`}
+                className="group flex items-center gap-1.5 mt-4 text-gray-900 hover:text-gray-950"
+              >
+                <MapPinIcon className="h-4 w-4 text-gray-400 group-hover:text-gray-600" />
+                <h3 className="text-sm font-medium group-hover:underline">{neighborhood}</h3>
                 <span className="text-xs text-gray-400">({shops.length})</span>
-              </div>
+              </button>
               <LocationList coffeeShops={shops} hideShopNames={true} showAddresses={true} />
             </div>
           ))}

--- a/app/components/Company.tsx
+++ b/app/components/Company.tsx
@@ -169,9 +169,7 @@ export const Company = ({ slug }: { slug: string }) => {
                 aria-label={`Show all shops in ${neighborhood}`}
                 className="group flex items-center gap-1.5 mt-4 text-gray-900 hover:text-gray-950"
               >
-                <MapPinIcon className="h-4 w-4 text-gray-400 group-hover:text-gray-600" />
                 <h3 className="text-sm font-medium group-hover:underline">{neighborhood}</h3>
-                <span className="text-xs text-gray-400">({shops.length})</span>
               </button>
               <LocationList coffeeShops={shops} hideShopNames={true} showAddresses={true} />
             </div>

--- a/app/components/Company.tsx
+++ b/app/components/Company.tsx
@@ -1,12 +1,28 @@
 'use client'
 
-import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
+import { ArrowTopRightOnSquareIcon, BuildingStorefrontIcon, MapPinIcon } from '@heroicons/react/24/outline'
 import { Instagram } from 'lucide-react'
 import LocationList from '@/app/components/LocationList'
 import { useState, useEffect } from 'react'
 import useShopsStore from '@/stores/coffeeShopsStore'
 import { formatDataToGeoJSON } from '../utils/utils'
-import { TCompany } from '@/types/shop-types'
+import { TCompany, TShop } from '@/types/shop-types'
+
+const groupByNeighborhood = (features: TShop[]): [string, TShop[]][] => {
+  const groups = new Map<string, TShop[]>()
+  for (const feature of features) {
+    const neighborhood = feature.properties.neighborhood
+    const group = groups.get(neighborhood)
+    if (group) {
+      group.push(feature)
+    } else {
+      groups.set(neighborhood, [feature])
+    }
+  }
+  return Array.from(groups.entries()).sort(
+    (a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0])
+  )
+}
 
 export const Company = ({ slug }: { slug: string }) => {
   const { setOverrideShops } = useShopsStore()
@@ -49,52 +65,104 @@ export const Company = ({ slug }: { slug: string }) => {
 
   if (loading) {
     return (
-      <div className="px-6 lg:px-4 mt-24 lg:mt-16 flex flex-col animate-pulse">
-        <div className="flex items-center justify-between mb-2">
-          <div className="h-8 bg-gray-200 rounded w-48"></div>
-          <div className="flex gap-2">
-            <div className="h-4 w-4 bg-gray-200 rounded"></div>
-            <div className="h-4 w-4 bg-gray-200 rounded"></div>
+      <div className="flex h-full flex-col overflow-y-auto animate-pulse">
+        <div className="h-56 sm:h-64 bg-gray-200 shrink-0" />
+        <div className="px-6 lg:px-4 py-6 flex flex-col">
+          <div className="flex gap-2 mb-4">
+            <div className="h-8 w-24 bg-gray-200 rounded-full" />
+            <div className="h-8 w-24 bg-gray-200 rounded-full" />
           </div>
-        </div>
-        <div className="space-y-2 mb-4">
-          <div className="h-4 bg-gray-200 rounded w-full"></div>
-          <div className="h-4 bg-gray-200 rounded w-3/4"></div>
-        </div>
-        <div className="space-y-3">
-          {[1, 2, 3].map(i => (
-            <div key={i} className="h-16 bg-gray-200 rounded"></div>
-          ))}
+          <div className="space-y-2 mb-6">
+            <div className="h-4 bg-gray-200 rounded w-full" />
+            <div className="h-4 bg-gray-200 rounded w-3/4" />
+          </div>
+          <div className="space-y-3">
+            {[1, 2, 3].map(i => (
+              <div key={i} className="h-28 bg-gray-200 rounded" />
+            ))}
+          </div>
         </div>
       </div>
     )
   }
   if (!company) return <p>Company not found</p>
 
-  const shopsGeoJSON = formatDataToGeoJSON(company.shops || [])
+  const { features } = formatDataToGeoJSON(company.shops || [])
+  const heroPhoto = features.find(f => f.properties.photo)?.properties.photo
+  const locationCount = features.length
+  const neighborhoodCount = new Set(features.map(f => f.properties.neighborhood)).size
+  const grouped = groupByNeighborhood(features)
 
   return (
     <div className="flex h-full flex-col overflow-y-auto">
-      <div className="px-6 lg:px-4 mt-20 lg:mt-16 flex flex-col">
-        <div className="flex items-center justify-between mb-2">
-          <h2 className="font-medium text-2xl">{company.name}</h2>
-
-          <div className="flex gap-2">
-            <a
-              href={`https://www.instagram.com/${company.instagram_handle}/`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className=""
-            >
-              <Instagram className="h-4 w-4" />
-            </a>
-            <a href={company.website} target="_blank" rel="noopener noreferrer">
-              <ArrowTopRightOnSquareIcon className="h-4 w-4" />
-            </a>
+      <div
+        className="h-56 sm:h-64 relative bg-stone-300 bg-cover bg-center shrink-0"
+        style={heroPhoto ? { backgroundImage: `url('${heroPhoto}')` } : undefined}
+      >
+        <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/40 to-transparent" />
+        <div className="absolute bottom-0 left-0 right-0 p-4 sm:p-6 text-white">
+          <span className="inline-flex items-center gap-1.5 bg-yellow-300 text-gray-950 px-2.5 py-1 rounded-full text-xs font-semibold mb-3">
+            <BuildingStorefrontIcon className="w-3.5 h-3.5" />
+            Coffee company
+          </span>
+          <h1 className="text-3xl sm:text-4xl font-serif tracking-tight leading-tight">{company.name}</h1>
+          <div className="flex items-center gap-2 mt-1.5 text-sm text-white/85">
+            <span>
+              {locationCount} {locationCount === 1 ? 'location' : 'locations'}
+            </span>
+            <span className="opacity-50">·</span>
+            <span>
+              {neighborhoodCount} {neighborhoodCount === 1 ? 'neighborhood' : 'neighborhoods'}
+            </span>
           </div>
         </div>
-        <p className="text-sm text-gray-600">{company.description}</p>
-        <LocationList coffeeShops={shopsGeoJSON.features} hideShopNames={true} />
+      </div>
+
+      <div className="px-6 lg:px-4 py-6 flex flex-col">
+        {(company.instagram_handle || company.website) && (
+          <div className="flex gap-2 mb-4">
+            {company.instagram_handle && (
+              <a
+                href={`https://www.instagram.com/${company.instagram_handle}/`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-gray-200 text-sm hover:bg-gray-100 transition-colors"
+              >
+                <Instagram className="h-4 w-4" />
+                Instagram
+              </a>
+            )}
+            {company.website && (
+              <a
+                href={company.website}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-gray-200 text-sm hover:bg-gray-100 transition-colors"
+              >
+                <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+                Website
+              </a>
+            )}
+          </div>
+        )}
+
+        {company.description && (
+          <p className="text-sm text-gray-600 leading-relaxed">{company.description}</p>
+        )}
+
+        <div className="mt-6">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-gray-500">Locations</h2>
+          {grouped.map(([neighborhood, shops]) => (
+            <div key={neighborhood}>
+              <div className="flex items-center gap-1.5 mt-4 text-gray-900">
+                <MapPinIcon className="h-4 w-4 text-gray-400" />
+                <h3 className="text-sm font-medium">{neighborhood}</h3>
+                <span className="text-xs text-gray-400">({shops.length})</span>
+              </div>
+              <LocationList coffeeShops={shops} hideShopNames={true} showAddresses={true} />
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/app/components/Company.tsx
+++ b/app/components/Company.tsx
@@ -5,6 +5,7 @@ import { Instagram } from 'lucide-react'
 import LocationList from '@/app/components/LocationList'
 import { useState, useEffect } from 'react'
 import useShopsStore from '@/stores/coffeeShopsStore'
+import { useAnalytics } from '@/hooks'
 import { formatDataToGeoJSON } from '../utils/utils'
 import { TCompany, TShop } from '@/types/shop-types'
 
@@ -26,6 +27,7 @@ const groupByNeighborhood = (features: TShop[]): [string, TShop[]][] => {
 
 export const Company = ({ slug }: { slug: string }) => {
   const { setOverrideShops, setSearchValue } = useShopsStore()
+  const plausible = useAnalytics()
   const [company, setCompany] = useState<TCompany | null>(null)
   const [loading, setLoading] = useState(true)
 
@@ -64,6 +66,7 @@ export const Company = ({ slug }: { slug: string }) => {
   }, [company, setOverrideShops])
 
   const handleNeighborhoodClick = (neighborhood: string) => {
+    plausible('NeighborhoodClick', { props: { neighborhood, company: company?.slug } })
     const url = new URL(window.location.href)
     url.searchParams.delete('company')
     url.searchParams.delete('shop')

--- a/app/components/Company.tsx
+++ b/app/components/Company.tsx
@@ -63,6 +63,15 @@ export const Company = ({ slug }: { slug: string }) => {
     return () => setOverrideShops(null)
   }, [company, setOverrideShops])
 
+  const handleNeighborhoodClick = (neighborhood: string) => {
+    const url = new URL(window.location.href)
+    url.searchParams.delete('company')
+    url.searchParams.delete('shop')
+    url.searchParams.set('neighborhood', neighborhood)
+    window.history.pushState(null, '', url.toString())
+    setSearchValue(neighborhood)
+  }
+
   if (loading) {
     return (
       <div className="flex h-full flex-col overflow-y-auto animate-pulse">
@@ -156,7 +165,7 @@ export const Company = ({ slug }: { slug: string }) => {
             <div key={neighborhood}>
               <button
                 type="button"
-                onClick={() => setSearchValue(neighborhood)}
+                onClick={() => handleNeighborhoodClick(neighborhood)}
                 aria-label={`Show all shops in ${neighborhood}`}
                 className="group flex items-center gap-1.5 mt-4 text-gray-900 hover:text-gray-950"
               >

--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -14,6 +14,7 @@ import usePanelStore from '@/stores/panelStore'
 import SearchFAB from './SearchFAB'
 import { useURLCompanySync } from '@/hooks/useURLCompanySync'
 import { useURLRoasterSync } from '@/hooks/useURLRoasterSync'
+import { useURLNeighborhoodSync } from '@/hooks/useURLNeighborhoodSync'
 
 export default function HomeClient() {
   const plausible = useAnalytics()
@@ -57,6 +58,7 @@ export default function HomeClient() {
   useURLRoasterSync()
   useURLNewsSync()
   useURLEventSync()
+  useURLNeighborhoodSync()
 
   useEffect(() => {
     if (!searchValue) return

--- a/app/components/LocationList.tsx
+++ b/app/components/LocationList.tsx
@@ -8,6 +8,7 @@ interface IProps {
   filter?: string
   units?: TUnits
   hideShopNames?: boolean
+  showAddresses?: boolean
 }
 
 export default function LocationList(props: IProps) {
@@ -30,6 +31,7 @@ export default function LocationList(props: IProps) {
               key={shop.properties.name + shop.properties.address}
               distance={props.distances?.[index] != null ? String(props.distances[index]) : undefined}
               hideShopName={props.hideShopNames}
+              showAddress={props.showAddresses}
               shop={shop}
               units={props.units}
             />

--- a/app/components/ShopCard.tsx
+++ b/app/components/ShopCard.tsx
@@ -8,6 +8,7 @@ interface IProps {
   distance?: string
   shop: TShop
   hideShopName?: boolean
+  showAddress?: boolean
   units?: TUnits
   onMouseEnter?: () => void
   onMouseLeave?: () => void
@@ -75,8 +76,8 @@ export default function ShopCard(props: IProps) {
         )}
         <div className="flex justify-between mt-1">
           <p className="w-fit text-sm mb-1 text-left text-white border border-transparent flex items-center gap-1">
-            <MapPinIcon className="h-4 w-4" />
-            {props.shop.properties.neighborhood}
+            <MapPinIcon className="h-4 w-4 shrink-0" />
+            {props.showAddress ? props.shop.properties.address : props.shop.properties.neighborhood}
           </p>
           {props.distance && props.units && (
             <p className="italic text-sm text-white">

--- a/hooks/useShopSelection.tsx
+++ b/hooks/useShopSelection.tsx
@@ -20,6 +20,7 @@ export function useShopSelection() {
       if (!isOnMap) {
         url.pathname = '/'
       }
+      params.delete('neighborhood')
       params.set('shop', `${shop.properties.name}_${shop.properties.neighborhood}`)
       url.search = params.toString()
       router.push(url.toString())

--- a/hooks/useURLNeighborhoodSync.tsx
+++ b/hooks/useURLNeighborhoodSync.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+import useCoffeeShopsStore from '@/stores/coffeeShopsStore'
+
+/**
+ * Keeps the search filter in sync with the `neighborhood` URL param.
+ * Setting a non-empty search value causes HomeClient to open the search panel.
+ */
+export const useURLNeighborhoodSync = () => {
+  const setSearchValue = useCoffeeShopsStore(s => s.setSearchValue)
+
+  const syncFromURL = () => {
+    const neighborhood = new URLSearchParams(window.location.search).get('neighborhood')
+    setSearchValue(neighborhood ?? '')
+  }
+
+  useEffect(() => {
+    syncFromURL()
+    window.addEventListener('popstate', syncFromURL)
+    return () => window.removeEventListener('popstate', syncFromURL)
+    // only run on mount
+    // eslint-disable-next-line
+  }, [])
+}

--- a/stores/panelStore.ts
+++ b/stores/panelStore.ts
@@ -11,7 +11,7 @@ type PanelEntry = {
   content: ReactNode
 }
 
-const URL_PARAMS = ['shop', 'company', 'roaster', 'news', 'event', 'events'] as const
+const URL_PARAMS = ['shop', 'company', 'roaster', 'news', 'event', 'events', 'neighborhood'] as const
 
 function hasProps<K extends string>(
   content: ReactNode,


### PR DESCRIPTION
Makes the company page (`?company=<slug>`) more visually engaging instead of the previous plain title + icon row + flat photo list.




| Before | After |
|--------|-------|
| <img width="562" height="876" alt="image" src="https://github.com/user-attachments/assets/1eb4a145-6761-458a-ab08-21317b1dd666" />    | <img width="563" height="867" alt="image" src="https://github.com/user-attachments/assets/3a5bb58f-c501-4660-a65b-780251171343" />   |