### PR TITLE
Restyle shop actions bar with a primary Directions button

### DIFF
--- a/app/components/DirectionsButton.tsx
+++ b/app/components/DirectionsButton.tsx
@@ -16,7 +16,7 @@ export default function DirectionsButton({ coordinates }: DirectionsButtonProps)
       })}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex items-center gap-1.5 bg-white hover:bg-stone-50 text-stone-800 px-4 py-2.5 rounded-3xl text-sm font-medium border border-stone-200 transition-colors"
+      className="inline-flex flex-1 items-center justify-center gap-1.5 bg-gray-950 hover:bg-gray-800 text-white px-4 py-2.5 rounded-full text-sm font-semibold transition-colors"
     >
       <MapPin className="h-4 w-4" />
       Directions

--- a/app/components/FavoriteButton.tsx
+++ b/app/components/FavoriteButton.tsx
@@ -88,10 +88,12 @@ export default function FavoriteButton({ shopUUID, shopName }: FavoriteButtonPro
       <button
         onClick={handleToggle}
         disabled={isLoading}
-        className="inline-flex items-center gap-1.5 bg-white hover:bg-stone-50 text-stone-800 px-4 py-2.5 rounded-3xl text-sm font-medium border border-stone-200 transition-colors disabled:opacity-50"
+        aria-label={isFavorited ? 'Favorited' : 'Favorite'}
+        aria-pressed={isFavorited}
+        title={isFavorited ? 'Favorited' : 'Favorite'}
+        className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-200 bg-white text-stone-700 hover:bg-stone-100 transition-colors disabled:opacity-50"
       >
-        <Heart className={`w-4 h-4 transition-colors ${isFavorited ? 'fill-red-500 text-red-500' : ''}`} />
-        {isFavorited ? 'Favorited' : 'Favorite'}
+        <Heart className={`size-[18px] transition-colors ${isFavorited ? 'fill-red-500 text-red-500' : ''}`} />
       </button>
 
       <FavoriteToast isOpen={showToast} onClose={() => setShowToast(false)} shopName={shopName} />

--- a/app/components/QuickActionsBar.tsx
+++ b/app/components/QuickActionsBar.tsx
@@ -32,10 +32,10 @@ export default function QuickActionsBar({ shop }: QuickActionsBarProps) {
 
   return (
     <>
-      <div ref={scrollRef} className="flex gap-2 px-4 sm:px-6 py-4 bg-white border-b border-stone-200 overflow-x-auto [&>button]:shrink-0">
+      <div ref={scrollRef} className="flex items-center gap-2 px-4 sm:px-6 py-4 bg-white border-b border-stone-200">
+        <DirectionsButton coordinates={coordinates} />
         <FavoriteButton shopUUID={uuid} shopName={name} />
         <ShareButton />
-        <DirectionsButton coordinates={coordinates} />
         {website && <WebsiteButton website={website} />}
         <ReportIssueButton onClick={() => setShowIssueModal(true)} />
       </div>

--- a/app/components/ReportIssueButton.tsx
+++ b/app/components/ReportIssueButton.tsx
@@ -9,10 +9,11 @@ export default function ReportIssueButton({ onClick }: ReportIssueButtonProps) {
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-1.5 bg-white hover:bg-stone-50 text-stone-800 px-4 py-2.5 rounded-3xl text-sm font-medium border border-stone-200 transition-colors"
+      aria-label="Report an issue"
+      title="Report an issue"
+      className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-200 bg-white text-stone-700 hover:bg-stone-100 transition-colors"
     >
-      <Flag className="size-4" />
-      Report
+      <Flag className="size-[18px]" />
     </button>
   )
 }

--- a/app/components/ShareButton.tsx
+++ b/app/components/ShareButton.tsx
@@ -12,10 +12,11 @@ export default function ShareButton() {
       <button
         type="button"
         onClick={copyCurrentUrl}
-        className="inline-flex items-center gap-1.5 bg-white hover:bg-stone-50 text-stone-800 px-4 py-2.5 rounded-3xl text-sm font-medium border border-stone-200 transition-colors"
+        aria-label="Share"
+        title="Share"
+        className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-200 bg-white text-stone-700 hover:bg-stone-100 transition-colors"
       >
-        <Share2 className="size-4" />
-        Share
+        <Share2 className="size-[18px]" />
       </button>
       <CopyLinkToast isOpen={showToast} onClose={closeToast} />
     </>

--- a/app/components/WebsiteButton.tsx
+++ b/app/components/WebsiteButton.tsx
@@ -1,4 +1,4 @@
-import { Globe } from 'lucide-react'
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
 
 interface WebsiteButtonProps {
   website: string
@@ -10,10 +10,11 @@ export default function WebsiteButton({ website }: WebsiteButtonProps) {
       href={website}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex items-center gap-1.5 bg-white hover:bg-stone-50 text-stone-800 px-4 py-2.5 rounded-3xl text-sm font-medium border border-stone-200 transition-colors"
+      aria-label="Website"
+      title="Website"
+      className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-200 bg-white text-stone-700 hover:bg-stone-100 transition-colors"
     >
-      <Globe className="size-4" />
-      Website
+      <ArrowTopRightOnSquareIcon className="size-[18px]" />
     </a>
   )
 }

--- a/tests/unit/PanelContent.test.tsx
+++ b/tests/unit/PanelContent.test.tsx
@@ -72,7 +72,7 @@ describe('PanelContent', () => {
     render(<PanelContent {...defaultProps} />)
 
     expect(screen.getByText('Directions')).toBeTruthy()
-    expect(screen.getByText('Website')).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Website' })).toBeTruthy()
   })
 
   it('renders the shop address', () => {
@@ -85,7 +85,7 @@ describe('PanelContent', () => {
   it('renders website link when provided', () => {
     render(<PanelContent {...defaultProps} />)
 
-    const websiteLink = screen.getByText('Website').closest('a')
+    const websiteLink = screen.getByRole('link', { name: 'Website' })
     expect(websiteLink).toHaveAttribute('href', mockShop.properties.website)
   })
 })


### PR DESCRIPTION
## What

Reworks the shop details quick-actions bar so it has a clear hierarchy.

**Before:** five equal-weight outlined pills (Favorite, Share, Directions, Website, Report) in a horizontal scroll row — nothing signalled which action mattered.

**After:** `Directions` is a single filled primary button that fills the row; Favorite, Share, Website, and Report collapse into compact circular icon buttons. Everything fits without horizontal scrolling.

| Before | After |
|--------|-------|
| <img width="554" height="356" alt="image" src="https://github.com/user-attachments/assets/8c8726a1-df43-4971-a79e-06937427ff94" />    | <img width="561" height="339" alt="image" src="https://github.com/user-attachments/assets/7ba6db46-2ee4-4248-bb3b-344fcf01b976" />   |