### PR TITLE
Give claim links a target-specific unfurl

### DIFF
--- a/app/claim/page.tsx
+++ b/app/claim/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import type { Metadata } from 'next'
 import { Footer } from '@/app/components/about'
 import { resolveClaimTarget } from '@/app/utils/claims'
 import type { ClaimType } from '@/types/claim-types'
@@ -20,9 +21,33 @@ const first = (value?: string | string[]) => {
   return Array.isArray(value) ? value[0] : value
 }
 
+const entryFrom = (params: Awaited<TProps['searchParams']>) => ({
+  shop: first(params.shop),
+  company: first(params.company),
+  roaster: first(params.roaster),
+})
+
+// Give a claim link a target-specific unfurl so it sells itself when shared in a
+// DM, instead of the generic site card. Falls back to the site default when the
+// link has no resolvable target.
+export async function generateMetadata({ searchParams }: TProps): Promise<Metadata> {
+  const entry = entryFrom(await searchParams)
+  const target = entry.shop || entry.company || entry.roaster ? await resolveClaimTarget(entry) : null
+  if (!target) return {}
+
+  const title = `Claim ${target.name} · pgh.coffee`
+  const description = 'Verify your listing to get a verified badge and a head start managing it when self-serve editing launches.'
+  const images = target.photo ? [target.photo] : undefined
+  return {
+    title,
+    description,
+    openGraph: { title, description, images },
+    twitter: { card: 'summary_large_image', title, description, images },
+  }
+}
+
 export default async function ClaimAListing({ searchParams }: TProps) {
-  const params = await searchParams
-  const entry = { shop: first(params.shop), company: first(params.company), roaster: first(params.roaster) }
+  const entry = entryFrom(await searchParams)
   const hasEntry = Boolean(entry.shop || entry.company || entry.roaster)
   const target = hasEntry ? await resolveClaimTarget(entry) : null
 

--- a/app/claim/page.tsx
+++ b/app/claim/page.tsx
@@ -27,9 +27,6 @@ const entryFrom = (params: Awaited<TProps['searchParams']>) => ({
   roaster: first(params.roaster),
 })
 
-// Give a claim link a target-specific unfurl so it sells itself when shared in a
-// DM, instead of the generic site card. Falls back to the site default when the
-// link has no resolvable target.
 export async function generateMetadata({ searchParams }: TProps): Promise<Metadata> {
   const entry = entryFrom(await searchParams)
   const target = entry.shop || entry.company || entry.roaster ? await resolveClaimTarget(entry) : null

--- a/app/utils/claims.ts
+++ b/app/utils/claims.ts
@@ -23,7 +23,7 @@ export interface ClaimTarget {
 // claim always targets the company when one exists. Count what it covers off
 // company_id only — a shop's roaster_id is "serves this coffee", not ownership.
 // @TODO why are we making DB calls here?
-async function companyTarget(id: string, name: string): Promise<ClaimTarget> {
+async function companyTarget(id: string, name: string, logo?: string | null): Promise<ClaimTarget> {
   const [{ count, error: countError }, { data: roasters, error: roasterError }] = await Promise.all([
     supabase.from('shops').select('uuid', { count: 'exact', head: true }).eq('company_id', id),
     supabase.from('roaster').select('id').eq('company_id', id).limit(1),
@@ -32,7 +32,7 @@ async function companyTarget(id: string, name: string): Promise<ClaimTarget> {
   // if a query fails — mirrors getShopByUuidPrefix, which throws on query failure.
   if (countError) throw new Error(`Failed to count company shops: ${countError.message}`)
   if (roasterError) throw new Error(`Failed to look up company roaster: ${roasterError.message}`)
-  return { type: 'company', id, name, locationCount: count ?? 0, hasRoaster: (roasters?.length ?? 0) > 0 }
+  return { type: 'company', id, name, photo: logo ?? undefined, locationCount: count ?? 0, hasRoaster: (roasters?.length ?? 0) > 0 }
 }
 
 // Resolve a `/claim` entry (shop uuid, company slug, or roaster slug) to the entity
@@ -44,16 +44,16 @@ export async function resolveClaimTarget(params: {
 }): Promise<ClaimTarget | null> {
   if (params.company) {
     const company = await getCompanyBySlug(params.company)
-    return company ? companyTarget(company.id, company.name) : null
+    return company ? companyTarget(company.id, company.name, company.logo) : null
   }
 
   if (params.roaster) {
     const roaster = await getRoasterBySlug(params.roaster)
     if (!roaster) return null
     if (roaster.company_id && roaster.company) {
-      return companyTarget(roaster.company.id, roaster.company.name)
+      return companyTarget(roaster.company.id, roaster.company.name, roaster.company.logo)
     }
-    return { type: 'roaster', id: roaster.id, name: roaster.name }
+    return { type: 'roaster', id: roaster.id, name: roaster.name, photo: roaster.logo ?? undefined }
   }
 
   if (params.shop) {
@@ -63,7 +63,7 @@ export async function resolveClaimTarget(params: {
     if (!/^[0-9a-f]{8}$/i.test(prefix)) return null
     const shop = await getShopByUuidPrefix(prefix)
     if (!shop) return null
-    if (shop.company) return companyTarget(shop.company.id, shop.company.name)
+    if (shop.company) return companyTarget(shop.company.id, shop.company.name, shop.company.logo)
     return { type: 'shop', id: shop.uuid, name: shop.name, subtitle: shop.neighborhood, photo: shop.photo ?? undefined }
   }
 

--- a/types/shop-types.ts
+++ b/types/shop-types.ts
@@ -11,6 +11,7 @@ export interface TCompany {
   website: string
   description: string
   instagram_handle: string
+  logo?: string
   is_verified?: boolean
   shops?: DbShop[]
   roaster?: { name: string; slug: string } | null


### PR DESCRIPTION
A pasted `/claim` link fell back to the generic `pgh.coffee — A guide to coffee in Pittsburgh, PA` OG card, so sharing one in a DM said nothing about the shop or that it's a claim link.

`generateMetadata` now resolves the target (same resolver the page already uses) and emits a `Claim <name> · pgh.coffee` title, a description about the verified badge, and the shop photo as the OG/Twitter image. Falls back to the site default when the link has no resolvable target.