### PR TITLE
Claim a company or roaster, not just a shop

### DIFF
--- a/app/api/shops/claim/route.ts
+++ b/app/api/shops/claim/route.ts
@@ -31,7 +31,10 @@ export async function POST(request: Request) {
   const { claim_type, target_id, contact_name, role, business_email, phone, social_media, message } = body
 
   const target = TARGETS[claim_type as keyof typeof TARGETS]
-  if (!target || !target_id || !contact_name || !business_email) {
+  if (!target) {
+    return NextResponse.json({ error: 'Invalid or missing claim type' }, { status: 400 })
+  }
+  if (!target_id || !contact_name || !business_email) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
   }
 

--- a/app/api/shops/claim/route.ts
+++ b/app/api/shops/claim/route.ts
@@ -45,10 +45,14 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid target id' }, { status: 400 })
   }
 
-  // Validate that the entity being claimed actually exists.
+  // Validate that the entity being claimed actually exists. For a shop or roaster
+  // also pull its company_id so ownership resolution is enforced here, not just in
+  // the page — a company owns its shops and roaster, so a company-owned target is
+  // claimed against the company. A company has no company_id to roll up to.
+  const selectColumns = claim_type === 'company' ? target.idColumn : `${target.idColumn}, company_id`
   const { data: entity, error: entityError } = await supabase
     .from(target.table)
-    .select(target.idColumn)
+    .select(selectColumns)
     .eq(target.idColumn, target_id)
     .single()
 
@@ -64,10 +68,23 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Listing not found' }, { status: 404 })
   }
 
