### PR TITLE
Emit Faro event on claim submission

### DIFF
--- a/app/claim/ClaimForm.tsx
+++ b/app/claim/ClaimForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRef, useState } from 'react'
+import { getFaro } from '@/lib/faro'
 import type { ClaimTarget } from '@/app/utils/claims'
 import ClaimSuccessDialog from './ClaimSuccessDialog'
 
@@ -74,6 +75,7 @@ export default function ClaimForm({ target }: TProps) {
         setError(errorResponse.error ?? 'Something went wrong. Please try again.')
         setIsSubmitting(false)
       } else {
+        getFaro()?.api.pushEvent('claim_submitted', { claim_type: target.type, target_id: target.id })
         setSuccessDialogIsOpen(true)
         claimForm.current?.reset()
         setIsSubmitting(false)


### PR DESCRIPTION
Pushes a `claim_submitted` Faro event (with `claim_type` and `target_id`, no PII) after the claim API returns OK, so a Grafana alert rule on the Faro Loki stream can send an email per submission.

Alert rule to pair with this:
```
count_over_time({app="pgh-coffee"} | logfmt | kind = `event` | event_name = `claim_submitted` [5m]) > 0
```