### PR TITLE
Restyle roaster details page to match company page

### DIFF
--- a/app/components/RoasterDetails.tsx
+++ b/app/components/RoasterDetails.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
-import { Instagram } from 'lucide-react'
+import { Flame, Instagram } from 'lucide-react'
+import Link from 'next/link'
 import { useState, useEffect } from 'react'
 import { useAnalytics } from '@/hooks'
 
@@ -43,17 +44,17 @@ export const RoasterDetails = ({ slug }: { slug: string }) => {
 
   if (loading) {
     return (
-      <div className="px-6 lg:px-4 mt-24 lg:mt-16 flex flex-col animate-pulse">
-        <div className="flex items-center justify-between mb-2">
-          <div className="h-8 bg-gray-200 rounded w-48"></div>
-          <div className="flex gap-2">
-            <div className="h-4 w-4 bg-gray-200 rounded"></div>
-            <div className="h-4 w-4 bg-gray-200 rounded"></div>
+      <div className="flex h-full flex-col overflow-y-auto animate-pulse">
+        <div className="h-56 sm:h-64 bg-gray-200 shrink-0" />
+        <div className="px-6 lg:px-4 py-6 flex flex-col">
+          <div className="flex gap-2 mb-4">
+            <div className="h-8 w-24 bg-gray-200 rounded-full" />
+            <div className="h-8 w-24 bg-gray-200 rounded-full" />
           </div>
-        </div>
-        <div className="space-y-2 mb-4">
-          <div className="h-4 bg-gray-200 rounded w-full"></div>
-          <div className="h-4 bg-gray-200 rounded w-3/4"></div>
+          <div className="space-y-2">
+            <div className="h-4 bg-gray-200 rounded w-full" />
+            <div className="h-4 bg-gray-200 rounded w-3/4" />
+          </div>
         </div>
       </div>
     )
@@ -63,21 +64,37 @@ export const RoasterDetails = ({ slug }: { slug: string }) => {
 
   return (
     <div className="flex h-full flex-col overflow-y-auto">
-      <div className="px-6 lg:px-4 mt-20 lg:mt-16 flex flex-col">
+      <div className="h-56 sm:h-64 relative bg-gradient-to-br from-stone-700 to-stone-900 shrink-0">
         {roaster.logo && (
-          <div className="mb-4">
+          <div className="absolute inset-0 flex items-center justify-center p-6">
             <img
               src={roaster.logo}
               alt={`${roaster.name} logo`}
-              className="h-24 w-24 object-contain"
+              className="max-h-28 max-w-[60%] object-contain rounded-2xl bg-white p-4 shadow-lg"
             />
           </div>
         )}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/40 to-transparent" />
+        <div className="absolute bottom-0 left-0 right-0 p-4 sm:p-6 text-white">
+          <span className="inline-flex items-center gap-1.5 bg-yellow-300 text-gray-950 px-2.5 py-1 rounded-full text-xs font-semibold mb-3">
+            <Flame className="w-3.5 h-3.5" />
+            Coffee roaster
+          </span>
+          <h1 className="text-3xl sm:text-4xl font-serif tracking-tight leading-tight">{roaster.name}</h1>
+          {roaster.company && (
+            <div className="mt-1.5 text-sm text-white/85">
+              Part of{' '}
+              <Link href={`/companies/${roaster.company.slug}`} className="font-medium hover:underline">
+                {roaster.company.name}
+              </Link>
+            </div>
+          )}
+        </div>
+      </div>
 
-        <div className="flex items-center justify-between mb-2">
-          <h2 className="font-medium text-2xl">{roaster.name}</h2>
-
-          <div className="flex gap-2">
+      <div className="px-6 lg:px-4 py-6 flex flex-col">
+        {(roaster.instagram || roaster.website) && (
+          <div className="flex gap-2 mb-4">
             {roaster.instagram && (
               <a
                 href={`https://www.instagram.com/${roaster.instagram}/`}
@@ -88,8 +105,10 @@ export const RoasterDetails = ({ slug }: { slug: string }) => {
                     props: { roasterName: roaster.name, roasterSlug: roaster.slug },
                   })
                 }
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-gray-200 text-sm hover:bg-gray-100 transition-colors"
               >
                 <Instagram className="h-4 w-4" />
+                Instagram
               </a>
             )}
             {roaster.website && (
@@ -102,23 +121,17 @@ export const RoasterDetails = ({ slug }: { slug: string }) => {
                     props: { roasterName: roaster.name, roasterSlug: roaster.slug },
                   })
                 }
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-gray-200 text-sm hover:bg-gray-100 transition-colors"
               >
                 <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+                Website
               </a>
             )}
           </div>
-        </div>
-
-        {roaster.description && (
-          <p className="text-sm text-gray-600 mb-4">{roaster.description}</p>
         )}
 
-        {roaster.company && (
-          <div className="mt-4 pt-4 border-t border-gray-200">
-            <p className="text-sm text-gray-500">
-              Part of <span className="font-medium">{roaster.company.name}</span>
-            </p>
-          </div>
+        {roaster.description && (
+          <p className="text-sm text-gray-600 leading-relaxed">{roaster.description}</p>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
Brings the roaster details panel in line with the company page's aesthetic. Previously the roaster page was a plain logo-and-text layout while the company page had a polished hero treatment.

| Before | After |
|--------|-------|
| <img width="1101" height="1293" alt="image" src="https://github.com/user-attachments/assets/abecad58-6343-4113-b784-7ec0100133be" />    | <img width="1076" height="1287" alt="image" src="https://github.com/user-attachments/assets/27e0db38-c452-47ab-ab2d-6b63aec1e267" />   |