### PR TITLE
Make shop photos a draggable single-row strip

### DIFF
--- a/app/components/PanelContent.tsx
+++ b/app/components/PanelContent.tsx
@@ -19,6 +19,8 @@ export default function PanelContent(props: IProps) {
     <div className="bg-[#FAF9F7]">
       <QuickActionsBar shop={props.shop} />
 
+      {photos && <PhotoGrid photos={photos} />}
+
       <div className="px-4 sm:px-6 py-5 border-b border-stone-200">
         <ShopLocation address={address} coordinates={coordinates} />
       </div>
@@ -34,7 +36,6 @@ export default function PanelContent(props: IProps) {
       <div className="h-px bg-stone-200 mx-4 sm:mx-6" />
 
       {/* Child components */}
-      {photos && <PhotoGrid photos={photos} />}
       <ShopNews shop={props.shop} />
       <ShopEvents shop={props.shop} />
       <NearbyShops shop={props.shop} />

--- a/app/components/PhotoGrid.tsx
+++ b/app/components/PhotoGrid.tsx
@@ -1,24 +1,60 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useAnalytics } from '@/hooks'
 import { Photo } from '@/types/shop-types'
 
 const BUCKET_URL = 'https://uljutxoijtvtcxvatqso.supabase.co/storage/v1/object/public/shop-photos'
 
+const DRAG_THRESHOLD = 5 // px before a mouse drag counts as a scroll (not a click)
+
 interface PhotoGridProps {
   photos: Photo[]
 }
+
+const getPhotoUrl = (photo: Photo | string) =>
+  typeof photo === 'string' ? photo : `${BUCKET_URL}/${photo.path}`
 
 export default function PhotoGrid({ photos }: PhotoGridProps) {
   const plausible = useAnalytics()
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null)
 
+  const scrollRef = useRef<HTMLDivElement>(null)
+  // Mouse drag-to-scroll. Touch keeps native momentum scrolling, so we only
+  // intercept mouse pointers. `dragged` suppresses the expand-click that would
+  // otherwise fire at the end of a drag.
+  const drag = useRef({ active: false, startX: 0, startScroll: 0, dragged: false })
+
   useEffect(() => {
     setExpandedIndex(null)
   }, [photos])
 
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.pointerType !== 'mouse' || !scrollRef.current) return
+    drag.current = { active: true, startX: e.clientX, startScroll: scrollRef.current.scrollLeft, dragged: false }
+  }
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!drag.current.active || !scrollRef.current) return
+    const dx = e.clientX - drag.current.startX
+    if (Math.abs(dx) > DRAG_THRESHOLD) {
+      drag.current.dragged = true
+      scrollRef.current.setPointerCapture(e.pointerId)
+    }
+    scrollRef.current.scrollLeft = drag.current.startScroll - dx
+  }
+
+  const onPointerUp = () => {
+    drag.current.active = false
+  }
+
   const handleImageClick = (index: number) => {
+    // Swallow the click that ends a drag so dragging doesn't toggle expansion.
+    if (drag.current.dragged) {
+      drag.current.dragged = false
+      return
+    }
+
     const isExpanding = expandedIndex !== index
 
     plausible('PhotoGridClick', {
@@ -28,35 +64,38 @@ export default function PhotoGrid({ photos }: PhotoGridProps) {
       },
     })
 
-    setExpandedIndex(expandedIndex === index ? null : index)
+    setExpandedIndex(isExpanding ? index : null)
   }
 
-  const getPhotoUrl = (photo: Photo | string) => {
-    if (typeof photo === 'string') {
-      return photo
-    }
-    return `${BUCKET_URL}/${photo.path}`
-  }
+  if (!photos.length) return null
 
   return (
-    <section className="flex flex-col mt-4 px-4 sm:px-6">
-      <div className="grid grid-cols-3 gap-2">
+    <section className="px-4 sm:px-6 py-5 border-b border-stone-200">
+      <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">Photos</p>
+      {/* p-1 keeps the focus/selection ring from being clipped by the scroll
+          container; the arbitrary properties hide the scrollbar across browsers. */}
+      <div
+        ref={scrollRef}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        className="flex items-start gap-2 overflow-x-auto p-1 cursor-grab select-none active:cursor-grabbing [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+      >
         {photos.map((photo, index) => (
           <button
             key={index}
             onClick={() => handleImageClick(index)}
-            className={`
-              relative overflow-hidden rounded-lg transition-all duration-300
-              ${expandedIndex === index ? 'col-span-3 aspect-[4/3]' : 'aspect-square'}
-              hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2
-            `}
-            aria-label={`Toggle photo expansion for coffee shop photo ${index + 1}`}
+            className={`shrink-0 overflow-hidden rounded-lg transition-all duration-300 hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-amber-500 ${
+              expandedIndex === index ? 'h-52 w-72 ring-2 ring-amber-500' : 'h-28 w-36'
+            }`}
+            aria-label={`Toggle coffee shop photo ${index + 1}`}
             aria-pressed={expandedIndex === index}
           >
             <img
               src={getPhotoUrl(photo)}
               alt={`Coffee shop photo ${index + 1}`}
-              className="w-full h-full object-cover"
+              draggable={false}
+              className="h-full w-full object-cover"
             />
           </button>
         ))}


### PR DESCRIPTION
## What

Moves photos to a dedicated Photos single-row section directly below the actions bar

## Screenshots

| Before | After |
|--------|-------|
| <img width="538" height="353" alt="image" src="https://github.com/user-attachments/assets/c40ea6a3-afb4-4fa5-9442-18a51f925c1a" />    | <img width="552" height="197" alt="image" src="https://github.com/user-attachments/assets/fe497a89-ea8f-41c1-90f8-8b8453f1a4e3" />   |