### PR TITLE
Fix OG/social metadata gaps across the site

### DIFF
--- a/app/(map)/opengraph-image.tsx
+++ b/app/(map)/opengraph-image.tsx
@@ -1,0 +1,1 @@
+export { default, size, contentType, alt } from '@/app/opengraph-image'

--- a/app/(map)/page.tsx
+++ b/app/(map)/page.tsx
@@ -5,11 +5,12 @@ const description =
   "Explore independent coffee shops across Pittsburgh's neighborhoods — find your next favorite spot on the map."
 
 export const metadata: Metadata = {
-  title: 'PGH Coffee',
+  title: 'pgh.coffee',
   description,
   alternates: { canonical: '/' },
   openGraph: {
-    title: 'PGH Coffee',
+    siteName: 'pgh.coffee',
+    title: 'pgh.coffee',
     description,
     url: '/',
   },

--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
   description,
   alternates: { canonical: '/about' },
   openGraph: {
+    siteName: 'pgh.coffee',
     title: 'About | pgh.coffee',
     description,
     url: '/about',

--- a/app/about/opengraph-image.tsx
+++ b/app/about/opengraph-image.tsx
@@ -1,0 +1,1 @@
+export { default, size, contentType, alt } from '@/app/opengraph-image'

--- a/app/claim/page.tsx
+++ b/app/claim/page.tsx
@@ -38,8 +38,7 @@ export async function generateMetadata({ searchParams }: TProps): Promise<Metada
   return {
     title,
     description,
-    openGraph: { title, description, images },
-    twitter: { card: 'summary_large_image', title, description, images },
+    openGraph: { siteName: 'pgh.coffee', title, description, images },
   }
 }
 

--- a/app/claim/page.tsx
+++ b/app/claim/page.tsx
@@ -34,7 +34,10 @@ export async function generateMetadata({ searchParams }: TProps): Promise<Metada
 
   const title = `Claim ${target.name} · pgh.coffee`
   const description = 'Verify your listing to get a verified badge and a head start managing it when self-serve editing launches.'
-  const images = target.photo ? [target.photo] : undefined
+  // Fall back to the site-default OG image: this openGraph object replaces the
+  // layout's wholesale, so without an explicit image a photo-less target
+  // (e.g. a roaster with no logo) would emit no og:image at all.
+  const images = target.photo ? [target.photo] : ['/opengraph-image']
   return {
     title,
     description,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,26 +13,25 @@ const inter = Inter({ subsets: ['latin'] })
 const organizationJsonLd = buildOrganizationJsonLd()
 const websiteJsonLd = buildWebsiteJsonLd()
 
+const siteDescription =
+  "A guide to independent coffee in Pittsburgh, PA. Explore shops across the city's neighborhoods and track your visits with a coffee passport."
+
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
+  title: 'pgh.coffee',
+  description: siteDescription,
+  // No images here: app/opengraph-image.tsx provides the site-default og:image
+  // and survives child routes' openGraph objects (config images replace this
+  // whole object wholesale, which is how the old static image kept vanishing).
   openGraph: {
+    siteName: 'pgh.coffee',
     title: 'pgh.coffee',
-    description: 'A guide to coffee in Pittsburgh, PA',
-    images: [
-      {
-        url: 'https://uljutxoijtvtcxvatqso.supabase.co/storage/v1/object/public/pgh-coffee-misc/opengraph-image.png',
-        width: 1200,
-        height: 630,
-        alt: 'A guide to coffee in Pittsburgh, PA',
-      },
-    ],
+    description: siteDescription,
   },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'pgh.coffee',
-    description: 'A guide to coffee in Pittsburgh, PA',
-    images: ['https://uljutxoijtvtcxvatqso.supabase.co/storage/v1/object/public/pgh-coffee-misc/twitter-image.png'],
-  },
+  // Card type only: title/description/image intentionally unset so X falls back
+  // to the og:* tags, letting per-route openGraph (and file-based opengraph-image)
+  // drive Twitter cards instead of this layout's static values leaking everywhere.
+  twitter: { card: 'summary_large_image' },
 }
 
 export const viewport: Viewport = {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,8 +21,10 @@ export const metadata: Metadata = {
   title: 'pgh.coffee',
   description: siteDescription,
   // No images here: app/opengraph-image.tsx provides the site-default og:image
-  // and survives child routes' openGraph objects (config images replace this
-  // whole object wholesale, which is how the old static image kept vanishing).
+  // for routes that don't define their own openGraph. It does NOT survive a
+  // child route's openGraph object (that replaces the parent's wholesale, images
+  // included) — which is why segments defining openGraph either set an image or
+  // re-export the default via their own opengraph-image.tsx.
   openGraph: {
     siteName: 'pgh.coffee',
     title: 'pgh.coffee',

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { ImageResponse } from 'next/og'
+
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+export const alt = 'pgh.coffee — a guide to independent coffee in Pittsburgh, PA'
+
+const logoSrc = `data:image/png;base64,${readFileSync(
+  join(process.cwd(), 'public', 'logo_with_no_text_transparent_108.png'),
+).toString('base64')}`
+
+const yellow = '#fde047' // matches nav bg-yellow-300
+const gray900 = '#111827'
+const gray500 = '#6b7280'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', background: 'white' }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 16,
+            background: yellow,
+            padding: '24px 64px',
+            fontSize: 40,
+            fontWeight: 700,
+            color: gray900,
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={logoSrc} width={48} height={48} alt="" />
+          pgh.coffee
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            flexGrow: 1,
+            justifyContent: 'center',
+            padding: '0 64px',
+            gap: 32,
+          }}
+        >
+          <div style={{ fontSize: 64, fontWeight: 700, color: gray900 }}>
+            Pittsburgh&apos;s independent coffee map
+          </div>
+          <div style={{ fontSize: 34, color: gray500 }}>
+            Explore shops across the city&apos;s neighborhoods and track your visits.
+          </div>
+          <div style={{ fontSize: 30, fontWeight: 600, color: gray900 }}>Find your next favorite shop &rarr;</div>
+        </div>
+      </div>
+    ),
+    size,
+  )
+}

