### PR TITLE
Add visit stats to account dashboard

### DIFF
--- a/app/account/components/Dashboard.tsx
+++ b/app/account/components/Dashboard.tsx
@@ -1,5 +1,11 @@
 import AccountDetails from '../AccountDetails'
+import VisitStats from './VisitStats'
 
 export default function Dashboard() {
-  return <AccountDetails />
+  return (
+    <div className="space-y-6">
+      <VisitStats />
+      <AccountDetails />
+    </div>
+  )
 }

--- a/app/account/components/VisitStats.tsx
+++ b/app/account/components/VisitStats.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Stamp, MapPin, Map } from 'lucide-react'
+import type { DbShop } from '@/types/shop-types'
+
+interface Visit {
+  id: string
+  created_at: string
+  shop: DbShop
+}
+
+interface Stats {
+  visited: number
+  total: number
+  topNeighborhood: string | null
+  neighborhoodsVisited: number
+  totalNeighborhoods: number
+}
+
+function computeStats(visits: Visit[], total: number, totalNeighborhoods: number): Stats {
+  const counts: Record<string, number> = {}
+  for (const visit of visits) {
+    const neighborhood = visit.shop?.neighborhood
+    if (neighborhood) {
+      counts[neighborhood] = (counts[neighborhood] ?? 0) + 1
+    }
+  }
+
+  let topNeighborhood: string | null = null
+  let topCount = 0
+  for (const [neighborhood, count] of Object.entries(counts)) {
+    if (count > topCount) {
+      topNeighborhood = neighborhood
+      topCount = count
+    }
+  }
+
+  return {
+    visited: visits.length,
+    total,
+    topNeighborhood,
+    neighborhoodsVisited: Object.keys(counts).length,
+    totalNeighborhoods,
+  }
+}
+
+export default function VisitStats() {
+  const [stats, setStats] = useState<Stats | null>(null)
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/api/visits').then((res) => {
+        if (!res.ok) throw new Error(`Failed to fetch visits: ${res.status}`)
+        return res.json()
+      }),
+      fetch('/api/shops/geojson').then((res) => {
+        if (!res.ok) throw new Error(`Failed to fetch shops: ${res.status}`)
+        return res.json()
+      }),
+    ])
+      .then(([visits, geojson]) => {
+        const visitList: Visit[] = Array.isArray(visits) ? visits : []
+        const features = geojson?.features ?? []
+        const total = features.length
+        const totalNeighborhoods = new Set(
+          features
+            .map((f: { properties?: { neighborhood?: string } }) => f.properties?.neighborhood)
+            .filter(Boolean),
+        ).size
+        setStats(computeStats(visitList, total, totalNeighborhoods))
+      })
+      .catch((err) => {
+        console.error('Failed to load visit stats:', err)
+        setStats(null)
+      })
+  }, [])
+
+  if (!stats) return null
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <StatCard
+        icon={<Stamp className="h-5 w-5 text-yellow-600" />}
+        label="Shops visited"
+        value={`${stats.visited} of ${stats.total}`}
+      />
+      <StatCard
+        icon={<Map className="h-5 w-5 text-yellow-600" />}
+        label="Neighborhoods explored"
+        value={`${stats.neighborhoodsVisited} of ${stats.totalNeighborhoods}`}
+      />
+      <StatCard
+        icon={<MapPin className="h-5 w-5 text-yellow-600" />}
+        label="Top neighborhood"
+        value={stats.topNeighborhood ?? '—'}
+      />
+    </div>
+  )
+}
+
+function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
+      <div className="flex items-center gap-2 mb-2">
+        <div className="w-9 h-9 bg-yellow-100 rounded-full flex items-center justify-center flex-shrink-0">
+          {icon}
+        </div>
+        <p className="text-sm font-medium text-gray-500">{label}</p>
+      </div>
+      <p className="text-2xl font-bold text-gray-900">{value}</p>
+    </div>
+  )
+}


### PR DESCRIPTION

<img width="1618" height="701" alt="image" src="https://github.com/user-attachments/assets/7d143ddf-4b6d-4bd0-8a8e-fad2ffc8e7fb" />


## What

Adds a stats row to the top of the account dashboard (`/account`) summarizing the user's passport progress:

- **Shops visited** — `X of Y` (visited count out of all shops)
- **Neighborhoods explored** — `X of Y` distinct neighborhoods with at least one visited shop, out of all neighborhoods that have shops
- **Top neighborhood** — the neighborhood with the most visited shops

## How

New `VisitStats` client component fetches `/api/visits` and `/api/shops/geojson` in parallel, tallies visits per neighborhood, and renders the cards in a responsive grid matching existing card styling. Renders nothing if data fails to load. Wired in above `AccountDetails` in the Dashboard.