### PR TITLE
Show verified badges on event details

### DIFF
--- a/app/components/EventCard.tsx
+++ b/app/components/EventCard.tsx
@@ -45,8 +45,10 @@ export type EventCardData = {
     name: string
     neighborhood: string
     uuid: string
+    is_verified?: boolean
+    company?: { is_verified?: boolean } | null
   }
-  roaster?: Pick<RoasterRef, 'name' | 'slug'>
+  roaster?: Pick<RoasterRef, 'name' | 'slug'> & { is_verified?: boolean }
 }
 
 interface EventCardProps {

--- a/app/components/EventDetails.tsx
+++ b/app/components/EventDetails.tsx
@@ -7,6 +7,7 @@ import { isPast } from '@/app/utils/utils'
 import { buildShopSlug } from '@/app/utils/shopSlug'
 import { EventCardData } from './EventCard'
 import CopyLinkToast from './CopyLinkToast'
+import VerifiedBadge from './VerifiedBadge'
 
 type TagKey = 'opening' | 'closure' | 'coming soon' | 'throwdown' | 'event' | 'seasonal' | 'menu'
 
@@ -148,8 +149,9 @@ export const EventDetails = ({ event }: EventDetailsProps) => {
                   onClick={handleShopClick}
                   className="text-left hover:opacity-80 transition-opacity"
                 >
-                  <div className="text-slate-900 font-bold text-[15px]">
+                  <div className="flex items-center gap-1 text-slate-900 font-bold text-[15px]">
                     {event.shop.name}
+                    {(event.shop.is_verified || event.shop.company?.is_verified) && <VerifiedBadge />}
                   </div>
                   <div className="text-sm text-gray-500 mt-0.5">
                     {event.shop.neighborhood}
@@ -176,8 +178,9 @@ export const EventDetails = ({ event }: EventDetailsProps) => {
                   onClick={handleRoasterClick}
                   className="text-left hover:opacity-80 transition-opacity"
                 >
-                  <div className="text-slate-900 font-bold text-[15px]">
+                  <div className="flex items-center gap-1 text-slate-900 font-bold text-[15px]">
                     {event.roaster.name}
+                    {event.roaster.is_verified && <VerifiedBadge />}
                   </div>
                 </button>
               </div>

--- a/tests/unit/EventDetails.test.tsx
+++ b/tests/unit/EventDetails.test.tsx
@@ -1,0 +1,46 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EventDetails } from '@/app/components/EventDetails'
+import type { EventCardData } from '@/app/components/EventCard'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/hooks', () => ({
+  useCopyToClipboard: () => ({ showToast: false, copyCurrentUrl: vi.fn(), closeToast: vi.fn() }),
+  useAnalytics: () => vi.fn(),
+}))
+
+const baseEvent: EventCardData = {
+  id: 'event-1',
+  title: 'Starts with Coffee',
+}
+
+describe('EventDetails verified badges', () => {
+  test('shows badge for verified roaster and company-verified shop', () => {
+    render(
+      <EventDetails
+        event={{
+          ...baseEvent,
+          roaster: { name: "It's Still Coffee", slug: 'its-still-coffee', is_verified: true },
+          shop: { name: 'De Fer', neighborhood: 'Downtown', uuid: 'u1', company: { is_verified: true } },
+        }}
+      />,
+    )
+    expect(screen.getAllByText('Verified')).toHaveLength(2)
+  })
+
+  test('no badge for unverified entities', () => {
+    render(
+      <EventDetails
+        event={{
+          ...baseEvent,
+          roaster: { name: "It's Still Coffee", slug: 'its-still-coffee' },
+          shop: { name: 'De Fer', neighborhood: 'Downtown', uuid: 'u1' },
+        }}
+      />,
+    )
+    expect(screen.queryByText('Verified')).toBeNull()
+  })
+})


### PR DESCRIPTION
Events joined to a verified roaster or shop rendered no badge — the API already returned `is_verified` on the joined rows, but `EventCardData` dropped the field and `EventDetails` never rendered it.

- Carry `is_verified` through `EventCardData` for the roaster and shop (plus the shop's company)
- Render `VerifiedBadge` next to the roaster name and shop name in `EventDetails`, using the same shop-or-company rule as `PanelHeader`
- Add a unit test covering badge on/off

<img width="562" height="707" alt="image" src="https://github.com/user-attachments/assets/684484a5-f8e2-4280-8731-9e1870ce4f94" />
