### PR TITLE
Stop shared-CDN caching of query-varying read endpoints

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
-import { publicCacheHeaders, TIME_SENSITIVE_TTL } from '@/lib/cacheHeaders'
 
 // Supabase configuration
 const supabaseUrl = process.env.SUPABASE_URL as string
@@ -45,5 +44,8 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Error fetching events' }, { status: 500 })
   }
 
-  return NextResponse.json(events, { headers: publicCacheHeaders(TIME_SENSITIVE_TTL) })
+  // No shared-CDN cache: this response varies by the shop_id/roaster_id query
+  // string, but the CDN keys its cache on the path alone, so a cached copy
+  // would be served across different filters (every shop showing every event).
+  return NextResponse.json(events)
 }

--- a/app/api/shops/batch/route.ts
+++ b/app/api/shops/batch/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { formatDataToGeoJSON } from '../../../utils/utils'
 import { logger } from '@/lib/logger'
-import { publicCacheHeaders, SHOP_DATA_TTL } from '@/lib/cacheHeaders'
 
 // Supabase configuration
 const supabaseUrl = process.env.SUPABASE_URL as string
@@ -38,7 +37,7 @@ export async function GET(request: Request) {
   const ids = idsParam.split(',').map(id => id.trim()).filter(id => id.length > 0)
 
   if (ids.length === 0) {
-    return NextResponse.json(formatDataToGeoJSON([]), { headers: publicCacheHeaders(SHOP_DATA_TTL) })
+    return NextResponse.json(formatDataToGeoJSON([]))
   }
 
   const shops = await fetchShopsByIds(ids)
@@ -50,6 +49,9 @@ export async function GET(request: Request) {
     )
   }
 
+  // No shared-CDN cache: this response varies by the `ids` query string, but the
+  // CDN keys its cache on the path alone, so a cached copy would be served for
+  // different id sets, returning the wrong shops.
   const geojson = formatDataToGeoJSON(shops)
-  return NextResponse.json(geojson, { headers: publicCacheHeaders(SHOP_DATA_TTL) })
+  return NextResponse.json(geojson)
 }

--- a/app/api/updates/route.ts
+++ b/app/api/updates/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
-import { publicCacheHeaders, TIME_SENSITIVE_TTL } from '@/lib/cacheHeaders'
 
 const supabaseUrl = process.env.SUPABASE_URL as string
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
@@ -36,5 +35,8 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Error fetching updates' }, { status: 500 })
   }
 
-  return NextResponse.json(updates, { headers: publicCacheHeaders(TIME_SENSITIVE_TTL) })
+  // No shared-CDN cache: this response varies by the shop_id query string, but
+  // the CDN keys its cache on the path alone, so a cached copy would be served
+  // across different shops (every shop showing every update).
+  return NextResponse.json(updates)
 }

--- a/tests/unit/cdnCacheInvariant.test.ts
+++ b/tests/unit/cdnCacheInvariant.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'fs'
+import { join } from 'path'
+
+// Guards against the bug fixed alongside this test: an endpoint whose response
+// body varies by query string must NOT carry a shared-CDN cache header. The CDN
+// keys its cache on the path alone, so caching `/api/events` would serve one
+// shop's (or the unfiltered) event list for every `?shop_id=` request.
+//
+// "Varies by query string" is detected as reading `searchParams`; "shared-CDN
+// cache" as using `publicCacheHeaders` / emitting `s-maxage`. Path-param routes
+// (e.g. `/api/roasters/[slug]`) and no-param list routes stay cacheable because
+// their bodies don't depend on the query string.
+
+const API_DIR = join(process.cwd(), 'app', 'api')
+
+const routeFiles = (dir: string): string[] =>
+  readdirSync(dir).flatMap(entry => {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) return routeFiles(full)
+    return /^route\.tsx?$/.test(entry) ? [full] : []
+  })
+
+const variesByQuery = (src: string) => src.includes('searchParams')
+const isSharedCached = (src: string) => /publicCacheHeaders|s-maxage/.test(src)
+
+describe('CDN cache safety invariant', () => {
+  test('no API route both varies by query string and sets a shared-CDN cache header', () => {
+    const offenders = routeFiles(API_DIR).filter(file => {
+      const src = readFileSync(file, 'utf8')
+      return variesByQuery(src) && isSharedCached(src)
+    })
+
+    expect(
+      offenders,
+      `These routes vary their body by the query string but emit a shared-CDN cache ` +
+        `header. The CDN keys on path only, so cached responses leak across query ` +
+        `values. Remove the shared-cache header (or move the filter into the path):\n` +
+        offenders.map(f => `  - ${f.replace(process.cwd() + '/', '')}`).join('\n'),
+    ).toEqual([])
+  })
+})

--- a/tests/unit/eventsRoute.test.ts
+++ b/tests/unit/eventsRoute.test.ts
@@ -44,8 +44,9 @@ describe('Events API Route - GET', () => {
 
     expect(response.status).toBe(200)
     expect(data).toEqual(mockEvents)
-    // Successful event responses are safe for the shared CDN to cache.
-    expect(response.headers.get('Cache-Control')).toContain('s-maxage=60')
+    // This endpoint's body varies by the shop_id/roaster_id query string, which
+    // the CDN does not include in its cache key, so it must not be shared-cached.
+    expect(response.headers.get('Cache-Control') ?? '').not.toContain('s-maxage=')
     expect(mockEq).toHaveBeenCalledWith('is_hidden', false)
     expect(mockEq).not.toHaveBeenCalledWith('shop_id', expect.anything())
     expect(mockEq).not.toHaveBeenCalledWith('roaster_id', expect.anything())

--- a/tests/unit/updatesRoute.test.ts
+++ b/tests/unit/updatesRoute.test.ts
@@ -53,6 +53,9 @@ describe('Updates API Route - GET', () => {
     expect(response.status).toBe(200)
     expect(data).toEqual(updates)
     expect(mockEqResult).toHaveBeenCalledWith('shop_id', 'shop-1')
+    // The body varies by shop_id, so it must not be cached on the shared CDN
+    // (which keys on path only) — otherwise one shop's updates leak to all.
+    expect(response.headers.get('Cache-Control') ?? '').not.toContain('s-maxage=')
   })
 
   test('returns 500 on database error', async () => {


### PR DESCRIPTION
## The bug
Every shop's detail panel showed *every* event (and update), regardless of which shop.

## Root cause
#258 added a shared-CDN `s-maxage` cache to `/api/events`, `/api/updates`, and `/api/shops/batch`, copying the `/api/featured-shop` pattern. But unlike `featured-shop` (which takes no params), these endpoints' response bodies vary by query string — `shop_id`, `roaster_id`, `ids`. The CDN keys its cache on the **path only**, so the unfiltered `/api/events` body (all events, fetched on page load) got cached and then served for every `/api/events?shop_id=X` request.

The route *logic* was always correct (verified: `?shop_id=X` returns only that shop's events); only the cache layer was wrong. Because #258 predates the `7a770fc` rollback point, rolling back didn't remove it.

## Fix
Drop the shared-cache header from the three query-varying endpoints (back to uncached, as before #258). Path-keyed / no-param endpoints (`geojson`, `featured-shop`, `companies/[…]`, `roasters/[…]`, `curated-lists`) keep their caching.

## Follow-up (optional)
To recover CDN caching for these safely, serve the filtered variants from distinct paths (e.g. `/api/shops/[id]/events`) so the CDN cache key differs. See https://github.com/Johngeorgesample/pgh-coffee/issues/277

Full suite passes (241), lint clean.