### PR TITLE
Run lint, build, and typecheck in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,4 @@
-name: Run unit tests
+name: CI
 
 on:
   push:
@@ -24,4 +24,17 @@ jobs:
         cache: 'npm'
     - name: Install dependencies
       run: npm install
-    - run: npm test
+    - name: Lint
+      run: npm run lint
+    - name: Build (typecheck + compile)
+      run: npm run build
+      env:
+        # Placeholder, non-functional values. Several API route modules build a
+        # Supabase client at import time; `next build` evaluates them during
+        # page-data collection and `createClient` throws if the URL is missing.
+        # The build never connects (all routes are request-time dynamic), so
+        # fake values suffice. Do NOT use a real key here.
+        SUPABASE_URL: https://placeholder.supabase.co
+        SUPABASE_ANON_KEY: placeholder-anon-key
+    - name: Test
+      run: npm test

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest"
   },
   "dependencies": {


### PR DESCRIPTION
## Why

CI previously ran only `npm test` — no typecheck, lint, or production build. Type errors, lint errors, and broken builds could merge to `main` and reach deploy without the test suite catching them.

`next build` already runs TypeScript checking and ESLint by default (`next.config.js` disables neither), so a single build step in CI closes the gap.

## Changes

- Add a `typecheck` script (`tsc --noEmit`) for local use.
- CI now runs **Lint → Build → Test** as ordered steps (workflow renamed to `CI`).

## Note on the build env

Several API route modules construct a Supabase client at import time (e.g. `app/api/companies/[company]/route.ts`), so `next build` throws `Error: supabaseUrl is required` during page-data collection when the env is unset. The Build step therefore sets **placeholder, non-functional** `SUPABASE_URL`/`SUPABASE_ANON_KEY` — the build never opens a connection (all routes are request-time dynamic), so fake values suffice. These are not secrets.

Follow-up worth considering (out of scope here): defer Supabase client construction into the handlers so the build needs no env at all.

## Verification

- `next build` (with placeholder env): exits 0, full route table.
- `vitest run`: 174 passed / 7 skipped.