### PR TITLE
Emit Faro events for account creation, shop submissions, and reports

### DIFF
--- a/app/components/AmenityReportModal.tsx
+++ b/app/components/AmenityReportModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 
 import { Checkbox, Dialog, DialogPanel, DialogTitle } from '@headlessui/react'
 import { amenityMap } from '@/lib/amenities'
+import { getFaro } from '@/lib/faro'
 
 interface Props {
   isOpen: boolean
@@ -40,6 +41,7 @@ export default function AmenityReportModal({ isOpen, onClose, onSuccess, ameniti
                 body: JSON.stringify({ shop_id: shopId, amenities: selected }),
               })
               if (!res.ok) throw new Error('Failed to submit')
+              getFaro()?.api.pushEvent('amenities_reported', { shop_id: shopId })
               onSuccess()
               onClose()
             } catch (err) {

--- a/app/components/AuthForm.tsx
+++ b/app/components/AuthForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
+import { getFaro } from '@/lib/faro'
 
 interface AuthFormProps {
   onSuccess: () => void
@@ -42,6 +43,8 @@ export default function AuthForm({ onSuccess, idPrefix = '' }: AuthFormProps) {
           setError('An account with this email already exists. Please sign in instead.')
           return
         }
+
+        getFaro()?.api.pushEvent('account_created')
 
         if (data.user && !data.session) {
           setError('Please check your email to confirm your account before signing in.')

--- a/app/components/IssueForm.tsx
+++ b/app/components/IssueForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { TShop } from '@/types/shop-types'
+import { getFaro } from '@/lib/faro'
 
 interface IProps {
   shop: TShop
@@ -72,6 +73,7 @@ export default function IssueForm({ shop, onSuccess }: IProps) {
         setError('Something went wrong submitting your correction. Please try again.')
         setIsSubmitting(false)
       } else {
+        getFaro()?.api.pushEvent('shop_reported', { shop_id: shop.properties.uuid })
         setIsSubmitting(false)
         onSuccess()
       }

--- a/app/components/submit/SubmitForm.tsx
+++ b/app/components/submit/SubmitForm.tsx
@@ -53,7 +53,7 @@ export default function SubmitForm() {
         console.error('Error:', errorResponse.error)
         setIsSubmitting(false)
       } else {
-        getFaro()?.api.pushEvent('shop_submitted', { neighborhood: data.neighborhood ?? '' })
+        getFaro()?.api.pushEvent('shop_submitted', { name: data.name })
         setSuccessDialogIsOpen(true)
         submitForm.current?.reset()
         setNeighborhoodValue('')

--- a/app/components/submit/SubmitForm.tsx
+++ b/app/components/submit/SubmitForm.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from 'react'
 import { Combobox, ComboboxInput, ComboboxOption, ComboboxOptions } from '@headlessui/react'
 import { neighborhoods } from '@/data/neighborhoods'
+import { getFaro } from '@/lib/faro'
 import SuccessDialog from '@/app/submit-a-shop/SuccessDialog'
 import { InfoIcon } from 'lucide-react'
 
@@ -52,6 +53,7 @@ export default function SubmitForm() {
         console.error('Error:', errorResponse.error)
         setIsSubmitting(false)
       } else {
+        getFaro()?.api.pushEvent('shop_submitted', { neighborhood: data.neighborhood ?? '' })
         setSuccessDialogIsOpen(true)
         submitForm.current?.reset()
         setNeighborhoodValue('')


### PR DESCRIPTION
Follows the pattern from #338 (`claim_submitted`) to instrument the remaining high-signal user actions so Grafana can alert on them:

- `account_created` — email sign-up in `AuthForm` (fires before the email-confirmation branch, since the account exists either way; Google OAuth sign-ups aren't distinguishable client-side and are not covered)
- `shop_submitted` — successful submission in `SubmitForm`, with `name`
- `shop_reported` — successful correction in `IssueForm`, with `shop_id`
- `amenities_reported` — successful amenity update in `AmenityReportModal`, with `shop_id`

All events fire only on the success path, matching #338.