### PR TITLE
Make favoriting the primary shop action

### DIFF
--- a/app/components/DirectionsButton.tsx
+++ b/app/components/DirectionsButton.tsx
@@ -16,10 +16,11 @@ export default function DirectionsButton({ coordinates }: DirectionsButtonProps)
       })}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex flex-1 items-center justify-center gap-1.5 bg-gray-950 hover:bg-gray-800 text-white px-4 py-2.5 rounded-full text-sm font-semibold transition-colors"
+      aria-label="Directions"
+      title="Directions"
+      className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-200 bg-white text-stone-700 hover:bg-stone-100 transition-colors"
     >
-      <MapPin className="h-4 w-4" />
-      Directions
+      <MapPin className="size-[18px]" />
     </a>
   )
 }

--- a/app/components/FavoriteButton.tsx
+++ b/app/components/FavoriteButton.tsx
@@ -91,9 +91,14 @@ export default function FavoriteButton({ shopUUID, shopName }: FavoriteButtonPro
         aria-label={isFavorited ? 'Favorited' : 'Favorite'}
         aria-pressed={isFavorited}
         title={isFavorited ? 'Favorited' : 'Favorite'}
-        className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-200 bg-white text-stone-700 hover:bg-stone-100 transition-colors disabled:opacity-50"
+        className={`inline-flex flex-1 items-center justify-center gap-1.5 px-4 py-2.5 rounded-full text-sm font-semibold transition-colors disabled:opacity-50 ${
+          isFavorited
+            ? 'bg-red-50 text-red-600 border border-red-200 hover:bg-red-100'
+            : 'bg-gray-950 hover:bg-gray-800 text-white'
+        }`}
       >
-        <Heart className={`size-[18px] transition-colors ${isFavorited ? 'fill-red-500 text-red-500' : ''}`} />
+        <Heart className={`h-4 w-4 transition-colors ${isFavorited ? 'fill-red-500 text-red-500' : ''}`} />
+        {isFavorited ? 'Favorited' : 'Favorite'}
       </button>
 
       <FavoriteToast isOpen={showToast} onClose={() => setShowToast(false)} shopName={shopName} />

--- a/app/components/QuickActionsBar.tsx
+++ b/app/components/QuickActionsBar.tsx
@@ -33,8 +33,8 @@ export default function QuickActionsBar({ shop }: QuickActionsBarProps) {
   return (
     <>
       <div ref={scrollRef} className="flex items-center gap-2 px-4 sm:px-6 py-4 bg-white border-b border-stone-200">
-        <DirectionsButton coordinates={coordinates} />
         <FavoriteButton shopUUID={uuid} shopName={name} />
+        <DirectionsButton coordinates={coordinates} />
         <ShareButton />
         {website && <WebsiteButton website={website} />}
         <ReportIssueButton onClick={() => setShowIssueModal(true)} />


### PR DESCRIPTION
## What

Reworks the shop quick-actions bar so **favoriting** is the main action instead of directions.

- `FavoriteButton` is now the full-width labeled primary CTA — dark "Favorite" by default, switching to a red "Favorited" state when active.
- `DirectionsButton` is demoted to a small circular icon button, matching Share / Website / Report.
- Favorite leads the action bar; directions follows.

## Notes

- All existing favorite logic is unchanged (login prompt for signed-out users, toast, analytics). Making it prominent just surfaces the login-modal path more often for signed-out users.