### PR TITLE
Add VerifiedBadge component

### DIFF
--- a/app/components/VerifiedBadge.tsx
+++ b/app/components/VerifiedBadge.tsx
@@ -1,0 +1,14 @@
+import { CheckBadgeIcon } from '@heroicons/react/24/solid'
+
+interface IProps {
+  className?: string
+}
+
+export default function VerifiedBadge({ className = '' }: IProps) {
+  return (
+    <span title="Verified by pgh.coffee" className={`inline-flex shrink-0 ${className}`}>
+      <CheckBadgeIcon className="size-5 text-yellow-300 drop-shadow" />
+      <span className="sr-only">Verified</span>
+    </span>
+  )
+}


### PR DESCRIPTION
Extracts the presentational `VerifiedBadge` component into its own PR so both the claim flow (#261) and the shop-detail badge (#312) can build on it independently, instead of #312 stacking on #261 just to share it.

Pure leaf component, no data dependencies. Consumers:
- #261 renders it in the `/claim` shop preview.
- #312 renders it in the shop panel header, driven by `properties.verified`.