### PR TITLE
Add tests for untested API routes

### DIFF
--- a/tests/unit/companyRoute.test.ts
+++ b/tests/unit/companyRoute.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
+
+// The route makes two distinct queries:
+//   companies: select().eq().single()  -> terminal single
+//   shops:     select().eq()           -> terminal eq (awaited)
+const mockCompanySingle = vi.fn()
+const mockShopsEq = vi.fn()
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: (table: string) => ({
+      select: () => ({
+        eq: (...args: unknown[]) => {
+          if (table === 'companies') {
+            return { single: mockCompanySingle }
+          }
+          return mockShopsEq(...args)
+        },
+      }),
+    }),
+  }),
+}))
+
+describe('Company API Route - GET', () => {
+  let GET: typeof import('@/app/api/companies/[company]/route').GET
+
+  beforeAll(async () => {
+    GET = (await import('@/app/api/companies/[company]/route')).GET
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const call = (slug: string) =>
+    GET(new Request(`http://localhost/api/companies/${slug}`) as never, {
+      params: Promise.resolve({ company: slug }),
+    })
+
+  test('returns the company with its shops when found', async () => {
+    const company = { id: 'c1', name: 'Test Co', slug: 'test-co' }
+    const shops = [{ name: 'Shop A' }]
+    mockCompanySingle.mockResolvedValueOnce({ data: company, error: null })
+    mockShopsEq.mockResolvedValueOnce({ data: shops, error: null })
+
+    const response = await call('test-co')
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ ...company, shops })
+  })
+
+  test('returns 404 when the company is not found', async () => {
+    mockCompanySingle.mockResolvedValueOnce({ data: null, error: { message: 'No rows' } })
+
+    const response = await call('missing')
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data.message).toBe('Company not found')
+  })
+
+  test('returns 500 when the shops query errors', async () => {
+    const company = { id: 'c1', name: 'Test Co', slug: 'test-co' }
+    mockCompanySingle.mockResolvedValueOnce({ data: company, error: null })
+    mockShopsEq.mockResolvedValueOnce({ data: null, error: { message: 'boom' } })
+
+    const response = await call('test-co')
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Error fetching company shops')
+  })
+})

--- a/tests/unit/eventsCaptureRoute.test.ts
+++ b/tests/unit/eventsCaptureRoute.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect, beforeAll, vi } from 'vitest'
+
+// The auth gate returns before any capture helper runs; mock the module only so
+// the route imports cleanly without touching real Supabase/Anthropic.
+vi.mock('@/lib/capture', () => ({
+  getImageData: vi.fn(),
+  getShopCandidates: vi.fn(),
+  buildShopContext: vi.fn(),
+  validateShopUUID: vi.fn(),
+  callAnthropicVision: vi.fn(),
+  getRoasterID: vi.fn(),
+  supabase: { from: vi.fn() },
+}))
+
+describe('Events Capture API Route - POST auth gate', () => {
+  let POST: typeof import('@/app/api/events/capture/route').POST
+
+  beforeAll(async () => {
+    POST = (await import('@/app/api/events/capture/route')).POST
+  })
+
+  test('returns 401 when x-capture-secret header is missing', async () => {
+    const request = new Request('http://localhost/api/events/capture', { method: 'POST' })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(data.error).toBe('Unauthorized')
+  })
+})