--- a/app/submit-a-shop/opengraph-image.tsx
+++ b/app/submit-a-shop/opengraph-image.tsx
@@ -1,0 +1,1 @@
+export { default, size, contentType, alt } from '@/app/opengraph-image'

--- a/app/submit-a-shop/page.tsx
+++ b/app/submit-a-shop/page.tsx
@@ -9,6 +9,7 @@ export const metadata: Metadata = {
   description,
   alternates: { canonical: '/submit-a-shop' },
   openGraph: {
+    siteName: 'pgh.coffee',
     title: 'Submit a Shop | pgh.coffee',
     description,
     url: '/submit-a-shop',

--- a/app/u/[id]/opengraph-image.tsx
+++ b/app/u/[id]/opengraph-image.tsx
@@ -105,6 +105,9 @@ export default async function Image({ params }: { params: Promise<{ id: string }
             <Stat value={stats.topNeighborhood} label="top neighborhood" valueSize={40} />
           )}
         </div>
+        <div style={{ fontSize: 30, fontWeight: 600, color: gray900 }}>
+          Track your own coffee passport at pgh.coffee &rarr;
+        </div>
       </Card>
     ),
     size,

--- a/app/u/[id]/page.tsx
+++ b/app/u/[id]/page.tsx
@@ -16,9 +16,20 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!profile) return { title: 'Profile not found' }
 
   const name = profile.displayName || 'Coffee lover'
