### PR TITLE
Offerings (phase 1): additive schema + lib + type threading

### DIFF
--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -24,6 +24,7 @@ const toFeature = (shop: DbShop): TShop => ({
     photos: shop.photos ?? undefined,
     uuid: shop.uuid,
     amenities: shop.amenities ?? undefined,
+    offerings: shop.offerings ?? undefined,
     roaster: toFeatureRoaster(shop),
     description: shop.description ?? undefined,
   },

--- a/lib/offeringKeys.ts
+++ b/lib/offeringKeys.ts
@@ -6,6 +6,7 @@ export const OFFERING_KEYS = [
   // Drink specialties — populated via editorial backfill.
   'espresso',
   'pour_over',
+  'drip',
   'cold_brew',
   'loose_leaf_tea',
   'matcha',

--- a/lib/offeringKeys.ts
+++ b/lib/offeringKeys.ts
@@ -1,0 +1,14 @@
+export const OFFERING_KEYS = [
+  // Food — backfilled from amenities (see offerings-schema.sql).
+  'pastries',
+  'snacks',
+  'full_food_menu',
+  // Drink specialties — populated via editorial backfill.
+  'espresso',
+  'pour_over',
+  'cold_brew',
+  'loose_leaf_tea',
+  'matcha',
+] as const
+
+export type OfferingKey = (typeof OFFERING_KEYS)[number]

--- a/lib/offerings.ts
+++ b/lib/offerings.ts
@@ -9,6 +9,7 @@ export const offeringMap = {
   full_food_menu: { label: 'Full Food Menu' },
   espresso: { label: 'Espresso' },
   pour_over: { label: 'Pour Over' },
+  drip: { label: 'Drip Coffee' },
   cold_brew: { label: 'Cold Brew' },
   loose_leaf_tea: { label: 'Loose-leaf Tea' },
   matcha: { label: 'Matcha' },

--- a/lib/offerings.ts
+++ b/lib/offerings.ts
@@ -1,0 +1,18 @@
+import type { OfferingKey } from './offeringKeys'
+
+export { OFFERING_KEYS, type OfferingKey } from './offeringKeys'
+
+// Offerings render as plain text pills (no icons), unlike amenities.
+export const offeringMap = {
+  pastries: { label: 'Pastries' },
+  snacks: { label: 'Snacks' },
+  full_food_menu: { label: 'Full Food Menu' },
+  espresso: { label: 'Espresso' },
+  pour_over: { label: 'Pour Over' },
+  cold_brew: { label: 'Cold Brew' },
+  loose_leaf_tea: { label: 'Loose-leaf Tea' },
+  matcha: { label: 'Matcha' },
+} satisfies Record<OfferingKey, { label: string }>
+
+export const getOffering = (key: string): { label: string } | undefined =>
+  (offeringMap as Record<string, { label: string }>)[key]

--- a/migrations/offerings-schema-rollback.sql
+++ b/migrations/offerings-schema-rollback.sql
@@ -1,0 +1,6 @@
+-- Rollback for offerings-schema.sql.
+--
+-- offerings-schema.sql only ADDED a column and backfilled it; the amenities
+-- column was never modified. So a full rollback is simply dropping the column.
+
+ALTER TABLE shops DROP COLUMN IF EXISTS offerings;

--- a/migrations/offerings-schema.sql
+++ b/migrations/offerings-schema.sql
@@ -1,0 +1,29 @@
+-- Schema for shop "offerings" — what a shop serves (food + drink specialties),
+-- as distinct from amenities (physical facilities like wifi, outlets, parking).
+--
+-- Apply by hand (no migration framework in this repo). Purely additive and
+-- non-breaking: adds one column and backfills it. The amenities column is left
+-- completely untouched, so existing amenity filters keep working. The food keys
+-- are COPIED (not moved) here; they are removed from amenities in a later
+-- cleanup migration once offerings is fully shipped.
+--
+-- Drink specialties (espresso, pour_over, ...) have no source data yet; they are
+-- populated separately via an editorial backfill (see descriptions-backfill.sql
+-- for the pattern). This migration only seeds the food keys.
+
+ALTER TABLE shops ADD COLUMN IF NOT EXISTS offerings text[] NOT NULL DEFAULT '{}';
+
+-- Copy the three food keys out of amenities into offerings. Unions with any
+-- existing offerings and de-dupes, so it is safe to re-run and order-independent
+-- with the editorial drink backfill.
+UPDATE shops
+SET offerings = array(
+  SELECT DISTINCT unnest(
+    offerings || array(
+      SELECT unnest(amenities)
+      INTERSECT
+      SELECT unnest(ARRAY['pastries', 'snacks', 'full_food_menu'])
+    )
+  )
+)
+WHERE amenities && ARRAY['pastries', 'snacks', 'full_food_menu'];

--- a/types/shop-types.ts
+++ b/types/shop-types.ts
@@ -32,6 +32,7 @@ export interface DbShop {
   // Embedded roaster (joined via roaster_id) whose coffee the shop serves.
   roasterRef?: { name: string; slug: string; company_id: string | null } | null
   amenities?: string[]
+  offerings?: string[]
   description?: string | null
 }
 
@@ -59,6 +60,7 @@ export interface TShop {
     website: string
     uuid: string
     amenities?: string[]
+    offerings?: string[]
     roaster?: TShopRoaster | null
     description?: string | null
     selected?: boolean


### PR DESCRIPTION
First phase of splitting the overloaded **amenities** concept into two: physical facilities (wifi, outlets, parking) stay in `amenities`; what a shop *serves* (food + drink specialties) moves to a new **offerings** field. Offerings will later feed a derived "highlights" pill strip under the shop description.

This PR is **fully additive and non-breaking** — `amenities` is left untouched, so existing amenity filters keep working.

## What's here
- `migrations/offerings-schema.sql` — adds `shops.offerings text[]` and copies the food keys (`pastries`, `snacks`, `full_food_menu`) out of `amenities`. 
- `migrations/offerings-schema-rollback.sql` — drops the column
- `lib/offeringKeys.ts` + `lib/offerings.ts` — offering key set + label map. Food keys are backfilled now; drink specialties (`espresso`, `pour_over`, …) await an editorial backfill.
- `offerings` threaded through `types/shop-types.ts` and the `toFeature` GeoJSON transform.

## Not in this PR (follow-up phases)
- **Phase 2** — `getHighlights` + `ShopHighlights` pill component (incl. `open_late` derived from hours).
- **Phase 3 (cleanup, only once live)** — remove food keys from `amenities`, `amenityKeys`, `amenityMap`, and the amenity filter list.
- Editorial SQL backfill for drink offerings.