--- a/tests/unit/roasterRoute.test.ts
+++ b/tests/unit/roasterRoute.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
+
+const mockSingleResult = vi.fn()
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: mockSingleResult,
+        }),
+      }),
+    }),
+  }),
+}))
+
+describe('Roaster API Route - GET', () => {
+  let GET: typeof import('@/app/api/roasters/[slug]/route').GET
+
+  beforeAll(async () => {
+    GET = (await import('@/app/api/roasters/[slug]/route')).GET
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const call = (slug: string) =>
+    GET(new Request(`http://localhost/api/roasters/${slug}`) as never, {
+      params: Promise.resolve({ slug }),
+    })
+
+  test('returns the roaster when found', async () => {
+    const roaster = { id: 'r1', name: 'Test Roaster', slug: 'test-roaster' }
+    mockSingleResult.mockResolvedValueOnce({ data: roaster, error: null })
+
+    const response = await call('test-roaster')
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(roaster)
+  })
+
+  test('returns 404 when the roaster is not found', async () => {
+    mockSingleResult.mockResolvedValueOnce({ data: null, error: { message: 'No rows' } })
+
+    const response = await call('missing')
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data.message).toBe('Roaster not found')
+  })
+})

--- a/tests/unit/shopsRoute.test.ts
+++ b/tests/unit/shopsRoute.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
+
+// `order(...)` is the terminal call when no neighborhood filter is applied.
+// When a neighborhood is supplied the route chains `.eq(...)` after `.order(...)`,
+// so `order` returns an object that is both awaitable and exposes `eq`.
+const mockOrderResult = vi.fn()
+const mockEqResult = vi.fn()
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        // `order` is awaited directly when no filter is applied, and also exposes
+        // `.eq` for the filtered path. Make it both thenable and chainable.
+        order: () => ({
+          eq: mockEqResult,
+          then: (...args: unknown[]) =>
+            (mockOrderResult() as Promise<unknown>).then(...(args as [never, never])),
+        }),
+      }),
+    }),
+  }),
+}))
+
+describe('Shops API Route - GET', () => {
+  let GET: typeof import('@/app/api/shops/route').GET
+
+  beforeAll(async () => {
+    GET = (await import('@/app/api/shops/route')).GET
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns shops on success', async () => {
+    const shops = [{ name: 'Test Shop', neighborhood: 'Downtown' }]
+    mockOrderResult.mockResolvedValueOnce({ data: shops, error: null })
+
+    const response = await GET(new Request('http://localhost/api/shops'))
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(shops)
+  })
+
+  test('applies neighborhood filter when query param is present', async () => {
+    const shops = [{ name: 'Filtered Shop', neighborhood: 'Lawrenceville' }]
+    mockEqResult.mockResolvedValueOnce({ data: shops, error: null })
+
+    const response = await GET(new Request('http://localhost/api/shops?neighborhood=Lawrenceville'))
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(shops)
+    expect(mockEqResult).toHaveBeenCalledWith('neighborhood', 'Lawrenceville')
+  })
+
+  test('returns 500 on database error', async () => {
+    mockOrderResult.mockResolvedValueOnce({ data: null, error: { message: 'boom' } })
+
+    const response = await GET(new Request('http://localhost/api/shops'))
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Error fetching shops')
+  })
+})

--- a/tests/unit/submitRoute.test.ts
+++ b/tests/unit/submitRoute.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
+
+const mockInsert = vi.fn()
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      insert: mockInsert,
+    }),
+  }),
+}))
+
+describe('Shops Submit API Route - POST', () => {
+  let POST: typeof import('@/app/api/shops/submit/route').POST
+
+  beforeAll(async () => {
+    POST = (await import('@/app/api/shops/submit/route')).POST
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const makeRequest = (body: unknown) =>
+    new Request('http://localhost/api/shops/submit', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    })
+
+  test('returns 400 when name is missing', async () => {
+    const response = await POST(makeRequest({ address: '123 Main St' }))
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Missing required fields')
+    expect(mockInsert).not.toHaveBeenCalled()
+  })
+
+  test('returns 400 when address is missing', async () => {
+    const response = await POST(makeRequest({ name: 'Test Shop' }))
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Missing required fields')
+    expect(mockInsert).not.toHaveBeenCalled()
+  })
+
+  test('returns 201 with inserted data on success', async () => {
+    const inserted = [{ name: 'Test Shop', address: '123 Main St' }]
+    mockInsert.mockResolvedValueOnce({ data: inserted, error: null })
+
+    const response = await POST(
+      makeRequest({ name: 'Test Shop', address: '123 Main St', neighborhood: 'Downtown', website: 'https://x.com' }),
+    )
+    const data = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(data).toEqual(inserted)
+    expect(mockInsert).toHaveBeenCalledWith([
+      { name: 'Test Shop', address: '123 Main St', neighborhood: 'Downtown', website: 'https://x.com' },
+    ])
+  })
+
+  test('returns 500 when insert fails', async () => {
+    mockInsert.mockResolvedValueOnce({ data: null, error: { message: 'boom' } })
+
+    const response = await POST(makeRequest({ name: 'Test Shop', address: '123 Main St' }))
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Error adding shop')
+  })
+})

--- a/tests/unit/updateByIdRoute.test.ts
+++ b/tests/unit/updateByIdRoute.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
+
+const mockSingleResult = vi.fn()
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: mockSingleResult,
+        }),
+      }),
+    }),
+  }),
+}))
+
+describe('Update By Id API Route - GET', () => {
+  let GET: typeof import('@/app/api/updates/[id]/route').GET
+
+  beforeAll(async () => {
+    GET = (await import('@/app/api/updates/[id]/route')).GET
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const call = (id: string) =>
+    GET(new Request(`http://localhost/api/updates/${id}`) as never, {
+      params: Promise.resolve({ id }),
+    })
+
+  test('returns the update when found', async () => {
+    const update = { id: 'u1', body: 'New hours' }
+    mockSingleResult.mockResolvedValueOnce({ data: update, error: null })
+
+    const response = await call('u1')
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(update)
+  })
+
+  test('returns 404 when the update is not found', async () => {
+    mockSingleResult.mockResolvedValueOnce({ data: null, error: { message: 'No rows' } })
+
+    const response = await call('missing')
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data.error).toBe('Update not found')
+  })
+})

--- a/tests/unit/updatesCaptureRoute.test.ts
+++ b/tests/unit/updatesCaptureRoute.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect, beforeAll, vi } from 'vitest'
+
+// The auth gate returns before any capture helper runs; mock the module only so
+// the route imports cleanly without touching real Supabase/Anthropic.
+vi.mock('@/lib/capture', () => ({
+  getImageData: vi.fn(),
+  getShopCandidates: vi.fn(),
+  buildShopContext: vi.fn(),
+  validateShopUUID: vi.fn(),
+  callAnthropicVision: vi.fn(),
+  getRoasterID: vi.fn(),
+  supabase: { from: vi.fn() },
+}))
+
+describe('Updates Capture API Route - POST auth gate', () => {
+  let POST: typeof import('@/app/api/updates/capture/route').POST
+
+  beforeAll(async () => {
+    POST = (await import('@/app/api/updates/capture/route')).POST
+  })
+
+  test('returns 401 when x-capture-secret header is missing', async () => {
+    const request = new Request('http://localhost/api/updates/capture', { method: 'POST' })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(data.error).toBe('Unauthorized')
+  })
+})

