### PR TITLE
Fix dead roaster link from news detail

### DIFF
--- a/app/components/NewsDetails.tsx
+++ b/app/components/NewsDetails.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { Calendar, SquareArrowOutUpRight, MapPin, Share2 } from 'lucide-react'
 import { useShopSelection, useCopyToClipboard, useAnalytics } from '@/hooks'
 import { formatDBShopAsFeature } from '@/app/utils/utils'
@@ -22,6 +23,7 @@ export const NewsDetails = ({ id }: { id: string; title?: string }) => {
   const [loading, setLoading] = useState(true)
   const { showToast, copyCurrentUrl, closeToast } = useCopyToClipboard()
   const plausible = useAnalytics()
+  const router = useRouter()
   const { handleShopSelect } = useShopSelection()
 
   useEffect(() => {
@@ -54,14 +56,7 @@ export const NewsDetails = ({ id }: { id: string; title?: string }) => {
     plausible('NewsDetailsRoasterClick', {
       props: { newsId: news.id, newsTitle: news.title, roasterSlug: news.roaster.slug },
     })
-    const url = new URL(window.location.href)
-    // Leaving the /news/{slug} page back to the map for the roaster overlay.
-    url.pathname = '/'
-    const params = new URLSearchParams()
-    params.set('roaster', news.roaster.slug)
-    url.search = params.toString()
-    window.history.pushState(null, '', url.toString())
-    window.dispatchEvent(new PopStateEvent('popstate'))
+    router.push(`/roasters/${encodeURIComponent(news.roaster.slug)}`)
   }
 
   const handleExternalLink = () => {

--- a/tests/unit/NewsDetails.test.tsx
+++ b/tests/unit/NewsDetails.test.tsx
@@ -1,0 +1,44 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { NewsDetails } from '@/app/components/NewsDetails'
+import type { NewsItem } from '@/types/news-types'
+
+const pushMock = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}))
+
+vi.mock('@/hooks', () => ({
+  useShopSelection: () => ({ handleShopSelect: vi.fn() }),
+  useCopyToClipboard: () => ({ showToast: false, copyCurrentUrl: vi.fn(), closeToast: vi.fn() }),
+  useAnalytics: () => vi.fn(),
+}))
+
+const newsWithRoaster = {
+  id: 'news-1',
+  title: 'Commonplace adds a new single origin',
+  roaster: { name: 'Commonplace Coffee', slug: 'commonplace-coffee' },
+} as NewsItem
+
+describe('NewsDetails roaster link', () => {
+  beforeEach(() => {
+    pushMock.mockClear()
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => newsWithRoaster,
+    }) as unknown as typeof fetch
+  })
+
+  test('clicking the roaster navigates to its /roasters/{slug} page', async () => {
+    render(<NewsDetails id="news-1" />)
+
+    // Wait for the fetched news (and its roaster) to render.
+    const roasterButton = await screen.findByRole('button', { name: /Commonplace Coffee/ })
+    fireEvent.click(roasterButton)
+
+    // The /roasters/{slug} route is what useRoasterRouteSync listens for; the
+    // old ?roaster= query param this replaced went unhandled.
+    expect(pushMock).toHaveBeenCalledWith('/roasters/commonplace-coffee')
+  })
+})


### PR DESCRIPTION
## Bug
Clicking the roaster on a news detail page (`/news/{slug}`) did nothing.

## Cause
`NewsDetails.handleRoasterClick` navigated via the legacy `?roaster=` query param. #273 moved roasters to `/roasters/{slug}` and removed the `?roaster=` handler (`useURLRoasterSync` → `useRoasterRouteSync`), so the pushed URL had no listener. `EventDetails` was migrated to `router.push('/roasters/{slug}')`; `NewsDetails` was the missed straggler (verified it's the last one using a legacy param).

## Fix
Navigate with `router.push('/roasters/{slug}')`, matching `EventDetails`. `useRoasterRouteSync` then opens the roaster panel.

Build passes, lint clean.