### PR TITLE
Track claim button clicks in analytics

### DIFF
--- a/app/components/ClaimButton.tsx
+++ b/app/components/ClaimButton.tsx
@@ -1,5 +1,8 @@
+'use client'
+
 import Link from 'next/link'
 import { BadgeCheck } from 'lucide-react'
+import { useAnalytics } from '@/hooks'
 
 interface ClaimButtonProps {
   href: string
@@ -7,9 +10,14 @@ interface ClaimButtonProps {
 }
 
 export default function ClaimButton({ href, label }: ClaimButtonProps) {
+  const plausible = useAnalytics()
+  // href is /claim?{shop|company|roaster}=..., so the first query key is the claim type
+  const type = new URLSearchParams(href.split('?')[1] ?? '').keys().next().value ?? 'unknown'
+
   return (
     <Link
       href={href}
+      onClick={() => plausible('ClaimButtonClick', { props: { type } })}
       className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-stone-300 bg-white px-3.5 py-2 text-sm font-semibold text-stone-700 shadow-sm hover:bg-stone-50 hover:border-stone-400 active:scale-[0.98] transition-all"
     >
       <BadgeCheck className="size-4" />


### PR DESCRIPTION
Only completed claim submissions (`claim_submitted_total`) were measured, leaving the top of the funnel dark. Fires a `ClaimButtonClick` event tagged with the claim `type` (shop/company/roaster) so click-through to the form can be compared against submissions.

The button was a plain server-rendered link; this makes it a client component to attach the handler.