### PR TITLE
Hide the claim button once an entity is verified

### DIFF
--- a/app/components/Company.tsx
+++ b/app/components/Company.tsx
@@ -158,10 +158,12 @@ export const Company = ({ slug }: { slug: string }) => {
           <p className="text-sm text-gray-600 leading-relaxed">{company.description}</p>
         )}
 
-        <div className="mt-5 flex items-center justify-between gap-3">
-          <p className="text-sm text-gray-500">Own {company.name}?</p>
-          <ClaimButton href={`/claim?company=${slug}`} label="Claim this brand" />
-        </div>
+        {!company.is_verified && (
+          <div className="mt-5 flex items-center justify-between gap-3">
+            <p className="text-sm text-gray-500">Own {company.name}?</p>
+            <ClaimButton href={`/claim?company=${slug}`} label="Claim this brand" />
+          </div>
+        )}
 
         {company.roaster && (
           <Link

--- a/app/components/PanelContent.tsx
+++ b/app/components/PanelContent.tsx
@@ -15,7 +15,7 @@ interface IProps {
 }
 
 export default function PanelContent(props: IProps) {
-  const { address, photos, amenities, roaster, uuid, name } = props.shop.properties
+  const { address, photos, amenities, roaster, uuid, name, verified } = props.shop.properties
   const description = props.shop.properties.description?.trim()
   const coordinates = props.shop.geometry?.coordinates
 
@@ -52,10 +52,12 @@ export default function PanelContent(props: IProps) {
         <ShopLocation address={address} coordinates={coordinates} />
       </div>
 
-      <div className="px-4 sm:px-6 py-5 border-b border-stone-200 flex items-center justify-between gap-3">
-        <p className="text-sm text-gray-500">Work at {name}?</p>
-        <ClaimButton href={`/claim?shop=${uuid}`} label="Claim this shop" />
-      </div>
+      {!verified && (
+        <div className="px-4 sm:px-6 py-5 border-b border-stone-200 flex items-center justify-between gap-3">
+          <p className="text-sm text-gray-500">Work at {name}?</p>
+          <ClaimButton href={`/claim?shop=${uuid}`} label="Claim this shop" />
+        </div>
+      )}
 
       <NearbyShops shop={props.shop} />
     </div>

--- a/app/components/RoasterDetails.tsx
+++ b/app/components/RoasterDetails.tsx
@@ -153,10 +153,12 @@ export const RoasterDetails = ({ slug }: { slug: string }) => {
           <p className="text-sm text-gray-600 leading-relaxed">{roaster.description}</p>
         )}
 
-        <div className="mt-5 flex items-center justify-between gap-3">
-          <p className="text-sm text-gray-500">Run {roaster.name}?</p>
-          <ClaimButton href={`/claim?roaster=${slug}`} label="Claim this roaster" />
-        </div>
+        {!roaster.is_verified && (
+          <div className="mt-5 flex items-center justify-between gap-3">
+            <p className="text-sm text-gray-500">Run {roaster.name}?</p>
+            <ClaimButton href={`/claim?roaster=${slug}`} label="Claim this roaster" />
+          </div>
+        )}
 
         {roaster.shops && roaster.shops.length > 0 && (
           <div className="mt-4 pt-4 border-t border-gray-200">

--- a/tests/unit/PanelContent.test.tsx
+++ b/tests/unit/PanelContent.test.tsx
@@ -118,4 +118,20 @@ describe('PanelContent', () => {
 
     expect(container.querySelector(descriptionSelector)).toBeNull()
   })
+
+  it('renders the claim button when the shop is not verified', () => {
+    render(<PanelContent {...defaultProps} />)
+
+    expect(screen.getByRole('link', { name: /Claim this shop/ })).toBeInTheDocument()
+  })
+
+  it('hides the claim button when the shop is verified', () => {
+    const shop: TShop = {
+      ...mockShop,
+      properties: { ...mockShop.properties, verified: true },
+    }
+    render(<PanelContent {...defaultProps} shop={shop} />)
+
+    expect(screen.queryByRole('link', { name: /Claim this shop/ })).toBeNull()
+  })
 })


### PR DESCRIPTION
## What do these changes accomplish?

Hides the "Claim this shop / brand / roaster" button once that entity has been verified (claimed).

## Why?

Once an owner has claimed and verified their shop, company, or roaster, the invitation to claim it is misleading — there's nothing left to claim. Hiding the button (and its "Work at / Own / Run …?" prompt) keeps the panel honest and stops duplicate claim submissions on already-owned listings.

