### PR TITLE
Surface shop-load failures with a retry fallback

### DIFF
--- a/app/api/shops/geojson/route.ts
+++ b/app/api/shops/geojson/route.ts
@@ -16,7 +16,7 @@ const fetchShops = async () => {
     .order('name', { ascending: true })
   if (error) {
     logger.error('Error fetching shops', { error: error.message })
-    return []
+    return null
   }
   return data
 }
@@ -24,11 +24,10 @@ const fetchShops = async () => {
 
 export const GET = withMetrics('shops/geojson', async () => {
   const shops = await fetchShops()
-  const geojson = formatDataToGeoJSON(shops)
 
   if (!shops) {
-    return NextResponse.json({ error: 'Error creating GeoJSON' }, { status: 500 })
+    return NextResponse.json({ error: 'Error fetching shops' }, { status: 500 })
   }
 
-  return NextResponse.json(geojson)
+  return NextResponse.json(formatDataToGeoJSON(shops))
 })

--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -7,6 +7,7 @@ import { TShop } from '@/types/shop-types'
 import Panel from '@/app/components/Panel'
 import ShopSearch from './ShopSearch'
 import MapContainerLazy from './MapContainerLazy'
+import MapErrorFallback from './MapErrorFallback'
 import { ExploreContent } from './ExploreContent'
 import { useURLShopSync, useURLEventSync, useURLNewsSync, useMediaQuery } from '@/hooks'
 import useShopsStore from '@/stores/coffeeShopsStore'
@@ -18,8 +19,16 @@ import { useURLNeighborhoodSync } from '@/hooks/useURLNeighborhoodSync'
 
 export default function HomeClient() {
   const plausible = useAnalytics()
-  const { allShops, fetchCoffeeShops, currentShop, setCurrentShop, searchValue, setSearchValue, clearAmenityFilters } =
-    useShopsStore()
+  const {
+    allShops,
+    fetchCoffeeShops,
+    loadError,
+    currentShop,
+    setCurrentShop,
+    searchValue,
+    setSearchValue,
+    clearAmenityFilters,
+  } = useShopsStore()
   const { panelContent, clearHistory, panelMode, setPanelContent } = usePanelStore()
 
   const largeViewport = useMediaQuery('(min-width: 1024px)')
@@ -119,6 +128,9 @@ export default function HomeClient() {
       <MapContainerLazy
         currentShopCoordinates={[currentShop?.geometry?.coordinates[0], currentShop?.geometry?.coordinates[1]]}
       />
+      {loadError && allShops.features.length === 0 && (
+        <MapErrorFallback onRetry={() => fetchCoffeeShops()} />
+      )}
       <Panel shop={currentShop} presented={presented} onPresentedChange={setPresented}>
         {panelContent}
       </Panel>

--- a/app/components/MapErrorFallback.tsx
+++ b/app/components/MapErrorFallback.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+interface MapErrorFallbackProps {
+  onRetry: () => void
+}
+
+export default function MapErrorFallback({ onRetry }: MapErrorFallbackProps) {
+  return (
+    <div
+      role="alert"
+      className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-4 bg-[#191a1a] px-6 text-center text-white"
+    >
+      <p className="max-w-sm text-sm text-gray-300">
+        We couldn’t load the coffee shops right now. Please check your connection
+        and try again.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="rounded-md bg-yellow-300 px-4 py-2 text-sm font-semibold text-black hover:bg-yellow-200"
+      >
+        Try again
+      </button>
+    </div>
+  )
+}

--- a/stores/coffeeShopsStore.ts
+++ b/stores/coffeeShopsStore.ts
@@ -6,6 +6,7 @@ import { doesShopMatchFilter } from '@/app/utils/utils'
 
 interface CoffeeShopsState {
   allShops: TFeatureCollection
+  loadError: boolean
   fetchCoffeeShops: () => Promise<void>
   setAllShops: (data: TShop[]) => void
   currentShop: TShop
@@ -33,6 +34,8 @@ const useCoffeeShopsStore = create<CoffeeShopsState>()(
         features: [],
       },
 
+      loadError: false,
+
       setAllShops: (data: TShop[] | { type: string; features: TShop[] }) =>
         set(prev => {
           const isGeoJSON = typeof data === 'object' && 'type' in data && 'features' in data
@@ -54,10 +57,14 @@ const useCoffeeShopsStore = create<CoffeeShopsState>()(
         }
         try {
           const response = await fetch('/api/shops/geojson')
+          if (!response.ok) {
+            throw new Error(`Failed to load shops: ${response.status}`)
+          }
           const data: TFeatureCollection = await response.json()
-          set({ allShops: data })
+          set({ allShops: data, loadError: false })
         } catch (error) {
           console.error('Error fetching coffee shops:', error)
+          set({ loadError: true })
         }
       },
 

--- a/tests/unit/MapErrorFallback.test.tsx
+++ b/tests/unit/MapErrorFallback.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import MapErrorFallback from '@/app/components/MapErrorFallback'
+
+describe('MapErrorFallback', () => {
+  it('renders a retry button', () => {
+    render(<MapErrorFallback onRetry={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy()
+  })
+
+  it('calls onRetry once when the button is clicked', () => {
+    const onRetry = vi.fn()
+    render(<MapErrorFallback onRetry={onRetry} />)
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/coffeeShopsStore.test.ts
+++ b/tests/unit/coffeeShopsStore.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { act } from '@testing-library/react'
+import useCoffeeShopsStore from '@/stores/coffeeShopsStore'
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+const validFeatureCollection = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: { name: 'Test Shop', uuid: 'shop-1' },
+      geometry: { type: 'Point', coordinates: [-79.925, 40.4363] },
+    },
+  ],
+}
+
+describe('coffeeShopsStore - fetchCoffeeShops', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useCoffeeShopsStore.setState({
+      allShops: { type: 'FeatureCollection', features: [] },
+      loadError: false,
+    })
+  })
+
+  test('sets loadError on a non-ok response and leaves shops empty', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+
+    await act(async () => {
+      await useCoffeeShopsStore.getState().fetchCoffeeShops()
+    })
+
+    expect(useCoffeeShopsStore.getState().loadError).toBe(true)
+    expect(useCoffeeShopsStore.getState().allShops.features).toHaveLength(0)
+  })
+
+  test('loads shops and clears loadError on success', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => validFeatureCollection,
+    })
+
+    await act(async () => {
+      await useCoffeeShopsStore.getState().fetchCoffeeShops()
+    })
+
+    expect(useCoffeeShopsStore.getState().loadError).toBe(false)
+    expect(useCoffeeShopsStore.getState().allShops.features).toHaveLength(1)
+  })
+})

--- a/tests/unit/geojsonRoute.test.ts
+++ b/tests/unit/geojsonRoute.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
+
+const mockOrder = vi.fn()
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({ select: () => ({ order: mockOrder }) }),
+  }),
+}))
+
+describe('Shops GeoJSON API Route - GET', () => {
+  let GET: typeof import('@/app/api/shops/geojson/route').GET
+
+  beforeAll(async () => {
+    const module = await import('@/app/api/shops/geojson/route')
+    GET = module.GET
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns 500 on a Supabase error', async () => {
+    mockOrder.mockResolvedValueOnce({ data: null, error: { message: 'boom' } })
+
+    const response = await GET()
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data).toEqual({ error: 'Error fetching shops' })
+  })
+
+  test('returns a FeatureCollection on success', async () => {
+    mockOrder.mockResolvedValueOnce({
+      data: [
+        {
+          name: 'Test Shop',
+          neighborhood: 'Downtown',
+          address: '123 Main St',
+          website: 'https://example.com',
+          uuid: 'shop-1',
+          longitude: -79.925,
+          latitude: 40.4363,
+        },
+      ],
+      error: null,
+    })
+
+    const response = await GET()
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.type).toBe('FeatureCollection')
+    expect(data.features[0].properties.uuid).toBe('shop-1')
+    expect(data.features[0].geometry.coordinates).toEqual([-79.925, 40.4363])
+  })
+})


