### PR TITLE
Include roaster info on shops from a roaster's shop list

### DIFF
--- a/app/api/roasters/[slug]/route.ts
+++ b/app/api/roasters/[slug]/route.ts
@@ -13,7 +13,7 @@ const supabase = createClient(supabaseUrl, supabaseAnonKey)
 const getRoasterShops = async (roasterId: string) => {
   const { data, error } = await supabase
     .from('shops')
-    .select('*, company:company_id(*)')
+    .select('*, company:company_id(*), roasterRef:roaster_id(name, slug, company_id)')
     .eq('roaster_id', roasterId)
 
   if (error) {

--- a/tests/unit/roasterRoute.test.ts
+++ b/tests/unit/roasterRoute.test.ts
@@ -5,18 +5,24 @@ import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
 //   shops:   select().eq()           -> terminal eq (awaited)
 const mockRoasterSingle = vi.fn()
 const mockShopsEq = vi.fn()
+// Records the select() string used for the shops query, so a test can assert
+// the roaster join is still requested.
+let shopsSelect: string | undefined
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: () => ({
     from: (table: string) => ({
-      select: () => ({
-        eq: (...args: unknown[]) => {
-          if (table === 'roaster') {
-            return { single: mockRoasterSingle }
-          }
-          return mockShopsEq(...args)
-        },
-      }),
+      select: (columns: string) => {
+        if (table === 'shops') shopsSelect = columns
+        return {
+          eq: (...args: unknown[]) => {
+            if (table === 'roaster') {
+              return { single: mockRoasterSingle }
+            }
+            return mockShopsEq(...args)
+          },
+        }
+      },
     }),
   }),
 }))
@@ -30,6 +36,7 @@ describe('Roaster API Route - GET', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    shopsSelect = undefined
   })
 
   const call = (slug: string) =>
@@ -48,6 +55,20 @@ describe('Roaster API Route - GET', () => {
 
     expect(response.status).toBe(200)
     expect(data).toEqual({ ...roaster, shops })
+  })
+
+  // Regression: the shops query once omitted the roaster join, so shops opened
+  // from a roaster's "Where to find this roaster's coffee" list rendered with no
+  // roaster section. toFeatureRoaster reads `roasterRef`, so the query must alias
+  // the roaster join to that name for the roaster card to survive. (issue #317)
+  test('fetches the roaster join for each shop so the roaster card can render', async () => {
+    const roaster = { id: 'r1', name: 'Test Roaster', slug: 'test-roaster' }
+    mockRoasterSingle.mockResolvedValueOnce({ data: roaster, error: null })
+    mockShopsEq.mockResolvedValueOnce({ data: [{ name: 'Shop A' }], error: null })
+
+    await call('test-roaster')
+
+    expect(shopsSelect).toMatch(/roasterRef:roaster_id\(/)
   })
 
   test('returns 404 when the roaster is not found', async () => {

--- a/tests/unit/roasterRoute.test.ts
+++ b/tests/unit/roasterRoute.test.ts
@@ -57,10 +57,6 @@ describe('Roaster API Route - GET', () => {
     expect(data).toEqual({ ...roaster, shops })
   })
 
-  // Regression: the shops query once omitted the roaster join, so shops opened
-  // from a roaster's "Where to find this roaster's coffee" list rendered with no
-  // roaster section. toFeatureRoaster reads `roasterRef`, so the query must alias
-  // the roaster join to that name for the roaster card to survive. (issue #317)
   test('fetches the roaster join for each shop so the roaster card can render', async () => {
     const roaster = { id: 'r1', name: 'Test Roaster', slug: 'test-roaster' }
     mockRoasterSingle.mockResolvedValueOnce({ data: roaster, error: null })


### PR DESCRIPTION
Fixes #317.

Shops opened from a roaster page's "Where to find this roaster's coffee" list rendered without their roaster section, even though every shop in that list serves the roaster.

`getRoasterShops` in `app/api/roasters/[slug]/route.ts` selected `*, company:company_id(*)` — no roaster join. `toFeatureRoaster` (the shared shop→feature helper) reads `shop.roasterRef`, so with no join the roaster card was skipped in `PanelContent`.

Fix: add the `roasterRef:roaster_id(name, slug, company_id)` join, matching the alias the map and shop-detail paths already use (`shops/geojson`, `utils/shops`, `featured-shop`).