### PR TITLE
Track profile views in analytics

### DIFF
--- a/app/u/[id]/ProfileViewTracker.tsx
+++ b/app/u/[id]/ProfileViewTracker.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useAnalytics } from '@/hooks'
+
+export default function ProfileViewTracker({ profileId }: { profileId: string }) {
+  const plausible = useAnalytics()
+
+  useEffect(() => {
+    plausible('ProfileView', { props: { profileId } })
+  }, [plausible, profileId])
+
+  return null
+}

--- a/app/u/[id]/page.tsx
+++ b/app/u/[id]/page.tsx
@@ -4,6 +4,7 @@ import { User } from 'lucide-react'
 import VisitStats from '@/app/account/components/VisitStats'
 import { getPublicProfile } from '@/app/utils/profiles'
 import Passport from './Passport'
+import ProfileViewTracker from './ProfileViewTracker'
 
 type Props = {
   params: Promise<{ id: string }>
@@ -31,6 +32,7 @@ export default async function PublicProfilePage({ params }: Props) {
 
   return (
     <div className="min-h-[calc(100vh-4rem)] bg-gray-50">
+      <ProfileViewTracker profileId={id} />
       <div className="max-w-3xl mx-auto p-4 sm:p-6 md:p-8 space-y-6">
         <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6 md:p-8">
           <div className="flex items-center gap-4">


### PR DESCRIPTION
## What

Fires a `ProfileView` Plausible (and Faro) event when someone opens a public profile page (`/u/[id]`), with the profile id as a prop.

Since the profile page is a server component, the event is emitted from a small client `ProfileViewTracker` mounted on the page — matching the existing `RoasterView` / `NewsView` view-tracking pattern.