### PR TITLE
Preview passport and favorites on the account dashboard

### DIFF
--- a/app/account/components/Dashboard.tsx
+++ b/app/account/components/Dashboard.tsx
@@ -5,6 +5,10 @@ import ShopListPreview from './ShopListPreview'
 export default function Dashboard() {
   return (
     <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+        <p className="text-gray-500">Your coffee at a glance.</p>
+      </div>
       <ShareProfileCard />
       <VisitStats />
       <ShopListPreview

--- a/app/account/components/Dashboard.tsx
+++ b/app/account/components/Dashboard.tsx
@@ -1,13 +1,24 @@
-import AccountDetails from '../AccountDetails'
 import VisitStats from './VisitStats'
 import ShareProfileCard from './ShareProfileCard'
+import ShopListPreview from './ShopListPreview'
 
 export default function Dashboard() {
   return (
     <div className="space-y-6">
-      <VisitStats />
       <ShareProfileCard />
-      <AccountDetails />
+      <VisitStats />
+      <ShopListPreview
+        title="Passport"
+        endpoint="/api/visits"
+        viewAllHref="/account/visited"
+        emptyText="No visits yet. Mark shops you've been to and watch your passport fill up."
+      />
+      <ShopListPreview
+        title="Favorites"
+        endpoint="/api/favorites"
+        viewAllHref="/account/favorites"
+        emptyText="No favorites yet. Save shops you love to see them here."
+      />
     </div>
   )
 }

--- a/app/account/components/Favorites.tsx
+++ b/app/account/components/Favorites.tsx
@@ -58,11 +58,17 @@ export default function Favorites() {
   return (
     <div>
       {hasFavorites ? (
-        <ul>
-          {favorites.map((fav) => (
-            <ShopCard key={fav.id} shop={formatDBShopAsFeature(fav.shop)} />
-          ))}
-        </ul>
+        <div className="space-y-4">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Favorites</h1>
+            <p className="text-gray-500">The coffee shops you&apos;ve saved.</p>
+          </div>
+          <ul>
+            {favorites.map((fav) => (
+              <ShopCard key={fav.id} shop={formatDBShopAsFeature(fav.shop)} />
+            ))}
+          </ul>
+        </div>
       ) : (
         <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6 md:p-8">
           <div className="flex flex-col items-center justify-center py-12 text-center">

--- a/app/account/components/Settings.tsx
+++ b/app/account/components/Settings.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import ShareLink from './ShareLink'
+import AccountDetails from '../AccountDetails'
 import { useOwnProfile } from '@/hooks'
 
 export default function Settings() {
@@ -82,6 +83,8 @@ export default function Settings() {
 
         {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
       </div>
+
+      <AccountDetails />
     </div>
   )
 }

--- a/app/account/components/ShopListPreview.tsx
+++ b/app/account/components/ShopListPreview.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { ArrowRight } from 'lucide-react'
+import ShopCard from '@/app/components/ShopCard'
+import { formatDBShopAsFeature } from '@/app/utils/utils'
+import type { DbShop } from '@/types/shop-types'
+
+interface Entry {
+  id: string
+  shop: DbShop
+}
+
+const PREVIEW_COUNT = 3
+
+export default function ShopListPreview({
+  title,
+  endpoint,
+  viewAllHref,
+  emptyText,
+}: {
+  title: string
+  endpoint: string
+  viewAllHref: string
+  emptyText: string
+}) {
+  const [entries, setEntries] = useState<Entry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    fetch(endpoint)
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to fetch ${endpoint}: ${res.status}`)
+        return res.json()
+      })
+      .then((data) => setEntries(Array.isArray(data) ? data : []))
+      .catch((err) => {
+        console.error(`Failed to fetch ${endpoint}:`, err)
+        setError(true)
+      })
+      .finally(() => setLoading(false))
+  }, [endpoint])
+
+  if (loading || error) return null
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6 md:p-8">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+        {entries.length > PREVIEW_COUNT && (
+          <Link
+            href={viewAllHref}
+            className="inline-flex items-center gap-1 text-sm font-medium text-yellow-600 hover:text-yellow-700"
+          >
+            See all
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        )}
+      </div>
+      {entries.length > 0 ? (
+        <ul>
+          {entries.slice(0, PREVIEW_COUNT).map((entry) => (
+            <ShopCard key={entry.id} shop={formatDBShopAsFeature(entry.shop)} />
+          ))}
+        </ul>
+      ) : (
+        <p className="text-gray-500">{emptyText}</p>
+      )}
+    </div>
+  )
+}

--- a/app/account/components/ShopListPreview.tsx
+++ b/app/account/components/ShopListPreview.tsx
@@ -43,7 +43,20 @@ export default function ShopListPreview({
       .finally(() => setLoading(false))
   }, [endpoint])
 
-  if (loading || error) return null
+  if (error) return null
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6 md:p-8 animate-pulse">
+        <div className="h-6 w-32 rounded bg-gray-200 mb-4" />
+        <div className="space-y-3">
+          {Array.from({ length: PREVIEW_COUNT }).map((_, i) => (
+            <div key={i} className="h-16 rounded-lg bg-gray-100" />
+          ))}
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6 md:p-8">


### PR DESCRIPTION
## What

- Dashboard now previews the first 3 shops from the user's passport and favorites, each with a "See all" CTA to the full list.
- Added a single reusable `ShopListPreview` component backing both sections.
- Moved account details (and sign-out) from the dashboard under **Settings**.
- Reordered the dashboard so the share-profile card sits above visit stats.