### PR DESCRIPTION
## Why

The map is the app's core interaction, but when the backend fails to return shops the user got a **blank map with no error and no recovery**. Two paths conspired:

- `app/api/shops/geojson/route.ts` swallowed Supabase errors — `fetchShops` returned `[]`, so the route replied `200` with an empty FeatureCollection. A DB failure was indistinguishable from "zero shops."
- `stores/coffeeShopsStore.ts` never checked `response.ok`, so even a `500` became a silently empty `allShops`.

## Changes

- **geojson route**: returns `500 { error: 'Error fetching shops' }` on a Supabase error instead of a 200 empty collection (also removes the prior dead `if (!shops)` branch).
- **store**: adds a `loadError` flag, checks `response.ok`, and sets `loadError` true on failure / false on success. The fetch-once cache guard is unchanged, so Retry re-fetches correctly after a failure.
- **`MapErrorFallback`**: a new overlay with a "Try again" button.
- **HomeClient**: renders the fallback only when `loadError && allShops.features.length === 0`.

## Tests (new)

- `geojsonRoute.test.ts` — 500 on DB error; 200 + correct feature shape on success.
- `coffeeShopsStore.test.ts` — `loadError` set on a non-ok response (shops stay empty); cleared on success.
- `MapErrorFallback.test.tsx` — renders the retry button; calls `onRetry` once on click.

Full suite: 180 passed / 7 skipped. Build: exit 0.

## Out of scope / follow-up

Does **not** handle the Mapbox-unsupported case (old browsers / in-app webviews where the canvas can't init) — `MapContainer` still doesn't check `mapboxgl.supported()`. That's a separate follow-up.