### PR TITLE
Clear stale company param when selecting a shop

### DIFF
--- a/hooks/useShopSelection.tsx
+++ b/hooks/useShopSelection.tsx
@@ -21,6 +21,13 @@ export function useShopSelection() {
         url.pathname = '/'
       }
       params.delete('neighborhood')
+      // Selecting a shop replaces any other content selection (e.g. a company
+      // drill-down), so clear the mutually-exclusive params first.
+      params.delete('company')
+      params.delete('roaster')
+      params.delete('news')
+      params.delete('event')
+      params.delete('events')
       params.set('shop', `${shop.properties.name}_${shop.properties.neighborhood}`)
       url.search = params.toString()
       router.push(url.toString())

--- a/tests/unit/useShopSelection.test.tsx
+++ b/tests/unit/useShopSelection.test.tsx
@@ -132,4 +132,17 @@ describe('useShopSelection', () => {
     expect(mockSetSearchValue).toHaveBeenCalledWith('')
     expect(mockClearAmenityFilters).toHaveBeenCalled()
   })
+
+  test('handleShopSelect replaces a lingering company param with the shop param', () => {
+    mockLocation.href = 'https://example.com/?company=some-roasting-co'
+    const { result } = renderHook(() => useShopSelection())
+
+    act(() => {
+      result.current.handleShopSelect(mockShop)
+    })
+
+    const pushedUrl = new URL(mockPush.mock.calls[0][0])
+    expect(pushedUrl.searchParams.has('company')).toBe(false)
+    expect(pushedUrl.searchParams.get('shop')).toBe('Test Coffee Shop_Downtown')
+  })
 })


### PR DESCRIPTION
## Problem

Drilling into a company (`?company=foo`) and then clicking one of its shops left the URL as `?company=foo&shop=bar`. Selecting a shop should fully replace any other content selection.

## Cause

`appendSearchParamToURL` in `hooks/useShopSelection.tsx` set `?shop=` and deleted `neighborhood`, but never removed the mutually-exclusive content params (`company`, `roaster`, `news`, `event`, `events`).

## Change

Delete those params before setting `shop`, mirroring the cleanup already done in `HomeClient`'s `removeSearchParam`. Added a regression test asserting a lingering `?company=` is dropped when a shop is selected.