### PR TITLE
Minimal nearby shops

### DIFF
--- a/app/components/NearbyShopList.tsx
+++ b/app/components/NearbyShopList.tsx
@@ -1,0 +1,24 @@
+import { TShop } from '@/types/shop-types'
+import { TUnits } from '@/types/unit-types'
+import NearbyShopRow from '@/app/components/NearbyShopRow'
+
+interface IProps {
+  shops: TShop[]
+  distances: number[]
+  units?: TUnits
+}
+
+export default function NearbyShopList(props: IProps) {
+  return (
+    <ul className="relative">
+      {props.shops.map((shop, index) => (
+        <NearbyShopRow
+          key={shop.properties.name + shop.properties.address}
+          shop={shop}
+          distance={String(props.distances[index])}
+          units={props.units}
+        />
+      ))}
+    </ul>
+  )
+}

--- a/app/components/NearbyShopRow.tsx
+++ b/app/components/NearbyShopRow.tsx
@@ -35,7 +35,7 @@ export default function NearbyShopRow(props: IProps) {
       className="group flex items-center gap-3 py-3 border-b border-stone-200 cursor-pointer"
     >
       <span className="min-w-0 flex-1">
-        <span className="block truncate font-medium text-gray-900">{props.shop.properties.name}</span>
+        <span className="block truncate font-medium text-gray-900 group-hover:text-amber-700 transition-colors">{props.shop.properties.name}</span>
         <span className="block truncate text-sm text-gray-500">{props.shop.properties.neighborhood}</span>
       </span>
 

--- a/app/components/NearbyShopRow.tsx
+++ b/app/components/NearbyShopRow.tsx
@@ -1,0 +1,51 @@
+import { ChevronRightIcon } from '@heroicons/react/24/outline'
+import { TShop } from '@/types/shop-types'
+import { TUnits } from '@/types/unit-types'
+import useShopsStore from '@/stores/coffeeShopsStore'
+import { useShopSelection } from '@/hooks'
+import { generateDistanceText } from '@/app/components/ShopCard'
+
+interface IProps {
+  shop: TShop
+  distance?: string
+  units?: TUnits
+}
+
+export default function NearbyShopRow(props: IProps) {
+  const { handleShopSelect } = useShopSelection()
+  const { setHoveredShop } = useShopsStore()
+
+  const handleClick = () => handleShopSelect(props.shop)
+
+  const handleKeyPress = (event: React.KeyboardEvent<HTMLLIElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      handleClick()
+    }
+  }
+
+  return (
+    <li
+      onMouseEnter={() => setHoveredShop(props.shop)}
+      onMouseLeave={() => setHoveredShop(null)}
+      onClick={handleClick}
+      onKeyDown={handleKeyPress}
+      tabIndex={0}
+      role="button"
+      className="group flex items-center gap-3 py-3 border-b border-stone-200 cursor-pointer"
+    >
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-medium text-gray-900">{props.shop.properties.name}</span>
+        <span className="block truncate text-sm text-gray-500">{props.shop.properties.neighborhood}</span>
+      </span>
+
+      {props.distance && props.units && (
+        <span className="shrink-0 text-sm text-gray-500">
+          {generateDistanceText({ units: props.units, distance: props.distance })}
+        </span>
+      )}
+
+      <ChevronRightIcon className="h-4 w-4 shrink-0 text-gray-400 transition-colors group-hover:text-gray-600" />
+    </li>
+  )
+}

--- a/app/components/NearbyShops.tsx
+++ b/app/components/NearbyShops.tsx
@@ -5,7 +5,7 @@ import { TUnits } from '@/types/unit-types'
 import useShopsStore from '@/stores/coffeeShopsStore'
 import haversineDistance from 'haversine-distance'
 import { DISTANCE_UNITS } from '@/app/settings/DistanceUnitsDialog'
-import NearbyShopRow from '@/app/components/NearbyShopRow'
+import NearbyShopList from '@/app/components/NearbyShopList'
 
 interface IProps {
   shop: TShop
@@ -73,16 +73,11 @@ export default function NearbyShops({ shop }: IProps) {
   return (
     <section className="relative mt-3 flex-1 px-4 sm:px-6">
       <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">Nearby shops</p>
-      <ul className="relative">
-        {sortedShopsWithDistances.shops.map((s, index) => (
-          <NearbyShopRow
-            key={s.properties.name + s.properties.address}
-            shop={s}
-            distance={String(sortedShopsWithDistances.distances[index])}
-            units={units}
-          />
-        ))}
-      </ul>
+      <NearbyShopList
+        shops={sortedShopsWithDistances.shops}
+        distances={sortedShopsWithDistances.distances}
+        units={units}
+      />
     </section>
   )
 }

--- a/app/components/NearbyShops.tsx
+++ b/app/components/NearbyShops.tsx
@@ -5,7 +5,7 @@ import { TUnits } from '@/types/unit-types'
 import useShopsStore from '@/stores/coffeeShopsStore'
 import haversineDistance from 'haversine-distance'
 import { DISTANCE_UNITS } from '@/app/settings/DistanceUnitsDialog'
-import ShopList from '@/app/components/ShopList'
+import NearbyShopRow from '@/app/components/NearbyShopRow'
 
 interface IProps {
   shop: TShop
@@ -72,12 +72,17 @@ export default function NearbyShops({ shop }: IProps) {
 
   return (
     <section className="relative mt-3 flex-1 px-4 sm:px-6">
-      <p className="mb-2 text-gray-700">Nearby shops</p>
-      <ShopList
-        coffeeShops={sortedShopsWithDistances.shops}
-        distances={sortedShopsWithDistances.distances}
-        units={units}
-      />
+      <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">Nearby shops</p>
+      <ul className="relative">
+        {sortedShopsWithDistances.shops.map((s, index) => (
+          <NearbyShopRow
+            key={s.properties.name + s.properties.address}
+            shop={s}
+            distance={String(sortedShopsWithDistances.distances[index])}
+            units={units}
+          />
+        ))}
+      </ul>
     </section>
   )
 }


### PR DESCRIPTION
## What

Replace the full photo cards in the **Nearby shops** panel section with compact text rows.

- New `NearbyShopRow` component: shop name with neighborhood beneath it, distance + chevron on the right. No photo, no avatar. The name picks up the same `amber-700` hover color as the address elsewhere in the panel.
- New `NearbyShopList` component owns the looping — `NearbyShops` hands it the sorted shops/distances and it renders the rows.
- `NearbyShops`' section label now uses the same uppercase tracked style as the other panel sections.

## Why

Nearby shops are a secondary "what else is close" section at the tail of the shop panel. The large photo cards competed visually with the selected shop's content and forced heavy scrolling. Compact rows let several nearby shops be scanned at a glance.

`ShopList`/`ShopCard` are untouched, so search and featured lists keep their photo cards — and the `FeaturedShopClick` analytics that lives there is unaffected.




| Before | After |
|---|---|
| <img width="547" height="848" alt="image" src="https://github.com/user-attachments/assets/3dee9bca-caec-4a2e-80f2-d2ba1a81015b" /> | <img width="554" height="853" alt="image" src="https://github.com/user-attachments/assets/1ca5226c-6313-4ec5-aba3-138a81479a77" /> |
