### PR TITLE
Add a map thumbnail to the shop location section

### DIFF
--- a/app/api/shops/static-map/[lng]/[lat]/route.ts
+++ b/app/api/shops/static-map/[lng]/[lat]/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
 
 // Don't let Next apply a fixed ISR window; the Cache-Control below drives CDN
@@ -24,14 +24,17 @@ const inBounds = (lng: number, lat: number) =>
 // Round to ~1m so trivially-different coordinates share a cached image.
 const round = (n: number) => Math.round(n * 1e5) / 1e5
 
-export async function GET(req: NextRequest) {
+// Coordinates live in the path (not the query string) so the shared CDN — which
+// keys on path alone — caches a distinct image per shop instead of leaking one
+// shop's map across coordinates. See tests/unit/cdnCacheInvariant.test.ts.
+export async function GET(_req: Request, ctx: { params: Promise<{ lng: string; lat: string }> }) {
   if (!MAPBOX_TOKEN) {
     return NextResponse.json({ error: 'Mapbox token not configured' }, { status: 500 })
   }
 
-  const params = req.nextUrl.searchParams
-  const lng = Number(params.get('lng'))
-  const lat = Number(params.get('lat'))
+  const { lng: lngParam, lat: latParam } = await ctx.params
+  const lng = Number(lngParam)
+  const lat = Number(latParam)
 
   if (!Number.isFinite(lng) || !Number.isFinite(lat) || !inBounds(lng, lat)) {
     return NextResponse.json({ error: 'Invalid or out-of-area coordinates' }, { status: 400 })

--- a/app/api/shops/static-map/route.ts
+++ b/app/api/shops/static-map/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { logger } from '@/lib/logger'
+
+// Don't let Next apply a fixed ISR window; the Cache-Control below drives CDN
+// caching instead.
+export const dynamic = 'force-dynamic'
+
+const MAPBOX_TOKEN = process.env.MAPBOX_ACCESS_TOKEN
+
+// Fixed server-side so the cache key space stays small and the route can't be
+// used to generate arbitrary (quota-burning) images. Matches the main map
+// (dark-v11) and ShopLocation's yellow-dot overlay.
+const STYLE = 'dark-v11'
+const SIZE = '600x320@2x'
+const ZOOM = 14
+
+// Padded Allegheny County bounding box. Requests outside it are rejected so the
+// proxy only ever spends our Mapbox quota on shops we actually map.
+const BOUNDS = { minLng: -80.5, maxLng: -79.6, minLat: 40.1, maxLat: 40.8 }
+
+const inBounds = (lng: number, lat: number) =>
+  lng >= BOUNDS.minLng && lng <= BOUNDS.maxLng && lat >= BOUNDS.minLat && lat <= BOUNDS.maxLat
+
+// Round to ~1m so trivially-different coordinates share a cached image.
+const round = (n: number) => Math.round(n * 1e5) / 1e5
+
+export async function GET(req: NextRequest) {
+  if (!MAPBOX_TOKEN) {
+    return NextResponse.json({ error: 'Mapbox token not configured' }, { status: 500 })
+  }
+
+  const params = req.nextUrl.searchParams
+  const lng = Number(params.get('lng'))
+  const lat = Number(params.get('lat'))
+
+  if (!Number.isFinite(lng) || !Number.isFinite(lat) || !inBounds(lng, lat)) {
+    return NextResponse.json({ error: 'Invalid or out-of-area coordinates' }, { status: 400 })
+  }
+
+  const center = `${round(lng)},${round(lat)}`
+  const url = `https://api.mapbox.com/styles/v1/mapbox/${STYLE}/static/${center},${ZOOM},0/${SIZE}?access_token=${MAPBOX_TOKEN}`
+
+  const upstream = await fetch(url)
+  if (!upstream.ok) {
+    logger.error('Mapbox static image request failed', { status: String(upstream.status) })
+    return NextResponse.json({ error: 'Failed to fetch map image' }, { status: 502 })
+  }
+
+  const body = await upstream.arrayBuffer()
+  return new NextResponse(body, {
+    headers: {
+      'Content-Type': upstream.headers.get('content-type') ?? 'image/png',
+      // A coordinate's map image is effectively immutable, so cache hard: long
+      // shared-CDN TTL absorbs traffic, and a day of browser cache spares repeat
+      // viewers a round-trip.
+      'Cache-Control': 'public, max-age=86400, s-maxage=2592000, stale-while-revalidate=86400',
+    },
+  })
+}

--- a/app/components/PanelContent.tsx
+++ b/app/components/PanelContent.tsx
@@ -19,9 +19,11 @@ export default function PanelContent(props: IProps) {
     <div className="bg-[#FAF9F7]">
       <QuickActionsBar shop={props.shop} />
 
-      <div className="px-4 sm:px-6 py-5">
+      <div className="px-4 sm:px-6 py-5 border-b border-stone-200">
         <ShopLocation address={address} coordinates={coordinates} />
+      </div>
 
+      <div className="px-4 sm:px-6 py-5">
         <ShopAmenities
           amenities={amenities ?? []}
           shopId={props.shop.properties.uuid}

--- a/app/components/PanelContent.tsx
+++ b/app/components/PanelContent.tsx
@@ -3,7 +3,7 @@ import NearbyShops from './NearbyShops'
 import { ShopNews } from './ShopNews'
 import { ShopEvents } from './ShopEvents'
 import QuickActionsBar from './QuickActionsBar'
-import { getGoogleMapsUrl } from './DirectionsButton'
+import ShopLocation from './ShopLocation'
 import PhotoGrid from './PhotoGrid'
 import ShopAmenities from './ShopAmenities'
 
@@ -20,19 +20,7 @@ export default function PanelContent(props: IProps) {
       <QuickActionsBar shop={props.shop} />
 
       <div className="px-4 sm:px-6 py-5">
-        <a
-          href={getGoogleMapsUrl({
-            latitude: coordinates[0],
-            longitude: coordinates[1],
-          })}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block group"
-        >
-          <address className="not-italic text-sm font-medium text-stone-800 group-hover:text-amber-700 transition-colors leading-snug">
-            {address}
-          </address>
-        </a>
+        <ShopLocation address={address} coordinates={coordinates} />
 
         <ShopAmenities
           amenities={amenities ?? []}

--- a/app/components/ShopLocation.tsx
+++ b/app/components/ShopLocation.tsx
@@ -1,0 +1,46 @@
+import { MapPinIcon } from '@heroicons/react/24/outline'
+import { getGoogleMapsUrl } from './DirectionsButton'
+
+interface IProps {
+  address: string
+  // GeoJSON order: [longitude, latitude]
+  coordinates: [number, number]
+}
+
+const MAPBOX_TOKEN = process.env.MAPBOX_ACCESS_TOKEN
+
+/**
+ * Builds a Mapbox Static Images URL with a marker at the shop. Returns null
+ * when the token is missing or the shop has no real coordinates (utils default
+ * unset coords to [0, 0]), so we don't render a pin in the Atlantic.
+ */
+const buildStaticMapUrl = (lng: number, lat: number) => {
+  if (!MAPBOX_TOKEN || (lng === 0 && lat === 0)) return null
+  const marker = `pin-l+fbbf24(${lng},${lat})`
+  return `https://api.mapbox.com/styles/v1/mapbox/streets-v12/static/${marker}/${lng},${lat},14,0/600x320@2x?access_token=${MAPBOX_TOKEN}`
+}
+
+export default function ShopLocation({ address, coordinates }: IProps) {
+  const [lng, lat] = coordinates
+  const mapUrl = buildStaticMapUrl(lng, lat)
+  // Preserve the existing (double-swapped) call so the Google Maps query stays
+  // lat,lng — see DirectionsButton.getGoogleMapsUrl.
+  const mapsHref = getGoogleMapsUrl({ latitude: coordinates[0], longitude: coordinates[1] })
+
+  return (
+    <a href={mapsHref} target="_blank" rel="noopener noreferrer" className="block group">
+      {mapUrl && (
+        <img
+          src={mapUrl}
+          alt={`Map showing ${address}`}
+          loading="lazy"
+          className="mb-3 h-36 w-full rounded-xl border border-stone-200 object-cover"
+        />
+      )}
+      <address className="not-italic flex items-start gap-2 text-sm font-medium text-stone-800 group-hover:text-amber-700 transition-colors leading-snug">
+        <MapPinIcon className="mt-0.5 h-4 w-4 shrink-0" />
+        {address}
+      </address>
+    </a>
+  )
+}

--- a/app/components/ShopLocation.tsx
+++ b/app/components/ShopLocation.tsx
@@ -7,19 +7,15 @@ interface IProps {
   coordinates: [number, number]
 }
 
-const MAPBOX_TOKEN = process.env.MAPBOX_ACCESS_TOKEN
-
 /**
- * Builds a Mapbox Static Images URL with a marker at the shop. Returns null
- * when the token is missing or the shop has no real coordinates (utils default
- * unset coords to [0, 0]), so we don't render a pin in the Atlantic.
+ * Points at our own static-map proxy (CDN-cached) rather than Mapbox directly,
+ * so repeat views don't each burn a Mapbox request. Returns null when the shop
+ * has no real coordinates (utils default unset coords to [0, 0]) so we don't
+ * render a map of the Atlantic.
  */
 const buildStaticMapUrl = (lng: number, lat: number) => {
-  if (!MAPBOX_TOKEN || (lng === 0 && lat === 0)) return null
-  // Match the main map's style (see MapContainer). No Mapbox marker — the
-  // map is centered on the shop, so we overlay a CSS dot to match the main
-  // map's yellow circle marker instead of a pin.
-  return `https://api.mapbox.com/styles/v1/mapbox/dark-v11/static/${lng},${lat},14,0/600x320@2x?access_token=${MAPBOX_TOKEN}`
+  if (lng === 0 && lat === 0) return null
+  return `/api/shops/static-map?lng=${lng}&lat=${lat}`
 }
 
 export default function ShopLocation({ address, coordinates }: IProps) {

--- a/app/components/ShopLocation.tsx
+++ b/app/components/ShopLocation.tsx
@@ -26,7 +26,9 @@ export default function ShopLocation({ address, coordinates }: IProps) {
   const mapsHref = getGoogleMapsUrl({ latitude: coordinates[0], longitude: coordinates[1] })
 
   return (
-    <a href={mapsHref} target="_blank" rel="noopener noreferrer" className="block group">
+    <>
+      <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">Location</p>
+      <a href={mapsHref} target="_blank" rel="noopener noreferrer" className="block group">
       {mapUrl && (
         <div className="relative mb-3">
           <img
@@ -43,6 +45,7 @@ export default function ShopLocation({ address, coordinates }: IProps) {
         <MapPinIcon className="mt-0.5 h-4 w-4 shrink-0" />
         {address}
       </address>
-    </a>
+      </a>
+    </>
   )
 }

--- a/app/components/ShopLocation.tsx
+++ b/app/components/ShopLocation.tsx
@@ -16,9 +16,10 @@ const MAPBOX_TOKEN = process.env.MAPBOX_ACCESS_TOKEN
  */
 const buildStaticMapUrl = (lng: number, lat: number) => {
   if (!MAPBOX_TOKEN || (lng === 0 && lat === 0)) return null
-  // Match the main map's style (see MapContainer).
-  const marker = `pin-l+fbbf24(${lng},${lat})`
-  return `https://api.mapbox.com/styles/v1/mapbox/dark-v11/static/${marker}/${lng},${lat},14,0/600x320@2x?access_token=${MAPBOX_TOKEN}`
+  // Match the main map's style (see MapContainer). No Mapbox marker — the
+  // map is centered on the shop, so we overlay a CSS dot to match the main
+  // map's yellow circle marker instead of a pin.
+  return `https://api.mapbox.com/styles/v1/mapbox/dark-v11/static/${lng},${lat},14,0/600x320@2x?access_token=${MAPBOX_TOKEN}`
 }
 
 export default function ShopLocation({ address, coordinates }: IProps) {
@@ -31,12 +32,16 @@ export default function ShopLocation({ address, coordinates }: IProps) {
   return (
     <a href={mapsHref} target="_blank" rel="noopener noreferrer" className="block group">
       {mapUrl && (
-        <img
-          src={mapUrl}
-          alt={`Map showing ${address}`}
-          loading="lazy"
-          className="mb-3 h-36 w-full rounded-xl border border-stone-200 object-cover"
-        />
+        <div className="relative mb-3">
+          <img
+            src={mapUrl}
+            alt={`Map showing ${address}`}
+            loading="lazy"
+            className="h-36 w-full rounded-xl border border-stone-200 object-cover"
+          />
+          {/* Matches the main map's yellow circle marker (see MapContainer). */}
+          <span className="absolute left-1/2 top-1/2 h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#FDE047] ring-2 ring-white" />
+        </div>
       )}
       <address className="not-italic flex items-start gap-2 text-sm font-medium text-stone-800 group-hover:text-amber-700 transition-colors leading-snug">
         <MapPinIcon className="mt-0.5 h-4 w-4 shrink-0" />

--- a/app/components/ShopLocation.tsx
+++ b/app/components/ShopLocation.tsx
@@ -16,8 +16,9 @@ const MAPBOX_TOKEN = process.env.MAPBOX_ACCESS_TOKEN
  */
 const buildStaticMapUrl = (lng: number, lat: number) => {
   if (!MAPBOX_TOKEN || (lng === 0 && lat === 0)) return null
+  // Match the main map's style (see MapContainer).
   const marker = `pin-l+fbbf24(${lng},${lat})`
-  return `https://api.mapbox.com/styles/v1/mapbox/streets-v12/static/${marker}/${lng},${lat},14,0/600x320@2x?access_token=${MAPBOX_TOKEN}`
+  return `https://api.mapbox.com/styles/v1/mapbox/dark-v11/static/${marker}/${lng},${lat},14,0/600x320@2x?access_token=${MAPBOX_TOKEN}`
 }
 
 export default function ShopLocation({ address, coordinates }: IProps) {

--- a/app/components/ShopLocation.tsx
+++ b/app/components/ShopLocation.tsx
@@ -15,7 +15,7 @@ interface IProps {
  */
 const buildStaticMapUrl = (lng: number, lat: number) => {
   if (lng === 0 && lat === 0) return null
-  return `/api/shops/static-map?lng=${lng}&lat=${lat}`
+  return `/api/shops/static-map/${lng}/${lat}`
 }
 
 export default function ShopLocation({ address, coordinates }: IProps) {


### PR DESCRIPTION
## What

Replaces the bare address text link on the shop details page with a proper location section: a Mapbox **static map thumbnail** with a marker, above the address.

## Why

The address alone gave no spatial contex, you couldn't tell where the shop sat without clicking out. The thumbnail places it at a glance, and the whole block still links through to Google Maps.


## Screenshot

| Before | After |
|--------|-------|
| <img width="556" height="1225" alt="image" src="https://github.com/user-attachments/assets/b6c101cc-b9ab-427f-bb05-13914b009351" />    | <img width="571" height="1242" alt="image" src="https://github.com/user-attachments/assets/bf935630-6f9f-4e20-97eb-52f62bc6be35" />   |