--- a/tests/unit/updatesRoute.test.ts
+++ b/tests/unit/updatesRoute.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
+
+// `order(...)` is terminal when no shop_id filter is applied; with a shop_id the
+// route chains `.eq('shop_id', ...)` after `.order(...)`.
+const mockOrderResult = vi.fn()
+const mockEqResult = vi.fn()
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        // `order` is awaited directly when no filter is applied, and also exposes
+        // `.eq` for the filtered path. Make it both thenable and chainable.
+        order: () => ({
+          eq: mockEqResult,
+          then: (...args: unknown[]) =>
+            (mockOrderResult() as Promise<unknown>).then(...(args as [never, never])),
+        }),
+      }),
+    }),
+  }),
+}))
+
+describe('Updates API Route - GET', () => {
+  let GET: typeof import('@/app/api/updates/route').GET
+
+  beforeAll(async () => {
+    GET = (await import('@/app/api/updates/route')).GET
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns updates on success', async () => {
+    const updates = [{ id: 'u1', body: 'New hours' }]
+    mockOrderResult.mockResolvedValueOnce({ data: updates, error: null })
+
+    const response = await GET(new Request('http://localhost/api/updates'))
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(updates)
+  })
+
+  test('filters by shop_id when query param is present', async () => {
+    const updates = [{ id: 'u2', shop_id: 'shop-1' }]
+    mockEqResult.mockResolvedValueOnce({ data: updates, error: null })
+
+    const response = await GET(new Request('http://localhost/api/updates?shop_id=shop-1'))
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(updates)
+    expect(mockEqResult).toHaveBeenCalledWith('shop_id', 'shop-1')
+  })
+
+  test('returns 500 on database error', async () => {
+    mockOrderResult.mockResolvedValueOnce({ data: null, error: { message: 'boom' } })
+
+    const response = await GET(new Request('http://localhost/api/updates'))
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Error fetching updates')
+  })
+})


### PR DESCRIPTION
## Why

13 of 21 `app/api/**` route handlers had no tests, including core data and write paths (shop submission, shops list, company/roaster detail, the updates feed). A regression — missing-field handling, a broken query, a wrong status code — could ship silently. The CI build gate (#267) catches type/build breakage but not behavioral regressions; these tests close that.

## Coverage (8 new files, 19 tests, no source changes)

| Route | Cases |
|---|---|
| `shops/submit` (POST) | 400 missing-field (no insert), 201 success, 500 insert error |
| `shops` (GET) | 200, neighborhood filter (asserts `.eq`), 500 |
| `updates` (GET) | 200, `shop_id` filter, 500 |
| `companies/[company]` (GET) | 200 (company + merged shops), 404, 500 |
| `roasters/[slug]` (GET) | 200, 404 |
| `updates/[id]` (GET) | 200, 404 |
| `events/capture`, `updates/capture` (POST) | 401 auth-gate (missing `x-capture-secret`) |

Each test asserts an externally observable contract (status code + response body) rather than restating implementation, following the existing `tests/unit/*Route*.test.ts` pattern (mock `@supabase/supabase-js`, exercise the real route code).

The tests document a few real per-route quirks: `companies`/`roasters` 404s use a `message` key while `updates/[id]` uses `error`; `roasters/[slug]` has no distinct 500 branch (a query error becomes a 404). Asserted as-is — no route behavior was changed.

## Out of scope

- `app/api/shops/geojson/route.ts` — covered by a separate change (#268).
- Capture routes' full happy path (needs `@/lib/capture` mocking) — only the auth gate is tested here.

Full suite: 193 passed / 7 skipped.