+  // Resolve up the ownership tree: a company-owned shop/roaster is persisted against
+  // company_id, so a direct API call can't record a leaf claim the page would have
+  // rolled up. Only a company-less shop/roaster stays a leaf claim.
+  const ownerCompanyId = (entity as { company_id?: string | null }).company_id
+  let persistedType = claim_type as keyof typeof TARGETS
+  let persistedColumn: string = target.fkColumn
+  let persistedId: string = target_id
+  if ((claim_type === 'shop' || claim_type === 'roaster') && ownerCompanyId) {
+    persistedType = 'company'
+    persistedColumn = 'company_id'
+    persistedId = ownerCompanyId
+  }
+
   const { error } = await supabase
     .from('claims')
     .insert([{
-      [target.fkColumn]: target_id,
+      [persistedColumn]: persistedId,
       contact_name,
       role,
       business_email,
@@ -84,8 +101,9 @@ export async function POST(request: Request) {
   }
 
   // Log only non-PII identifiers — contact_name/business_email would ship to Loki.
-  logger.info('Claim submitted', { claim_type, target_id })
-  metrics.claimSubmitted(claim_type)
+  // Use the resolved type/id so a company-owned shop counts as a company claim.
+  logger.info('Claim submitted', { claim_type: persistedType, target_id: persistedId })
+  metrics.claimSubmitted(persistedType)
   // Return a minimal, stable payload rather than echoing the insert result.
   return NextResponse.json({ ok: true }, { status: 201 })
 }

--- a/app/api/shops/claim/route.ts
+++ b/app/api/shops/claim/route.ts
@@ -7,29 +7,38 @@ const supabaseUrl = process.env.SUPABASE_URL as string
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
 const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
+// A claim targets exactly one entity. Each type maps to the table we validate the
+// target against and the claims column the id lands in.
+const TARGETS = {
+  shop: { table: 'shops', idColumn: 'uuid', fkColumn: 'shop_id' },
+  company: { table: 'companies', idColumn: 'id', fkColumn: 'company_id' },
+  roaster: { table: 'roaster', idColumn: 'id', fkColumn: 'roaster_id' },
+} as const
+
 export async function POST(request: Request) {
   const body = await request.json()
-  const { shop_id, contact_name, role, business_email, phone, social_media, message } = body
+  const { claim_type, target_id, contact_name, role, business_email, phone, social_media, message } = body
 
-  if (!shop_id || !contact_name || !business_email) {
+  const target = TARGETS[claim_type as keyof typeof TARGETS]
+  if (!target || !target_id || !contact_name || !business_email) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
   }
 
-  // Validate that the shop being claimed actually exists
-  const { data: shop, error: shopError } = await supabase
-    .from('shops')
-    .select('uuid')
-    .eq('uuid', shop_id)
+  // Validate that the entity being claimed actually exists.
+  const { data: entity, error: entityError } = await supabase
+    .from(target.table)
+    .select(target.idColumn)
+    .eq(target.idColumn, target_id)
     .single()
 
-  if (shopError || !shop) {
-    return NextResponse.json({ error: 'Shop not found' }, { status: 404 })
+  if (entityError || !entity) {
+    return NextResponse.json({ error: 'Listing not found' }, { status: 404 })
   }
 
   const { data, error } = await supabase
-    .from('shop_claims')
+    .from('claims')
     .insert([{
-      shop_id,
+      [target.fkColumn]: target_id,
       contact_name,
       role,
       business_email,
@@ -45,7 +54,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Error submitting claim' }, { status: 500 })
   }
 
-  logger.info('Shop claim submitted', { shop_id, contact_name, business_email })
-  metrics.shopClaimSubmitted()
+  logger.info('Claim submitted', { claim_type, target_id, contact_name, business_email })
+  metrics.claimSubmitted()
   return NextResponse.json(data, { status: 201 })
 }

--- a/app/api/shops/claim/route.ts
+++ b/app/api/shops/claim/route.ts
@@ -85,7 +85,7 @@ export async function POST(request: Request) {
 
   // Log only non-PII identifiers — contact_name/business_email would ship to Loki.
   logger.info('Claim submitted', { claim_type, target_id })
-  metrics.claimSubmitted()
+  metrics.claimSubmitted(claim_type)
   // Return a minimal, stable payload rather than echoing the insert result.
   return NextResponse.json({ ok: true }, { status: 201 })
 }

--- a/app/claim/ClaimForm.tsx
+++ b/app/claim/ClaimForm.tsx
@@ -1,23 +1,11 @@
 'use client'
 
 import { useRef, useState } from 'react'
+import { ClaimTarget } from '@/app/utils/claims'
 import ClaimSuccessDialog from './ClaimSuccessDialog'
 
 interface TProps {
-  shopId: string
-  shopName: string
-  neighborhood?: string
-  companyName?: string
-}
-
-interface IClaimSubmission {
-  shop_id: string
-  contact_name: string
-  role: string
-  business_email: string
-  phone: string
-  social_media: string
-  message: string
+  target: ClaimTarget
 }
 
 const inputClasses =
@@ -34,16 +22,28 @@ const steps = [
   },
   {
     title: 'Get verified + early access',
-    body: 'Your shop earns a verified badge, and you’ll be first to manage your own listing when self-serve editing launches.',
+    body: 'Your listing earns a verified badge, and you’ll be first to manage it when self-serve editing launches.',
   },
 ]
 
-export default function ClaimForm({ shopId, shopName, neighborhood, companyName }: TProps) {
+// A company claim covers everything the company owns; spell that out so the owner
+// knows they're not claiming just one location.
+function coverageNote(target: ClaimTarget): string | null {
+  if (target.type !== 'company') return null
+  const count = target.locationCount ?? 0
+  const locations = count === 1 ? '1 location' : `${count} locations`
+  const parts = [count > 0 ? locations : null, target.hasRoaster ? 'your roastery' : null].filter(Boolean)
+  if (parts.length === 0) return 'This covers the whole brand.'
+  return `This covers ${parts.join(' and ')} — the whole brand, not just one spot.`
+}
+
+export default function ClaimForm({ target }: TProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [successDialogIsOpen, setSuccessDialogIsOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const claimForm = useRef<HTMLFormElement>(null)
+  const coverage = coverageNote(target)
 
   async function handleForm(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -51,8 +51,9 @@ export default function ClaimForm({ shopId, shopName, neighborhood, companyName 
     setError(null)
     const formData = new FormData(event.currentTarget)
 
-    const data: IClaimSubmission = {
-      shop_id: shopId,
+    const data = {
+      claim_type: target.type,
+      target_id: target.id,
       contact_name: formData.get('contact_name') as string,
       role: formData.get('role') as string,
       business_email: formData.get('business_email') as string,
@@ -88,23 +89,13 @@ export default function ClaimForm({ shopId, shopName, neighborhood, companyName 
       <div className="bg-white rounded-2xl shadow-lg p-8 md:p-12 max-w-2xl mx-auto">
         <div className="mb-8 rounded-lg bg-stone-50 border border-stone-200 px-4 py-3">
           <p className="text-sm text-slate-600">You&apos;re claiming</p>
-          <p className="text-lg font-semibold text-gray-900">{shopName}</p>
-          {neighborhood && <p className="text-sm text-slate-600">{neighborhood}</p>}
+          <p className="text-lg font-semibold text-gray-900">{target.name}</p>
+          {target.subtitle && <p className="text-sm text-slate-600">{target.subtitle}</p>}
         </div>
 
-        {companyName && (
+        {coverage && (
           <div className="mb-8 rounded-lg bg-amber-50 border border-amber-200 px-4 py-3">
-            <p className="text-sm text-amber-900">
-              Part of {companyName}. You&apos;re claiming just{' '}
-              {neighborhood ? (
-                <>
-                  the <span className="font-semibold">{neighborhood}</span> location
-                </>
-              ) : (
-                'this location'
-              )}
-              {' '}— each location is claimed separately.
-            </p>
+            <p className="text-sm text-amber-900">{coverage}</p>
           </div>
         )}
 
@@ -138,7 +129,7 @@ export default function ClaimForm({ shopId, shopName, neighborhood, companyName 
 
             <div>
               <label htmlFor="role" className="block text-sm font-medium text-gray-900 mb-2">
-                Your role at the shop
+                Your role
               </label>
               <input id="role" name="role" type="text" placeholder="Owner, manager, …" className={inputClasses} />
             </div>
@@ -153,7 +144,7 @@ export default function ClaimForm({ shopId, shopName, neighborhood, companyName 
               </label>
               <input id="business_email" name="business_email" required type="email" className={inputClasses} />
               <p className="mt-2 text-xs text-slate-500">
-                An email on the shop&apos;s domain speeds up verification.
+                An email on the business&apos;s domain speeds up verification.
               </p>
             </div>
 
@@ -181,7 +172,7 @@ export default function ClaimForm({ shopId, shopName, neighborhood, companyName 
           </fieldset>
 
           <fieldset>
-            <legend className="text-sm font-semibold text-gray-900 mb-4">Anything that proves it&apos;s your shop</legend>
+            <legend className="text-sm font-semibold text-gray-900 mb-4">Anything that proves it&apos;s yours</legend>
             <label htmlFor="message" className="sr-only">
               Anything that helps confirm ownership
             </label>

--- a/app/claim/ClaimForm.tsx
+++ b/app/claim/ClaimForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRef, useState } from 'react'
-import { ClaimTarget } from '@/app/utils/claims'
+import type { ClaimTarget } from '@/app/utils/claims'
 import ClaimSuccessDialog from './ClaimSuccessDialog'
 
 interface TProps {

--- a/app/claim/ClaimPreview.tsx
+++ b/app/claim/ClaimPreview.tsx
@@ -2,11 +2,11 @@ import VerifiedBadge from '@/app/components/VerifiedBadge'
 
 interface IProps {
   name?: string
-  neighborhood?: string
+  subtitle?: string
   photo?: string
 }
 
-export default function ClaimShopPreview({ name, neighborhood, photo }: IProps) {
+export default function ClaimPreview({ name, subtitle, photo }: IProps) {
   if (!name) return null
 
   return (
@@ -23,7 +23,7 @@ export default function ClaimShopPreview({ name, neighborhood, photo }: IProps) 
               {name}
               <VerifiedBadge className="mt-0.5" />
             </h2>
-            {neighborhood && <p className="text-base text-white/80 mt-0.5">{neighborhood}</p>}
+            {subtitle && <p className="text-base text-white/80 mt-0.5">{subtitle}</p>}
           </div>
         </div>
       </div>

--- a/app/claim/page.tsx
+++ b/app/claim/page.tsx
@@ -1,44 +1,41 @@
 import Link from 'next/link'
 import { Footer } from '@/app/components/about'
-import { getShopByUuidPrefix } from '@/app/utils/shops'
-import ClaimShopPreview from './ClaimShopPreview'
+import { resolveClaimTarget, ClaimType } from '@/app/utils/claims'
+import ClaimPreview from './ClaimPreview'
 import ClaimForm from './ClaimForm'
 
 interface TProps {
-  searchParams: Promise<{ shop?: string }>
+  searchParams: Promise<{ shop?: string; company?: string; roaster?: string }>
 }
 
-export default async function ClaimAShop({ searchParams }: TProps) {
-  const { shop } = await searchParams
+const HEADINGS: Record<ClaimType, string> = {
+  shop: "Your shop's on the map. Make it yours.",
+  company: "Your brand's on the map. Make it yours.",
+  roaster: "Your roastery's on the map. Make it yours.",
+}
 
-  // The first uuid group is the prefix the lookup expects. Everything the page
-  // shows (name, neighborhood, photo, company) comes from this row, so the claim
-  // link only needs the uuid.
-  const shopRow = shop ? await getShopByUuidPrefix(shop.slice(0, 8)) : null
+export default async function ClaimAListing({ searchParams }: TProps) {
+  const params = await searchParams
+  const hasEntry = Boolean(params.shop || params.company || params.roaster)
+  const target = hasEntry ? await resolveClaimTarget(params) : null
 
   return (
     <div>
       <header className="max-w-7xl mx-auto px-6 py-16">
         <div className="max-w-2xl mx-auto text-center">
           <h1 className="text-5xl md:text-7xl font-bold leading-tight mb-8">
-            You built the spot. Make it official.
+            {target ? HEADINGS[target.type] : "You're on the map. Make it yours."}
           </h1>
           <p className="text-xl md:text-2xl text-slate-600 font-light leading-relaxed">
-            Claim your shop to get a verified badge and a head start managing your own listing when self-serve editing
-            launches.
+            Claim your listing to get a verified badge and a head start managing it when self-serve editing launches.
           </p>
         </div>
       </header>
 
-      {shop ? (
+      {target ? (
         <>
-          <ClaimShopPreview name={shopRow?.name} neighborhood={shopRow?.neighborhood} photo={shopRow?.photo ?? undefined} />
-          <ClaimForm
-            shopId={shop}
-            shopName={shopRow?.name ?? 'this shop'}
-            neighborhood={shopRow?.neighborhood}
-            companyName={shopRow?.company?.name}
-          />
+          <ClaimPreview name={target.name} subtitle={target.subtitle} photo={target.photo} />
+          <ClaimForm target={target} />
         </>
       ) : (
         <section className="max-w-2xl mx-auto px-6 pb-20 text-center">

--- a/app/components/ClaimButton.tsx
+++ b/app/components/ClaimButton.tsx
@@ -1,18 +1,19 @@
 import Link from 'next/link'
 import { BadgeCheck } from 'lucide-react'
 
-interface ClaimShopButtonProps {
-  shopUUID: string
+interface ClaimButtonProps {
+  href: string
+  label: string
 }
 
-export default function ClaimShopButton({ shopUUID }: ClaimShopButtonProps) {
+export default function ClaimButton({ href, label }: ClaimButtonProps) {
   return (
     <Link
-      href={`/claim?shop=${shopUUID}`}
+      href={href}
       className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-stone-300 bg-white px-3.5 py-2 text-sm font-semibold text-stone-700 shadow-sm hover:bg-stone-50 hover:border-stone-400 active:scale-[0.98] transition-all"
     >
       <BadgeCheck className="size-4" />
-      Claim this shop
+      {label}
     </Link>
   )
 }

--- a/app/components/Company.tsx
+++ b/app/components/Company.tsx
@@ -4,6 +4,7 @@ import { ArrowTopRightOnSquareIcon, BuildingStorefrontIcon, ChevronRightIcon, Ma
 import { Flame, Instagram } from 'lucide-react'
 import Link from 'next/link'
 import LocationList from '@/app/components/LocationList'
+import ClaimButton from '@/app/components/ClaimButton'
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import useShopsStore from '@/stores/coffeeShopsStore'
@@ -152,6 +153,11 @@ export const Company = ({ slug }: { slug: string }) => {
         {company.description && (
           <p className="text-sm text-gray-600 leading-relaxed">{company.description}</p>
         )}
+
+        <div className="mt-5 flex items-center justify-between gap-3">
+          <p className="text-sm text-gray-500">Own {company.name}?</p>
+          <ClaimButton href={`/claim?company=${slug}`} label="Claim this brand" />
+        </div>
 
         {company.roaster && (
           <Link

--- a/app/components/PanelContent.tsx
+++ b/app/components/PanelContent.tsx
@@ -3,7 +3,7 @@ import NearbyShops from './NearbyShops'
 import { ShopNews } from './ShopNews'
 import { ShopEvents } from './ShopEvents'
 import QuickActionsBar from './QuickActionsBar'
-import ClaimShopButton from './ClaimShopButton'
+import ClaimButton from './ClaimButton'
 import ShopLocation from './ShopLocation'
 import ShopRoaster from './ShopRoaster'
 import PhotoGrid from './PhotoGrid'
@@ -54,7 +54,7 @@ export default function PanelContent(props: IProps) {
 
       <div className="px-4 sm:px-6 py-5 border-b border-stone-200 flex items-center justify-between gap-3">
         <p className="text-sm text-gray-500">Work at {name}?</p>
-        <ClaimShopButton shopUUID={uuid} />
+        <ClaimButton href={`/claim?shop=${uuid}`} label="Claim this shop" />
       </div>
 
       <NearbyShops shop={props.shop} />

--- a/app/components/RoasterDetails.tsx
+++ b/app/components/RoasterDetails.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { useState, useEffect } from 'react'
 import { useAnalytics } from '@/hooks'
 import LocationList from '@/app/components/LocationList'
+import ClaimButton from '@/app/components/ClaimButton'
 import useShopsStore from '@/stores/coffeeShopsStore'
 import { formatDataToGeoJSON } from '../utils/utils'
 import { DbShop } from '@/types/shop-types'
@@ -146,6 +147,11 @@ export const RoasterDetails = ({ slug }: { slug: string }) => {
         {roaster.description && (
           <p className="text-sm text-gray-600 leading-relaxed">{roaster.description}</p>
         )}
+
+        <div className="mt-5 flex items-center justify-between gap-3">
+          <p className="text-sm text-gray-500">Run {roaster.name}?</p>
+          <ClaimButton href={`/claim?roaster=${slug}`} label="Claim this roaster" />
+        </div>
 
         {roaster.shops && roaster.shops.length > 0 && (
           <div className="mt-4 pt-4 border-t border-gray-200">

--- a/app/utils/claims.ts
+++ b/app/utils/claims.ts
@@ -26,10 +26,14 @@ export interface ClaimTarget {
 // claim always targets the company when one exists. Count what it covers off
 // company_id only — a shop's roaster_id is "serves this coffee", not ownership.
 async function companyTarget(id: string, name: string): Promise<ClaimTarget> {
-  const [{ count }, { data: roasters }] = await Promise.all([
+  const [{ count, error: countError }, { data: roasters, error: roasterError }] = await Promise.all([
     supabase.from('shops').select('uuid', { count: 'exact', head: true }).eq('company_id', id),
     supabase.from('roaster').select('id').eq('company_id', id).limit(1),
   ])
+  // Throw rather than silently show misleading coverage (0 locations / no roaster)
+  // if a query fails — mirrors getShopByUuidPrefix, which throws on query failure.
+  if (countError) throw new Error(`Failed to count company shops: ${countError.message}`)
+  if (roasterError) throw new Error(`Failed to look up company roaster: ${roasterError.message}`)
   return { type: 'company', id, name, locationCount: count ?? 0, hasRoaster: (roasters?.length ?? 0) > 0 }
 }
 

--- a/app/utils/claims.ts
+++ b/app/utils/claims.ts
@@ -1,0 +1,66 @@
+import { createClient } from '@supabase/supabase-js'
+import { getShopByUuidPrefix } from './shops'
+import { getCompanyBySlug } from './companies'
+import { getRoasterBySlug } from './roasters'
+
+const supabaseUrl = process.env.SUPABASE_URL as string
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
+const supabase = createClient(supabaseUrl, supabaseAnonKey)
+
+export type ClaimType = 'shop' | 'company' | 'roaster'
+
+// What the claim page shows and the form submits. `id` is the value that lands in
+// the matching claims.{type}_id column.
+export interface ClaimTarget {
+  type: ClaimType
+  id: string
+  name: string
+  subtitle?: string
+  photo?: string
+  // Company-only: how much the claim covers, for the scope copy.
+  locationCount?: number
+  hasRoaster?: boolean
+}
+
+// A company owns its shops and its roaster, and one person owns the company, so a
+// claim always targets the company when one exists. Count what it covers off
+// company_id only — a shop's roaster_id is "serves this coffee", not ownership.
+async function companyTarget(id: string, name: string): Promise<ClaimTarget> {
+  const [{ count }, { data: roasters }] = await Promise.all([
+    supabase.from('shops').select('uuid', { count: 'exact', head: true }).eq('company_id', id),
+    supabase.from('roaster').select('id').eq('company_id', id).limit(1),
+  ])
+  return { type: 'company', id, name, locationCount: count ?? 0, hasRoaster: (roasters?.length ?? 0) > 0 }
+}
+
+// Resolve a `/claim` entry (shop uuid, company slug, or roaster slug) to the entity
+// the claim should actually target. Returns null when the entity can't be found.
+export async function resolveClaimTarget(params: {
+  shop?: string
+  company?: string
+  roaster?: string
+}): Promise<ClaimTarget | null> {
+  if (params.company) {
+    const company = await getCompanyBySlug(params.company)
+    return company ? companyTarget(company.id, company.name) : null
+  }
+
+  if (params.roaster) {
+    const roaster = await getRoasterBySlug(params.roaster)
+    if (!roaster) return null
+    if (roaster.company_id && roaster.company) {
+      return companyTarget(roaster.company.id, roaster.company.name)
+    }
+    return { type: 'roaster', id: roaster.id, name: roaster.name }
+  }
+
+  if (params.shop) {
+    // The first uuid group is the prefix the lookup expects.
+    const shop = await getShopByUuidPrefix(params.shop.slice(0, 8))
+    if (!shop) return null
+    if (shop.company) return companyTarget(shop.company.id, shop.company.name)
+    return { type: 'shop', id: shop.uuid, name: shop.name, subtitle: shop.neighborhood, photo: shop.photo ?? undefined }
+  }
+
+  return null
+}

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -82,7 +82,7 @@ function gauge(metricName: string, value: number, labels: Record<string, string>
 export const metrics = {
   shopSubmitted:              () => increment('shop_submitted_total'),
   shopReportSubmitted:        () => increment('shop_report_submitted_total'),
-  claimSubmitted:             () => increment('claim_submitted_total'),
+  claimSubmitted:             (claimType: string) => increment('claim_submitted_total', { claim_type: claimType }),
   shopAmenityReportSubmitted: () => increment('amenity_report_submitted_total'),
   shopNotFound:               (reason: 'invalid_slug' | 'no_match') => increment('shop_not_found_total', { reason }),
   shopViewed:                 (name: string, neighborhood: string) => increment('shop_view_total', { name, neighborhood }),

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -82,7 +82,7 @@ function gauge(metricName: string, value: number, labels: Record<string, string>
 export const metrics = {
   shopSubmitted:              () => increment('shop_submitted_total'),
   shopReportSubmitted:        () => increment('shop_report_submitted_total'),
-  shopClaimSubmitted:         () => increment('shop_claim_submitted_total'),
+  claimSubmitted:             () => increment('claim_submitted_total'),
   shopAmenityReportSubmitted: () => increment('amenity_report_submitted_total'),
   shopNotFound:               (reason: 'invalid_slug' | 'no_match') => increment('shop_not_found_total', { reason }),
   shopViewed:                 (name: string, neighborhood: string) => increment('shop_view_total', { name, neighborhood }),

--- a/migrations/claims-schema-rollback.sql
+++ b/migrations/claims-schema-rollback.sql
@@ -1,4 +1,4 @@
--- Rollback for claims-schema.sql. Drops the shop_claims table (with its policy,
+-- Rollback for claims-schema.sql. Drops the claims table (with its policy,
 -- indexes, and all submitted claims). Irreversible.
 
-DROP TABLE IF EXISTS shop_claims;
+DROP TABLE IF EXISTS claims;

--- a/migrations/claims-schema.sql
+++ b/migrations/claims-schema.sql
@@ -1,10 +1,17 @@
--- Schema for the "Claim your shop" flow.
+-- Schema for the "Claim your listing" flow.
 --
 -- Apply by hand (no migration framework in this repo). Additive: creates one new
 -- table with indexes and RLS. Claims land here as `pending` and are verified by
 -- hand before a listing is handed over to an owner.
 --
--- shop_claims — one row per ownership claim submitted via POST /api/shops/claim.
+-- claims — one row per ownership claim submitted via POST /api/shops/claim.
+--
+-- A claim targets exactly one of a shop, a company, or a roaster. Ownership rolls
+-- up the company tree: a company owns its shops and its roaster, so the claim page
+-- resolves a company-owned shop or roaster to the company and claims company_id.
+-- Only a company-less shop lands as shop_id, only a company-less roaster as
+-- roaster_id. The CHECK enforces exactly one target. Note a shop's roaster_id is
+-- "serves this coffee", not ownership, so a roaster claim never reaches those shops.
 --
 -- RLS: this table holds PII (contact_name, business_email, phone, social_media,
 -- message).
@@ -13,9 +20,11 @@
 -- Review claims with the service role (SQL editor / server), which bypasses RLS.
 -- The API insert does not chain .select(), so it never needs read access to succeed.
 
-CREATE TABLE IF NOT EXISTS shop_claims (
+CREATE TABLE IF NOT EXISTS claims (
   id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  shop_id        uuid NOT NULL REFERENCES shops(uuid),
+  shop_id        uuid REFERENCES shops(uuid),
+  company_id     uuid REFERENCES companies(id),
+  roaster_id     uuid REFERENCES roaster(id),
   contact_name   text NOT NULL,
   role           text,
   business_email text NOT NULL,
@@ -23,14 +32,17 @@ CREATE TABLE IF NOT EXISTS shop_claims (
   social_media   text,
   message        text,
   status         text NOT NULL DEFAULT 'pending', -- pending | approved | rejected
-  created_at     timestamptz NOT NULL DEFAULT now()
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT claims_one_target CHECK (num_nonnulls(shop_id, company_id, roaster_id) = 1)
 );
 
-CREATE INDEX IF NOT EXISTS shop_claims_shop_id_idx ON shop_claims(shop_id);
-CREATE INDEX IF NOT EXISTS shop_claims_status_idx  ON shop_claims(status);
+CREATE INDEX IF NOT EXISTS claims_shop_id_idx    ON claims(shop_id);
+CREATE INDEX IF NOT EXISTS claims_company_id_idx ON claims(company_id);
+CREATE INDEX IF NOT EXISTS claims_roaster_id_idx ON claims(roaster_id);
+CREATE INDEX IF NOT EXISTS claims_status_idx     ON claims(status);
 
-ALTER TABLE shop_claims ENABLE ROW LEVEL SECURITY;
+ALTER TABLE claims ENABLE ROW LEVEL SECURITY;
 
 DO $$ BEGIN
-  CREATE POLICY "Anyone can submit a claim" ON shop_claims FOR INSERT TO anon, authenticated WITH CHECK (true);
+  CREATE POLICY "Anyone can submit a claim" ON claims FOR INSERT TO anon, authenticated WITH CHECK (true);
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/tests/unit/claimRoute.test.ts
+++ b/tests/unit/claimRoute.test.ts
@@ -123,6 +123,19 @@ describe('Claim API Route - POST', () => {
     expect(inserted.shop_id).toBeUndefined()
   })
 
+  test('persists a roaster claim against roaster_id', async () => {
+    const ROASTER_ID = '33333333-3333-3333-3333-333333333333'
+    mockEntityValidation.mockResolvedValueOnce({ data: { id: ROASTER_ID }, error: null })
+    mockInsertResult.mockResolvedValueOnce({ data: null, error: null })
+
+    const response = await post({ ...validClaim, claim_type: 'roaster', target_id: ROASTER_ID })
+
+    expect(response.status).toBe(201)
+    const inserted = mockInsertResult.mock.calls[0][0][0]
+    expect(inserted.roaster_id).toBe(ROASTER_ID)
+    expect(inserted.shop_id).toBeUndefined()
+  })
+
   test('returns 500 when the claim insert fails', async () => {
     mockEntityValidation.mockResolvedValueOnce({ data: { uuid: SHOP_ID }, error: null })
     mockInsertResult.mockResolvedValueOnce({ data: null, error: { message: 'insert failed' } })

--- a/tests/unit/claimRoute.test.ts
+++ b/tests/unit/claimRoute.test.ts
@@ -1,27 +1,20 @@
 import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
 
-const mockShopValidationResult = vi.fn()
+const mockEntityValidation = vi.fn()
 const mockInsertResult = vi.fn()
 
+// The route validates the target against its entity table (shops/companies/roaster)
+// and inserts into `claims`. Any non-claims table stands in for the validation lookup.
 vi.mock('@supabase/supabase-js', () => ({
   createClient: () => ({
     from: (table: string) => {
-      if (table === 'shops') {
-        return { select: () => ({ eq: () => ({ single: mockShopValidationResult }) }) }
-      }
-      if (table === 'shop_claims') {
+      if (table === 'claims') {
         return { insert: mockInsertResult }
       }
-      return {}
+      return { select: () => ({ eq: () => ({ single: mockEntityValidation }) }) }
     },
   }),
 }))
-
-const validClaim = {
-  shop_id: 'shop-uuid-123',
-  contact_name: 'Jane Roaster',
-  business_email: 'jane@example.com',
-}
 
 describe('Claim API Route - POST', () => {
   let POST: typeof import('@/app/api/shops/claim/route').POST
@@ -45,28 +38,69 @@ describe('Claim API Route - POST', () => {
   }
 
   test('rejects a claim missing a business email before touching the database', async () => {
-    const response = await post({ shop_id: 'shop-uuid-123', contact_name: 'Jane Roaster' })
+    const response = await post({ claim_type: 'shop', target_id: 'shop-1', contact_name: 'Jane' })
 
     expect(response.status).toBe(400)
-    expect(mockShopValidationResult).not.toHaveBeenCalled()
+    expect(mockEntityValidation).not.toHaveBeenCalled()
   })
 
-  test('rejects a claim for a shop that does not exist', async () => {
-    mockShopValidationResult.mockResolvedValueOnce({ data: null, error: { message: 'No rows found' } })
+  test('rejects a claim with an unknown target type', async () => {
+    const response = await post({
+      claim_type: 'franchise',
+      target_id: 'x',
+      contact_name: 'Jane',
+      business_email: 'jane@example.com',
+    })
 
-    const response = await post(validClaim)
+    expect(response.status).toBe(400)
+    expect(mockEntityValidation).not.toHaveBeenCalled()
+  })
+
+  test('rejects a claim for an entity that does not exist', async () => {
+    mockEntityValidation.mockResolvedValueOnce({ data: null, error: { message: 'No rows found' } })
+
+    const response = await post({
+      claim_type: 'shop',
+      target_id: 'missing',
+      contact_name: 'Jane',
+      business_email: 'jane@example.com',
+    })
 
     expect(response.status).toBe(404)
     expect(mockInsertResult).not.toHaveBeenCalled()
   })
 
-  test('persists a valid claim as pending', async () => {
-    mockShopValidationResult.mockResolvedValueOnce({ data: { uuid: 'shop-uuid-123' }, error: null })
+  test('persists a shop claim against shop_id', async () => {
+    mockEntityValidation.mockResolvedValueOnce({ data: { uuid: 'shop-1' }, error: null })
     mockInsertResult.mockResolvedValueOnce({ data: [{ id: 'claim-1' }], error: null })
 
-    const response = await post(validClaim)
+    const response = await post({
+      claim_type: 'shop',
+      target_id: 'shop-1',
+      contact_name: 'Jane',
+      business_email: 'jane@example.com',
+    })
 
     expect(response.status).toBe(201)
-    expect(mockInsertResult).toHaveBeenCalledWith([expect.objectContaining({ status: 'pending' })])
+    expect(mockInsertResult).toHaveBeenCalledWith([
+      expect.objectContaining({ shop_id: 'shop-1', status: 'pending' }),
+    ])
+  })
+
+  test('persists a company claim against company_id, not shop_id', async () => {
+    mockEntityValidation.mockResolvedValueOnce({ data: { id: 'company-1' }, error: null })
+    mockInsertResult.mockResolvedValueOnce({ data: [{ id: 'claim-2' }], error: null })
+
+    const response = await post({
+      claim_type: 'company',
+      target_id: 'company-1',
+      contact_name: 'Jane',
+      business_email: 'jane@example.com',
+    })
+
+    expect(response.status).toBe(201)
+    const inserted = mockInsertResult.mock.calls[0][0][0]
+    expect(inserted.company_id).toBe('company-1')
+    expect(inserted.shop_id).toBeUndefined()
   })
 })

--- a/tests/unit/claimRoute.test.ts
+++ b/tests/unit/claimRoute.test.ts
@@ -111,6 +111,20 @@ describe('Claim API Route - POST', () => {
     ])
   })
 
+  test('resolves a company-owned shop claim up to company_id', async () => {
+    // A shop with a company_id is owned by that company, so the claim must persist
+    // against company_id even when the request says claim_type: 'shop'.
+    mockEntityValidation.mockResolvedValueOnce({ data: { uuid: SHOP_ID, company_id: COMPANY_ID }, error: null })
+    mockInsertResult.mockResolvedValueOnce({ data: null, error: null })
+
+    const response = await post(validClaim)
+
+    expect(response.status).toBe(201)
+    const inserted = mockInsertResult.mock.calls[0][0][0]
+    expect(inserted.company_id).toBe(COMPANY_ID)
+    expect(inserted.shop_id).toBeUndefined()
+  })
+
   test('persists a company claim against company_id, not shop_id', async () => {
     mockEntityValidation.mockResolvedValueOnce({ data: { id: COMPANY_ID }, error: null })
     mockInsertResult.mockResolvedValueOnce({ data: null, error: null })


### PR DESCRIPTION
Stacks on #261 (`claim-your-shop`). #312 (`verified-badge`) should be re-parented onto this branch so the stack reads 261 → this → 312.

## Why

Independent Pittsburgh coffee is owned at the brand level — one person owns the roastery and every café. Per-location claims made that owner submit and hand-verify the same identity several times, and it fought the coming self-serve dashboard, which is rooted at the company.

## What

Claims now target the **top of the ownership tree**:

- A company-owned shop or roaster resolves **up to the company**; the claim is against the company and covers the whole brand.
- Only a company-less shop or roaster is claimed directly.
- Coverage follows `company_id` only, so a roaster claim never reaches the shops that merely *serve* its coffee.

Schema: `shop_claims` → `claims`, with one target of `shop`/`company`/`roaster` and a CHECK enforcing exactly one. (The table was never applied to the DB, so there's no data to migrate; DDL + the exactly-one CHECK were validated against the live schema.)

Adds claim entry points on the company and roaster panels; the single resolver feeds all three (shop / company / roaster) entry points.

## Scope / follow-ups

- **Badge display is out of scope** — this is claim submission only. #312 surfaces `shops.verified`; nothing yet renders a verified badge on a *company* or *roaster* page. Follow-up.
- Re-parent #312 onto this branch (the last step of the stack).
- Manual QA of the rendered `/claim?company=` and `/claim?roaster=` pages once the `claims` migration is applied.