### PR TITLE
Verified badge for claimed shops

### DIFF
--- a/app/components/PanelHeader.tsx
+++ b/app/components/PanelHeader.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useAnalytics } from '@/hooks'
 import { TShop } from '@/types/shop-types'
 import PhotoDialog from './PhotoDialog'
+import VerifiedBadge from './VerifiedBadge'
 import { BuildingStorefrontIcon } from '@heroicons/react/24/outline'
 
 interface IProps {
@@ -11,7 +12,7 @@ interface IProps {
 }
 
 export default function PanelHeader(props: IProps) {
-  const { name, neighborhood, photo, company } = props.shop.properties
+  const { name, neighborhood, photo, company, verified } = props.shop.properties
   const plausible = useAnalytics()
   const router = useRouter()
 
@@ -45,7 +46,10 @@ export default function PanelHeader(props: IProps) {
             </button>
           )}
 
-          <h1 className="text-2xl sm:text-3xl font-serif font-normal tracking-tight leading-tight">{name}</h1>
+          <h1 className="flex items-center gap-1.5 text-2xl sm:text-3xl font-serif font-normal tracking-tight leading-tight">
+            {name}
+            {verified && <VerifiedBadge className="mt-0.5" />}
+          </h1>
           <p className="text-base text-white/80 mt-0.5">{neighborhood}</p>
         </div>
       </div>

--- a/app/components/PanelHeader.tsx
+++ b/app/components/PanelHeader.tsx
@@ -1,9 +1,7 @@
 'use client'
-import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAnalytics } from '@/hooks'
 import { TShop } from '@/types/shop-types'
-import PhotoDialog from './PhotoDialog'
 import VerifiedBadge from './VerifiedBadge'
 import { BuildingStorefrontIcon } from '@heroicons/react/24/outline'
 

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -26,6 +26,7 @@ const toFeature = (shop: DbShop): TShop => ({
     amenities: shop.amenities ?? undefined,
     roaster: toFeatureRoaster(shop),
     description: shop.description ?? undefined,
+    verified: shop.is_verified ?? undefined,
   },
   geometry: {
     type: 'Point',

--- a/migrations/verified-schema-rollback.sql
+++ b/migrations/verified-schema-rollback.sql
@@ -1,0 +1,5 @@
+-- Rollback for verified-schema.sql. Drops the verification columns from shops
+-- (and any verification state stored in them). Irreversible.
+
+ALTER TABLE shops DROP COLUMN IF EXISTS verified_at;
+ALTER TABLE shops DROP COLUMN IF EXISTS is_verified;

--- a/migrations/verified-schema.sql
+++ b/migrations/verified-schema.sql
@@ -1,0 +1,19 @@
+-- Schema for the verified-shop badge.
+--
+-- Apply by hand (no migration framework in this repo). Purely additive: adds two
+-- columns to the existing shops table. Safe to run on a live table — the default
+-- backfills existing rows to unverified, and no rows are rewritten beyond that.
+--
+-- is_verified — true once a shop's ownership has been confirmed (today via a
+--               hand-reviewed shop_claims row). Surfaced through the public shops
+--               API as `properties.verified` and drives the panel badge.
+-- verified_at — when verification was granted, for audit and so a shop can be
+--               cleanly un-verified later.
+--
+-- NOTE: a link back to the claim that granted verification
+-- (e.g. verified_claim_id uuid REFERENCES shop_claims(id)) is intentionally left
+-- out until shop_claims is actually live in Supabase — a FK to a not-yet-created
+-- table would fail to apply. Add it in the same migration that creates shop_claims.
+
+ALTER TABLE shops ADD COLUMN IF NOT EXISTS is_verified boolean NOT NULL DEFAULT false;
+ALTER TABLE shops ADD COLUMN IF NOT EXISTS verified_at timestamptz;

--- a/types/shop-types.ts
+++ b/types/shop-types.ts
@@ -33,6 +33,7 @@ export interface DbShop {
   roasterRef?: { name: string; slug: string; company_id: string | null } | null
   amenities?: string[]
   description?: string | null
+  is_verified?: boolean
 }
 
 // The roaster a shop serves, plus whether it's the shop's own in-house roaster.

--- a/types/shop-types.ts
+++ b/types/shop-types.ts
@@ -61,6 +61,7 @@ export interface TShop {
     amenities?: string[]
     roaster?: TShopRoaster | null
     description?: string | null
+    verified?: boolean
     selected?: boolean
   }
   geometry: {


### PR DESCRIPTION
Depends on #324 (which adds the `VerifiedBadge` component) and stacks on #261 (claim-your-shop).

Renders the verified badge on a shop's detail panel when the shop is verified, plus the schema + API plumbing to drive it. The badge component itself now lives in #324, so this PR no longer defines it.

## Changes
- `PanelHeader.tsx` — renders `VerifiedBadge` beside the shop name, gated on `properties.verified`.
- `shop-types.ts` — adds `verified` to the shop feature properties and `is_verified` to the `DbShop` row type.
- `app/utils/utils.ts` — maps `is_verified` → `properties.verified` in the GeoJSON transform. Both fetch paths already `select('*')`, so no query changes were needed.
- `migrations/verified-schema.sql` (+ rollback) — adds `is_verified boolean not null default false` and `verified_at timestamptz` to `shops`. Additive and safe on the live table.

## Workflow once merged
1. Apply `migrations/verified-schema.sql` by hand (same convention as the other files in `migrations/`).
2. When a `shop_claims` row is approved, set the shop's `is_verified = true` (and `verified_at = now()`).
3. The badge lights up automatically via `properties.verified`.

## Deliberately deferred
- No automation sets `is_verified` yet — flipped by hand on claim approval for now.
- The link back to the granting claim (`verified_claim_id`) is left out until `shop_claims` is live in Supabase, since a FK to a not-yet-created table can't apply. Add it in the migration that creates `shop_claims`.