### PR TITLE
ShopList owns layout and card width

### DIFF
--- a/app/account/components/Favorites.tsx
+++ b/app/account/components/Favorites.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { Heart, MapPin } from 'lucide-react'
-import ShopCard from '@/app/components/ShopCard'
+import ShopList from '@/app/components/ShopList'
 import { formatDBShopAsFeature } from '@/app/utils/utils'
 import type { DbShop } from '@/types/shop-types'
 
@@ -58,11 +58,7 @@ export default function Favorites() {
   return (
     <div>
       {hasFavorites ? (
-        <ul>
-          {favorites.map((fav) => (
-            <ShopCard key={fav.id} shop={formatDBShopAsFeature(fav.shop)} />
-          ))}
-        </ul>
+        <ShopList coffeeShops={favorites.map((fav) => formatDBShopAsFeature(fav.shop))} />
       ) : (
         <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6 md:p-8">
           <div className="flex flex-col items-center justify-center py-12 text-center">

--- a/app/account/components/Visited.tsx
+++ b/app/account/components/Visited.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { Stamp, MapPin } from 'lucide-react'
-import ShopCard from '@/app/components/ShopCard'
+import ShopList from '@/app/components/ShopList'
 import { formatDBShopAsFeature } from '@/app/utils/utils'
 import type { DbShop } from '@/types/shop-types'
 
@@ -22,17 +22,17 @@ export default function Visited() {
 
   useEffect(() => {
     fetch('/api/visits')
-      .then((res) => {
+      .then(res => {
         if (!res.ok) {
           throw new Error(`Failed to fetch visits: ${res.status}`)
         }
         return res.json()
       })
-      .then((data) => {
+      .then(data => {
         setVisits(Array.isArray(data) ? data : [])
         setLoading(false)
       })
-      .catch((err) => {
+      .catch(err => {
         console.error('Failed to fetch visits:', err)
         setError(true)
         setLoading(false)
@@ -63,11 +63,7 @@ export default function Visited() {
             <h1 className="text-2xl font-bold text-gray-900">Passport</h1>
             <p className="text-gray-500">Keep track of the coffee shops you&apos;ve visited.</p>
           </div>
-          <ul>
-            {visits.map((visit) => (
-              <ShopCard key={visit.id} shop={formatDBShopAsFeature(visit.shop)} />
-            ))}
-          </ul>
+          <ShopList coffeeShops={visits.map(visit => formatDBShopAsFeature(visit.shop))} />
         </div>
       ) : (
         <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6 md:p-8">

--- a/app/components/ShopCard.tsx
+++ b/app/components/ShopCard.tsx
@@ -13,6 +13,7 @@ interface IProps {
   onMouseEnter?: () => void
   onMouseLeave?: () => void
   featured?: boolean
+  className?: string
 }
 
 export const roundDistance = ({ units, distance }: { units: string; distance: number }) => {
@@ -53,7 +54,7 @@ export default function ShopCard(props: IProps) {
     <li
       onMouseEnter={() => setHoveredShop(props.shop)}
       onMouseLeave={() => setHoveredShop(null)}
-      className={`${props.featured ? 'h-46' : 'h-28'} relative mb-4 rounded-sm overflow-hidden shadow-md cursor-pointer`}
+      className={`${props.featured ? 'h-46' : 'h-28'} ${props.className ?? ''} relative mb-4 rounded-sm overflow-hidden shadow-md cursor-pointer`}
       onClick={handleClick}
       onKeyDown={handleKeyPress}
       tabIndex={0}

--- a/app/components/ShopList.tsx
+++ b/app/components/ShopList.tsx
@@ -7,11 +7,17 @@ interface IProps {
   distances?: number[]
   units?: TUnits
   hideShopNames?: boolean
+  layout?: 'column' | 'grid'
+  cardWidth?: string
 }
 
 export default function ShopList(props: IProps) {
+  const layout = props.layout ?? 'column'
+  const isGrid = layout === 'grid'
+  const cardWidth = isGrid ? (props.cardWidth ?? 'w-[calc(50%-0.5rem)]') : undefined
+
   return (
-    <ul className="relative mt-6 flex-1">
+    <ul className={`relative mt-6 flex-1 ${isGrid ? 'flex flex-wrap gap-x-4' : ''}`}>
       {props.coffeeShops.map((shop: TShop, index) => {
         return (
           <ShopCard
@@ -20,6 +26,7 @@ export default function ShopList(props: IProps) {
             hideShopName={props.hideShopNames}
             shop={shop}
             units={props.units}
+            className={cardWidth}
           />
         )
       })}


### PR DESCRIPTION
## What

- **`ShopList`** gains two optional props:
  - `layout?: 'column' | 'grid'` — defaults to `'column'` (existing behavior). `'grid'` renders the `<ul>` as a `flex flex-wrap` container.
  - `cardWidth?: string` — Tailwind width class applied to each card in grid layout (defaults to `w-[calc(50%-0.5rem)]`, i.e. two columns accounting for the gap).
- **`ShopCard`** no longer decides its own width. The `size` experiment is replaced with a generic `className?` hook that `ShopList` composes onto the card. Column layout keeps full-width cards as before.
- **`Visited`** and **`Favorites`** drop their bespoke `<ul>` + `ShopCard` loops and render through `ShopList` instead.

## Notes

- Existing `ShopList` callers (`ShopSearch`, `CuratedList`) pass no new props, so behavior is unchanged.
- `Visited`/`Favorites` now key cards by name+address (via `ShopList`) instead of the visit/favorite row id.
- `LocationList` (ShopList + filter) and `FeaturedShop` (single card) were intentionally left as-is.