### PR TITLE
Include roaster info on shops from a company's shop list

### DIFF
--- a/app/api/companies/[company]/route.ts
+++ b/app/api/companies/[company]/route.ts
@@ -12,7 +12,7 @@ const supabase = createClient(supabaseUrl, supabaseAnonKey)
 const getCompanyShops = async (companyId: string) => {
   const { data, error } = await supabase
     .from('shops')
-    .select('*, company:company_id(*)')
+    .select('*, company:company_id(*), roasterRef:roaster_id(name, slug, company_id)')
     .eq('company_id', companyId)
 
   if (error) {

--- a/tests/unit/companyRoute.test.ts
+++ b/tests/unit/companyRoute.test.ts
@@ -70,8 +70,6 @@ describe('Company API Route - GET', () => {
 
     await call('test-co')
 
-    // Without this join roasterRef is absent and toFeature maps roaster to null,
-    // hiding the roasts section for shops opened from the company page.
     expect(selectArgs.shops).toContain('roasterRef:roaster_id(name, slug, company_id)')
   })
 

--- a/tests/unit/companyRoute.test.ts
+++ b/tests/unit/companyRoute.test.ts
@@ -7,21 +7,26 @@ import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
 const mockCompanySingle = vi.fn()
 const mockShopsEq = vi.fn()
 const mockRoasterMaybeSingle = vi.fn()
+// Records the column string each table's select() was called with.
+const selectArgs: Record<string, string> = {}
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: () => ({
     from: (table: string) => ({
-      select: () => ({
-        eq: (...args: unknown[]) => {
-          if (table === 'companies') {
-            return { single: mockCompanySingle }
-          }
-          if (table === 'roaster') {
-            return { maybeSingle: mockRoasterMaybeSingle }
-          }
-          return mockShopsEq(...args)
-        },
-      }),
+      select: (columns: string) => {
+        selectArgs[table] = columns
+        return {
+          eq: (...args: unknown[]) => {
+            if (table === 'companies') {
+              return { single: mockCompanySingle }
+            }
+            if (table === 'roaster') {
+              return { maybeSingle: mockRoasterMaybeSingle }
+            }
+            return mockShopsEq(...args)
+          },
+        }
+      },
     }),
   }),
 }))
@@ -55,6 +60,19 @@ describe('Company API Route - GET', () => {
 
     expect(response.status).toBe(200)
     expect(data).toEqual({ ...company, shops, roaster })
+  })
+
+  test('fetches the roasterRef join so shops carry roaster info for the roasts section', async () => {
+    const company = { id: 'c1', name: 'Test Co', slug: 'test-co' }
+    mockCompanySingle.mockResolvedValueOnce({ data: company, error: null })
+    mockShopsEq.mockResolvedValueOnce({ data: [{ name: 'Shop A' }], error: null })
+    mockRoasterMaybeSingle.mockResolvedValueOnce({ data: null, error: null })
+
+    await call('test-co')
+
+    // Without this join roasterRef is absent and toFeature maps roaster to null,
+    // hiding the roasts section for shops opened from the company page.
+    expect(selectArgs.shops).toContain('roasterRef:roaster_id(name, slug, company_id)')
   })
 
   test('returns 404 when the company is not found', async () => {


### PR DESCRIPTION
Clicking a shop from the company page didn't show the roasts (in-house roaster) section.

`PanelContent` gates `ShopRoaster` on `shop.properties.roaster`, which `toFeature` derives from `shop.roasterRef`. The company route's shop query (`getCompanyShops`) only joined `company`, not `roasterRef`, so the property came back null and the section was hidden.

Added the same `roasterRef:roaster_id(name, slug, company_id)` join already used by the geojson, roaster, and featured-shop routes.