### PR TITLE
Clarify verified badge tooltip

### DIFF
--- a/app/components/VerifiedBadge.tsx
+++ b/app/components/VerifiedBadge.tsx
@@ -6,8 +6,8 @@ interface IProps {
 
 export default function VerifiedBadge({ className = '' }: IProps) {
   return (
-    <span title="Verified by pgh.coffee" className={`inline-flex shrink-0 ${className}`}>
-      <CheckBadgeIcon className="size-5 text-yellow-300 drop-shadow" />
+    <span title="Claimed by this business" className={`inline-flex shrink-0 ${className}`}>
+      <CheckBadgeIcon className="size-5 text-yellow-300" />
       <span className="sr-only">Verified</span>
     </span>
   )


### PR DESCRIPTION
The tooltip said "Verified by pgh.coffee", but the badge actually means the listing was claimed by someone at the business. Update it to "Claimed by this business". Also drops a stray drop-shadow on the icon.