### PR TITLE
Render shop descriptions in the panel and SEO

### DIFF
--- a/app/components/PanelContent.tsx
+++ b/app/components/PanelContent.tsx
@@ -13,7 +13,8 @@ interface IProps {
 }
 
 export default function PanelContent(props: IProps) {
-  const { address, photos, amenities, roaster, description } = props.shop.properties
+  const { address, photos, amenities, roaster } = props.shop.properties
+  const description = props.shop.properties.description?.trim()
   const coordinates = props.shop.geometry?.coordinates
 
   return (

--- a/app/components/PanelContent.tsx
+++ b/app/components/PanelContent.tsx
@@ -13,12 +13,18 @@ interface IProps {
 }
 
 export default function PanelContent(props: IProps) {
-  const { address, photos, amenities, roaster } = props.shop.properties
+  const { address, photos, amenities, roaster, description } = props.shop.properties
   const coordinates = props.shop.geometry?.coordinates
 
   return (
     <div className="bg-[#FAF9F7]">
       <QuickActionsBar shop={props.shop} />
+
+      {description && (
+        <div className="px-4 sm:px-6 py-5 border-b border-stone-200">
+          <p className="text-sm text-gray-600 leading-relaxed">{description}</p>
+        </div>
+      )}
 
       {roaster && (
         <div className="px-4 sm:px-6 py-5 border-b border-stone-200">

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -108,7 +108,9 @@ export const getAllShopsForSeo = cache(async (): Promise<ShopListEntry[]> => {
  */
 export function buildShopMetadata(shop: DbShop): Metadata {
   const title = `${shop.name} | ${shop.neighborhood} | pgh.coffee`
-  const description = `${shop.name} is an independent coffee shop in ${shop.neighborhood}, Pittsburgh — ${shop.address}.`
+  const description =
+    shop.description?.trim() ||
+    `${shop.name} is an independent coffee shop in ${shop.neighborhood}, Pittsburgh — ${shop.address}.`
   const path = buildShopPath(shop)
 
   const metadata: Metadata = {

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -25,6 +25,7 @@ const toFeature = (shop: DbShop): TShop => ({
     uuid: shop.uuid,
     amenities: shop.amenities ?? undefined,
     roaster: toFeatureRoaster(shop),
+    description: shop.description ?? undefined,
   },
   geometry: {
     type: 'Point',

--- a/tests/unit/PanelContent.test.tsx
+++ b/tests/unit/PanelContent.test.tsx
@@ -88,4 +88,30 @@ describe('PanelContent', () => {
     const websiteLink = screen.getByRole('link', { name: 'Website' })
     expect(websiteLink).toHaveAttribute('href', mockShop.properties.website)
   })
+
+  it('renders the description block when description is a non-empty string', () => {
+    const shop: TShop = {
+      ...mockShop,
+      properties: { ...mockShop.properties, description: '  A cozy neighborhood cafe.  ' },
+    }
+    render(<PanelContent {...defaultProps} shop={shop} />)
+
+    // Rendered trimmed
+    expect(screen.getByText('A cozy neighborhood cafe.')).toBeInTheDocument()
+  })
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty string', ''],
+    ['whitespace only', '   '],
+  ])('does not render the description block for %s', (_label, description) => {
+    const shop: TShop = {
+      ...mockShop,
+      properties: { ...mockShop.properties, description },
+    }
+    render(<PanelContent {...defaultProps} shop={shop} />)
+
+    expect(screen.queryByText(/cafe/i)).not.toBeInTheDocument()
+  })
 })

--- a/tests/unit/PanelContent.test.tsx
+++ b/tests/unit/PanelContent.test.tsx
@@ -89,15 +89,19 @@ describe('PanelContent', () => {
     expect(websiteLink).toHaveAttribute('href', mockShop.properties.website)
   })
 
-  it('renders the description block when description is a non-empty string', () => {
+  // The description intro block is the only <p> with this class combination.
+  const descriptionSelector = 'p.text-sm.text-gray-600.leading-relaxed'
+
+  it('renders the description block (trimmed) when description is a non-empty string', () => {
     const shop: TShop = {
       ...mockShop,
       properties: { ...mockShop.properties, description: '  A cozy neighborhood cafe.  ' },
     }
-    render(<PanelContent {...defaultProps} shop={shop} />)
+    const { container } = render(<PanelContent {...defaultProps} shop={shop} />)
 
-    // Rendered trimmed
-    expect(screen.getByText('A cozy neighborhood cafe.')).toBeInTheDocument()
+    const paragraph = container.querySelector(descriptionSelector)
+    expect(paragraph).toBeInTheDocument()
+    expect(paragraph).toHaveTextContent('A cozy neighborhood cafe.')
   })
 
   it.each([
@@ -110,8 +114,8 @@ describe('PanelContent', () => {
       ...mockShop,
       properties: { ...mockShop.properties, description },
     }
-    render(<PanelContent {...defaultProps} shop={shop} />)
+    const { container } = render(<PanelContent {...defaultProps} shop={shop} />)
 
-    expect(screen.queryByText(/cafe/i)).not.toBeInTheDocument()
+    expect(container.querySelector(descriptionSelector)).toBeNull()
   })
 })

--- a/tests/unit/seo.test.ts
+++ b/tests/unit/seo.test.ts
@@ -202,4 +202,25 @@ describe('buildShopMetadata', () => {
     expect(twitter?.images).toBeUndefined()
     expect(twitter?.card).toBeUndefined()
   })
+
+  test('prefers the trimmed shop description over the generated template', () => {
+    const shop: DbShop = { ...baseShop, description: '  A long-running Regent Square coffee bar.  ' }
+    const metadata = buildShopMetadata(shop)
+    const expected = 'A long-running Regent Square coffee bar.'
+    const twitter = metadata.twitter as { description?: string } | undefined
+
+    expect(metadata.description).toBe(expected)
+    expect(metadata.openGraph?.description).toBe(expected)
+    expect(twitter?.description).toBe(expected)
+  })
+
+  test('falls back to the generated template when the description is whitespace-only', () => {
+    const shop: DbShop = { ...baseShop, description: '   ' }
+    const metadata = buildShopMetadata(shop)
+    const expected =
+      '61B Cafe is an independent coffee shop in Regent Square, Pittsburgh — 1108 S Braddock Ave, Pittsburgh, PA 15218.'
+
+    expect(metadata.description).toBe(expected)
+    expect(metadata.openGraph?.description).toBe(expected)
+  })
 })

--- a/types/shop-types.ts
+++ b/types/shop-types.ts
@@ -32,6 +32,7 @@ export interface DbShop {
   // Embedded roaster (joined via roaster_id) whose coffee the shop serves.
   roasterRef?: { name: string; slug: string; company_id: string | null } | null
   amenities?: string[]
+  description?: string | null
 }
 
 // The roaster a shop serves, plus whether it's the shop's own in-house roaster.
@@ -59,6 +60,7 @@ export interface TShop {
     uuid: string
     amenities?: string[]
     roaster?: TShopRoaster | null
+    description?: string | null
     selected?: boolean
   }
   geometry: {


### PR DESCRIPTION
Wires up an optional shop `description` and renders it everywhere a shop is shown, degrading gracefully when null/empty so this can ship before any descriptions exist (and independently of the backfill data PR).

- `types/shop-types.ts` — `description?: string | null` on `DbShop` and `TShop.properties`
- `app/utils/utils.ts` — the shared `toFeature` mapper carries `description` into the geojson payload the panel reads (the only path that reaches it)
- `app/components/PanelContent.tsx` — renders a top intro block (plain `<p>`, styled like `RoasterDetails`/`Company`) only when present
- `app/utils/seo.ts` — shop metadata prefers `shop.description`, falling back to the existing generated template when null

Existing `select('*')` queries already return the column once it exists, so no query changes. `tsc`, lint, and the full unit suite (247 passing) are green.

Pairs with the data PR (migration + descriptions); either can merge first.