### PR TITLE
Render shop amenities as a labeled card grid

### DIFF
--- a/app/components/ShopAmenities.tsx
+++ b/app/components/ShopAmenities.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import dynamic from 'next/dynamic'
 import { useAnalytics } from '@/hooks'
 
-import AmenityChip from './AmenityChip'
+import { getAmenity } from '@/lib/amenities'
 import IssueSuccessDialog from './IssueSuccessDialog'
 
 const AmenityReportModal = dynamic(() => import('./AmenityReportModal'), { ssr: false })
@@ -32,13 +32,26 @@ export default function ShopAmenities({ amenities, shopId }: IProps) {
 
   return (
     <>
-      <div className="flex flex-wrap gap-2 my-3">
-        {amenities.map(amenity => (
-          <AmenityChip key={amenity} amenity={amenity} />
-        ))}
+      <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">Amenities</p>
+
+      <div className="grid grid-cols-2 gap-2">
+        {amenities.map(amenity => {
+          const entry = getAmenity(amenity)
+          if (!entry) return null
+          const Icon = entry.icon
+          return (
+            <div
+              key={amenity}
+              className="flex items-center gap-2 rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-700"
+            >
+              <Icon className="h-4 w-4 shrink-0 text-stone-500" />
+              {entry.label}
+            </div>
+          )
+        })}
       </div>
 
-      <p className="text-xs text-gray-700">
+      <p className="mt-3 text-xs text-gray-700">
         Missing something?{' '}
         <button type="button" aria-label="Report amenity" className="text-amber-700" onClick={handleOnClick}>
           Let me know


### PR DESCRIPTION
## What

Restyles the shop amenities into their own section below the location block, matching the redesign prototype (#281): a two-column grid of bordered icon cards under an **Amenities** header, replacing the inline chips.

| Before | After |
|--------|-------|
| <img width="524" height="114" alt="image" src="https://github.com/user-attachments/assets/00c24fb5-6a01-496f-ab52-24268153225d" />    | <img width="552" height="231" alt="image" src="https://github.com/user-attachments/assets/3bbf31d1-ec96-4d94-99e8-a4c8442a9949" />   |