### PR TITLE
Show verified badge everywhere ShopCard renders

### DIFF
--- a/app/api/favorites/route.ts
+++ b/app/api/favorites/route.ts
@@ -20,7 +20,7 @@ export async function GET() {
     .select(`
       id,
       created_at,
-      shop:shops (*)
+      shop:shops (*, company:company_id (*))
     `)
     .eq('user_id', user.id)
     .order('created_at', { ascending: false })

--- a/app/api/visits/route.ts
+++ b/app/api/visits/route.ts
@@ -20,7 +20,7 @@ export async function GET() {
     .select(`
       id,
       created_at,
-      shop:shops (*)
+      shop:shops (*, company:company_id (*))
     `)
     .eq('user_id', user.id)
     .order('created_at', { ascending: false })

--- a/app/components/ShopCard.tsx
+++ b/app/components/ShopCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { MapPinIcon } from '@heroicons/react/24/outline'
+import VerifiedBadge from './VerifiedBadge'
 import { TShop } from '@/types/shop-types'
 import { TUnits } from '@/types/unit-types'
 import useShopsStore from '@/stores/coffeeShopsStore'
@@ -81,7 +82,10 @@ export default function ShopCard(props: IProps) {
       <div className="absolute inset-0 bg-[linear-gradient(0deg,rgba(0,0,0,0.7),transparent_100%)]"></div>
       <div className="px-2 py-1 absolute bottom-0 w-full">
         {!props.hideShopName && (
-          <p className="font-medium text-white text-2xl text-left block">{props.shop.properties.name}</p>
+          <p className="font-medium text-white text-2xl text-left flex items-center gap-1.5">
+            <span className="truncate">{props.shop.properties.name}</span>
+            {(props.shop.properties.verified || props.shop.properties.company?.is_verified) && <VerifiedBadge />}
+          </p>
         )}
         <div className="flex justify-between mt-1">
           <p className="w-fit text-sm mb-1 text-left text-white border border-transparent flex items-center gap-1">

--- a/app/utils/profiles.ts
+++ b/app/utils/profiles.ts
@@ -40,7 +40,7 @@ export const getPublicProfile = cache(async (id: string): Promise<PublicProfile 
 
   const { data: visitsData, error: visitsError } = await supabase
     .from('user_visits')
-    .select('id, created_at, shop:shops (*)')
+    .select('id, created_at, shop:shops (*, company:company_id (*))')
     .eq('user_id', profile.user_id)
     .order('created_at', { ascending: false })
 

--- a/tests/unit/NearbyShopRow.test.tsx
+++ b/tests/unit/NearbyShopRow.test.tsx
@@ -1,0 +1,46 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import NearbyShopRow from '@/app/components/NearbyShopRow'
+import type { TShop } from '@/types/shop-types'
+
+vi.mock('@/hooks', () => ({
+  useShopSelection: () => ({ handleShopSelect: vi.fn() }),
+  useAnalytics: () => vi.fn(),
+}))
+
+vi.mock('@/stores/coffeeShopsStore', () => ({
+  __esModule: true,
+  default: () => vi.fn(),
+}))
+
+const makeShop = (overrides: Partial<TShop['properties']> = {}): TShop =>
+  ({
+    type: 'Feature',
+    properties: {
+      company: null,
+      name: 'Test Shop',
+      neighborhood: 'Downtown',
+      address: '',
+      website: '',
+      uuid: 'u1',
+      ...overrides,
+    },
+    geometry: { type: 'Point', coordinates: [0, 0] },
+  }) as TShop
+
+describe('NearbyShopRow verified badge', () => {
+  test('shows badge for a verified shop', () => {
+    render(<NearbyShopRow shop={makeShop({ verified: true })} />)
+    expect(screen.getByText('Verified')).toBeTruthy()
+  })
+
+  test('shows badge when the owning company is verified', () => {
+    render(<NearbyShopRow shop={makeShop({ company: { is_verified: true } as TShop['properties']['company'] })} />)
+    expect(screen.getByText('Verified')).toBeTruthy()
+  })
+
+  test('no badge for an unverified shop', () => {
+    render(<NearbyShopRow shop={makeShop()} />)
+    expect(screen.queryByText('Verified')).toBeNull()
+  })
+})

--- a/tests/unit/ShopCard.test.tsx
+++ b/tests/unit/ShopCard.test.tsx
@@ -114,6 +114,26 @@ describe('ShopCard', () => {
     expect(handleShopSelectMock).toHaveBeenCalledWith(mockShop)
   })
 
+  it('shows verified badge for a verified shop', () => {
+    const shop = { ...mockShop, properties: { ...mockShop.properties, verified: true } }
+    render(<ShopCard {...defaultProps} shop={shop} />)
+    expect(screen.getByText('Verified')).toBeTruthy()
+  })
+
+  it('shows verified badge when the owning company is verified', () => {
+    const shop = {
+      ...mockShop,
+      properties: { ...mockShop.properties, company: { is_verified: true } },
+    } as TShop
+    render(<ShopCard {...defaultProps} shop={shop} />)
+    expect(screen.getByText('Verified')).toBeTruthy()
+  })
+
+  it('shows no verified badge for an unverified shop', () => {
+    render(<ShopCard {...defaultProps} />)
+    expect(screen.queryByText('Verified')).toBeNull()
+  })
+
   it('has correct accessibility attributes', () => {
     render(<ShopCard {...defaultProps} />)
     const card = screen.getByRole('button')


### PR DESCRIPTION
Adds the verified badge to `ShopCard`. Search results, company location lists, the Explore featured shop, account favorites/visited, and passports will now show the badge. 