+  const shopCount = profile.visits.length
+  const neighborhoodCount = new Set(profile.visits.map((v) => v.shop?.neighborhood).filter(Boolean)).size
+  const title = `${name} · pgh.coffee`
+  const description =
+    `${name} has visited ${shopCount} independent Pittsburgh coffee ${shopCount === 1 ? 'shop' : 'shops'}` +
+    ` across ${neighborhoodCount} ${neighborhoodCount === 1 ? 'neighborhood' : 'neighborhoods'}.` +
+    ' Track your own coffee passport on pgh.coffee.'
+
+  // No twitter object: the layout's { card: 'summary_large_image' } is inherited
+  // and X falls back to og:* tags plus this route's opengraph-image.tsx.
   return {
-    title: `${name} · pgh.coffee`,
-    description: `${name} has visited ${profile.visits.length} Pittsburgh coffee shops.`,
+    title,
+    description,
+    openGraph: { siteName: 'pgh.coffee', title, description },
   }
 }
 

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -103,9 +103,9 @@ export const getAllShopsForSeo = cache(async (): Promise<ShopListEntry[]> => {
  * Builds OG/Twitter metadata for a shop page from real shop data. Now that shops
  * live at a real `/shops/{slug}` path, canonical/og:url are expressed through the
  * metadata API (resolved against metadataBase in the root layout).
- * Image/photo fields are only set when present. (Note: this openGraph object
- * replaces the layout's wholesale, so a photo-less shop would emit no og:image —
- * every shop currently has a photo, so this stays theoretical.)
+ * This openGraph object replaces the layout's wholesale, so a photo-less shop
+ * falls back to the site-default OG image rather than emitting no og:image
+ * (photo is nullable in the DB even though every shop currently has one).
  */
 export function buildShopMetadata(shop: DbShop): Metadata {
   const title = `${shop.name} | ${shop.neighborhood} | pgh.coffee`
@@ -129,9 +129,9 @@ export function buildShopMetadata(shop: DbShop): Metadata {
     // inherited and X falls back to these og:* tags for title/description/image.
   }
 
-  if (shop.photo) {
-    metadata.openGraph!.images = [{ url: shop.photo, alt: shop.name }]
-  }
+  metadata.openGraph!.images = shop.photo
+    ? [{ url: shop.photo, alt: shop.name }]
+    : ['/opengraph-image']
 
   return metadata
 }

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -103,8 +103,9 @@ export const getAllShopsForSeo = cache(async (): Promise<ShopListEntry[]> => {
  * Builds OG/Twitter metadata for a shop page from real shop data. Now that shops
  * live at a real `/shops/{slug}` path, canonical/og:url are expressed through the
  * metadata API (resolved against metadataBase in the root layout).
- * Image/photo fields are only set when present; otherwise the root layout's
- * site-default image is inherited via Next's metadata merging.
+ * Image/photo fields are only set when present. (Note: this openGraph object
+ * replaces the layout's wholesale, so a photo-less shop would emit no og:image —
+ * every shop currently has a photo, so this stays theoretical.)
  */
 export function buildShopMetadata(shop: DbShop): Metadata {
   const title = `${shop.name} | ${shop.neighborhood} | pgh.coffee`
@@ -118,18 +119,18 @@ export function buildShopMetadata(shop: DbShop): Metadata {
     description,
     alternates: { canonical: path },
     openGraph: {
+      siteName: SITE_NAME,
       title,
       description,
       type: 'website',
       url: path,
     },
-    twitter: shop.photo
-      ? { card: 'summary_large_image', title, description, images: [shop.photo] }
-      : { title, description },
+    // No twitter object: the layout's { card: 'summary_large_image' } is
+    // inherited and X falls back to these og:* tags for title/description/image.
   }
 
   if (shop.photo) {
-    metadata.openGraph!.images = [{ url: shop.photo }]
+    metadata.openGraph!.images = [{ url: shop.photo, alt: shop.name }]
   }
 
   return metadata

--- a/tests/unit/profileMetadata.test.ts
+++ b/tests/unit/profileMetadata.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test, vi } from 'vitest'
+import { generateMetadata } from '@/app/u/[id]/page'
+import { getPublicProfile } from '@/app/utils/profiles'
+import type { Visit } from '@/app/utils/visitStats'
+
+vi.mock('@/app/utils/profiles', () => ({ getPublicProfile: vi.fn() }))
+
+const visit = (id: string, neighborhood: string) =>
+  ({ id, created_at: '2026-01-01', shop: { neighborhood } }) as unknown as Visit
+
+const params = Promise.resolve({ id: '00000000-0000-0000-0000-000000000000' })
+
+describe('profile generateMetadata', () => {
+  test('builds share metadata from visit stats, without a twitter object', async () => {
+    vi.mocked(getPublicProfile).mockResolvedValueOnce({
+      displayName: 'Ada',
+      avatarUrl: null,
+      visits: [visit('1', 'Bloomfield'), visit('2', 'Bloomfield'), visit('3', 'Shadyside')],
+    })
+
+    const metadata = await generateMetadata({ params })
+
+    expect(metadata.title).toBe('Ada · pgh.coffee')
+    expect(metadata.description).toBe(
+      'Ada has visited 3 independent Pittsburgh coffee shops across 2 neighborhoods. Track your own coffee passport on pgh.coffee.',
+    )
+    expect(metadata.openGraph).toMatchObject({ siteName: 'pgh.coffee', title: 'Ada · pgh.coffee' })
+    // No twitter object: the layout's { card: 'summary_large_image' } must be
+    // inherited so X falls back to og:* and this route's opengraph-image.
+    expect(metadata.twitter).toBeUndefined()
+  })
+
+  test('singularizes counts for a single visit', async () => {
+    vi.mocked(getPublicProfile).mockResolvedValueOnce({
+      displayName: null,
+      avatarUrl: null,
+      visits: [visit('1', 'Bloomfield')],
+    })
+
+    const metadata = await generateMetadata({ params })
+
+    expect(metadata.description).toContain('Coffee lover has visited 1 independent Pittsburgh coffee shop across 1 neighborhood.')
+  })
+})

--- a/tests/unit/seo.test.ts
+++ b/tests/unit/seo.test.ts
@@ -193,11 +193,13 @@ describe('buildShopMetadata', () => {
     expect(metadata.twitter).toBeUndefined()
   })
 
-  test('omits image fields when the shop has no photo, allowing site default to be inherited', () => {
+  test('falls back to the site-default OG image when the shop has no photo', () => {
+    // The openGraph object replaces the layout's wholesale, so without an
+    // explicit fallback a photo-less shop would emit no og:image at all.
     const shop: DbShop = { ...baseShop, photo: null }
     const metadata = buildShopMetadata(shop)
 
-    expect(metadata.openGraph?.images).toBeUndefined()
+    expect(metadata.openGraph?.images).toEqual(['/opengraph-image'])
     expect(metadata.twitter).toBeUndefined()
   })
 

--- a/tests/unit/seo.test.ts
+++ b/tests/unit/seo.test.ts
@@ -187,31 +187,27 @@ describe('buildShopMetadata', () => {
     expect(metadata.title).toBe('61B Cafe | Regent Square | pgh.coffee')
     expect(metadata.alternates?.canonical).toBe('/shops/61b-cafe-regent-square-00000000')
     expect(metadata.openGraph?.url).toBe('/shops/61b-cafe-regent-square-00000000')
-    expect(metadata.openGraph?.images).toEqual([{ url: baseShop.photo }])
-    const twitter = metadata.twitter as { card?: string; images?: unknown } | undefined
-    expect(twitter?.card).toBe('summary_large_image')
-    expect(twitter?.images).toEqual([baseShop.photo])
+    expect(metadata.openGraph?.images).toEqual([{ url: baseShop.photo, alt: baseShop.name }])
+    // No twitter object: the layout's { card: 'summary_large_image' } is inherited
+    // and X falls back to the og:* tags.
+    expect(metadata.twitter).toBeUndefined()
   })
 
   test('omits image fields when the shop has no photo, allowing site default to be inherited', () => {
     const shop: DbShop = { ...baseShop, photo: null }
     const metadata = buildShopMetadata(shop)
-    const twitter = metadata.twitter as { card?: string; images?: unknown } | undefined
 
     expect(metadata.openGraph?.images).toBeUndefined()
-    expect(twitter?.images).toBeUndefined()
-    expect(twitter?.card).toBeUndefined()
+    expect(metadata.twitter).toBeUndefined()
   })
 
   test('prefers the trimmed shop description over the generated template', () => {
     const shop: DbShop = { ...baseShop, description: '  A long-running Regent Square coffee bar.  ' }
     const metadata = buildShopMetadata(shop)
     const expected = 'A long-running Regent Square coffee bar.'
-    const twitter = metadata.twitter as { description?: string } | undefined
 
     expect(metadata.description).toBe(expected)
     expect(metadata.openGraph?.description).toBe(expected)
-    expect(twitter?.description).toBe(expected)
   })
 
   test('falls back to the generated template when the description is whitespace-only', () => {


### PR DESCRIPTION
## What do these changes accomplish?

Closes #341. Stacked on #340.

- Every route now emits a correct `og:image`: a generated branded card (tagline + CTA) is the site default via `app/opengraph-image.tsx`, shop pages keep their photo, profiles keep the passport card — on both `og:image` and `twitter:image`.
- `og:site_name` is emitted on every page.
- Profile shares show the person's name and a ~140-char description with visit stats instead of the generic site title/tagline.
- The layout's `twitter` config is reduced to `{ card: 'summary_large_image' }`; per-route og tags now drive Twitter cards, and the redundant per-route `twitter` objects are gone.
- Both generated OG images carry conversion text; shop photos get `og:image:alt`; home `og:title` unified to `pgh.coffee`.

## Why?

Checker reports (#341) flagged missing images, missing site name, and short/generic descriptions. The root cause of most of it: Next's metadata merge replaces a parent's `openGraph`/`twitter` objects wholesale, so any route defining its own `openGraph` silently dropped the layout's images and `siteName`, and the layout's static `twitter:image` overrode the dynamic profile passport card from #340 on X. A file-based default image (re-exported into segments that define their own `openGraph`, since a parent's file image doesn't survive a child's `openGraph` either) plus a card-type-only `twitter` config makes per-route metadata win by default instead of leaking generic values everywhere.

Skipped `og:image:width/height` on shop photos — dimensions vary per photo and aren't known at build.

Verified every route's rendered tags locally plus both generated images; `npm run lint`, `npm test` (308 passed), and `npm run build` all pass.