### PR TITLE
Hide updates/events sections when shop has no data

### DIFF
--- a/app/components/PanelContent.tsx
+++ b/app/components/PanelContent.tsx
@@ -44,10 +44,8 @@ export default function PanelContent(props: IProps) {
         </div>
       )}
 
-      <div className="py-5 border-b border-stone-200">
-        <ShopNews shop={props.shop} />
-        <ShopEvents shop={props.shop} />
-      </div>
+      <ShopNews shop={props.shop} />
+      <ShopEvents shop={props.shop} />
 
       <div className="px-4 sm:px-6 py-5 border-b border-stone-200">
         <ShopLocation address={address} coordinates={coordinates} />

--- a/app/components/ShopEvents.tsx
+++ b/app/components/ShopEvents.tsx
@@ -45,7 +45,7 @@ export const ShopEvents = ({ shop }: Props) => {
   if (loading || !events.length) return null
 
   return (
-    <section className="flex flex-col mt-4 px-4 sm:px-6">
+    <section className="flex flex-col border-b border-stone-200 px-4 py-5 sm:px-6">
       <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">Events</p>
 
       <ul className="list-none flex flex-col gap-3">

--- a/app/components/ShopNews.tsx
+++ b/app/components/ShopNews.tsx
@@ -65,7 +65,7 @@ export const ShopNews = ({ shop }: Props) => {
   if (!relevantNews.length) return null
 
   return (
-    <section className="flex flex-col mt-4 px-4 sm:px-6">
+    <section className="flex flex-col border-b border-stone-200 px-4 py-5 sm:px-6">
       <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">Updates</p>
 
       <ul className="divide-y divide-gray-100 rounded-lg border border-gray-100 bg-white">


### PR DESCRIPTION
## Problem

Shops with no news or events showed a block of dead space in the panel. The shared wrapper `<div className="py-5 border-b border-stone-200">` around `ShopNews`/`ShopEvents` always rendered its padding and border, even when both child components returned `null`.

## Fix

Make each section self-contained — `ShopNews` and `ShopEvents` now own their own `border-b border-stone-200 px-4 py-5 sm:px-6` section and already `return null` when empty. The wrapper div in `PanelContent` is removed, so nothing renders (and no space is reserved) when a shop has no updates/events.

This follows the existing pattern used by `ShopHours`, `PhotoGrid`, and `NearbyShops`, which are rendered bare and manage their own section borders.

## Note

When a shop has both updates and events, they now render as two stacked bordered sections rather than one combined block — consistent with every other section in the panel.