### PR TITLE
Add motion where state changes were jarring or unacknowledged

### DIFF
--- a/app/components/FavoriteButton.tsx
+++ b/app/components/FavoriteButton.tsx
@@ -21,8 +21,6 @@ export default function FavoriteButton({ shopUUID, shopName }: FavoriteButtonPro
   const [isLoading, setIsLoading] = useState(true)
   const [showToast, setShowToast] = useState(false)
   const [showLoginModal, setShowLoginModal] = useState(false)
-  // Pop only when the user adds a favorite, never on initial render of an
-  // already-favorited shop.
   const [justAdded, setJustAdded] = useState(false)
 
   useEffect(() => {

--- a/app/components/FavoriteButton.tsx
+++ b/app/components/FavoriteButton.tsx
@@ -21,6 +21,9 @@ export default function FavoriteButton({ shopUUID, shopName }: FavoriteButtonPro
   const [isLoading, setIsLoading] = useState(true)
   const [showToast, setShowToast] = useState(false)
   const [showLoginModal, setShowLoginModal] = useState(false)
+  // Pop only when the user adds a favorite, never on initial render of an
+  // already-favorited shop.
+  const [justAdded, setJustAdded] = useState(false)
 
   useEffect(() => {
     const checkFavoriteStatus = async () => {
@@ -74,6 +77,7 @@ export default function FavoriteButton({ shopUUID, shopName }: FavoriteButtonPro
         })
         if (!wasAlreadyFavorited) {
           setShowToast(true)
+          setJustAdded(true)
         }
       }
     } catch (error) {
@@ -91,9 +95,12 @@ export default function FavoriteButton({ shopUUID, shopName }: FavoriteButtonPro
         aria-label={isFavorited ? 'Favorited' : 'Favorite'}
         aria-pressed={isFavorited}
         title={isFavorited ? 'Favorited' : 'Favorite'}
-        className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-200 bg-white text-stone-700 hover:bg-stone-100 transition-colors disabled:opacity-50"
+        className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-200 bg-white text-stone-700 hover:bg-stone-100 transition ease-out active:scale-95 disabled:opacity-50"
       >
-        <Heart className={`size-[18px] transition-colors ${isFavorited ? 'fill-red-500 text-red-500' : ''}`} />
+        <Heart
+          onAnimationEnd={() => setJustAdded(false)}
+          className={`size-[18px] transition-colors ${isFavorited ? 'fill-red-500 text-red-500' : ''} ${justAdded ? 'animate-pop motion-reduce:animate-none' : ''}`}
+        />
       </button>
 
       <FavoriteToast isOpen={showToast} onClose={() => setShowToast(false)} shopName={shopName} />

--- a/app/components/IssueModal.tsx
+++ b/app/components/IssueModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react'
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react'
 import { TShop } from '@/types/shop-types'
 import IssueForm from './IssueForm'
 
@@ -14,9 +14,15 @@ interface Props {
 export default function IssueModal({ isOpen, onClose, onSuccess, shop }: Props) {
   return (
     <Dialog open={isOpen} onClose={onClose} className="relative z-50">
-      <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+      <DialogBackdrop
+        transition
+        className="fixed inset-0 bg-black/30 transition-opacity data-closed:opacity-0 data-enter:duration-300 data-leave:duration-200 data-enter:ease-out data-leave:ease-in"
+      />
       <div className="fixed inset-0 flex items-center justify-center p-4">
-        <DialogPanel className="relative max-w-md w-full bg-white rounded-xl p-6 shadow-xl">
+        <DialogPanel
+          transition
+          className="relative max-w-md w-full bg-white rounded-xl p-6 shadow-xl transition-all data-closed:translate-y-4 data-closed:opacity-0 data-enter:duration-300 data-leave:duration-200 data-enter:ease-out data-leave:ease-in sm:data-closed:translate-y-0 sm:data-closed:scale-95"
+        >
           <button
             type="button"
             onClick={onClose}

--- a/app/components/IssueModal.tsx
+++ b/app/components/IssueModal.tsx
@@ -21,7 +21,7 @@ export default function IssueModal({ isOpen, onClose, onSuccess, shop }: Props) 
       <div className="fixed inset-0 flex items-center justify-center p-4">
         <DialogPanel
           transition
-          className="relative max-w-md w-full bg-white rounded-xl p-6 shadow-xl transition-all data-closed:translate-y-4 data-closed:opacity-0 data-enter:duration-300 data-leave:duration-200 data-enter:ease-out data-leave:ease-in sm:data-closed:translate-y-0 sm:data-closed:scale-95"
+          className="relative max-w-md w-full bg-white rounded-xl p-6 shadow-xl transition-all motion-safe:data-closed:translate-y-4 data-closed:opacity-0 data-enter:duration-300 data-leave:duration-200 data-enter:ease-out data-leave:ease-in sm:motion-safe:data-closed:translate-y-0 sm:motion-safe:data-closed:scale-95"
         >
           <button
             type="button"

--- a/app/components/LoginPromptModal.tsx
+++ b/app/components/LoginPromptModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react'
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react'
 import AuthForm from './AuthForm'
 
 interface LoginPromptModalProps {
@@ -11,9 +11,15 @@ interface LoginPromptModalProps {
 export default function LoginPromptModal({ isOpen, onClose }: LoginPromptModalProps) {
   return (
     <Dialog open={isOpen} onClose={onClose} className="relative z-50">
-      <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+      <DialogBackdrop
+        transition
+        className="fixed inset-0 bg-black/30 transition-opacity data-closed:opacity-0 data-enter:duration-300 data-leave:duration-200 data-enter:ease-out data-leave:ease-in"
+      />
       <div className="fixed inset-0 flex items-center justify-center p-4">
-        <DialogPanel className="max-w-md w-full bg-white rounded-xl p-6 shadow-xl">
+        <DialogPanel
+          transition
+          className="max-w-md w-full bg-white rounded-xl p-6 shadow-xl transition-all data-closed:translate-y-4 data-closed:opacity-0 data-enter:duration-300 data-leave:duration-200 data-enter:ease-out data-leave:ease-in sm:data-closed:translate-y-0 sm:data-closed:scale-95"
+        >
           <DialogTitle className="text-lg font-semibold text-stone-900 mb-2">
             Sign in to save favorites
           </DialogTitle>

--- a/app/components/LoginPromptModal.tsx
+++ b/app/components/LoginPromptModal.tsx
@@ -18,7 +18,7 @@ export default function LoginPromptModal({ isOpen, onClose }: LoginPromptModalPr
       <div className="fixed inset-0 flex items-center justify-center p-4">
         <DialogPanel
           transition
-          className="max-w-md w-full bg-white rounded-xl p-6 shadow-xl transition-all data-closed:translate-y-4 data-closed:opacity-0 data-enter:duration-300 data-leave:duration-200 data-enter:ease-out data-leave:ease-in sm:data-closed:translate-y-0 sm:data-closed:scale-95"
+          className="max-w-md w-full bg-white rounded-xl p-6 shadow-xl transition-all motion-safe:data-closed:translate-y-4 data-closed:opacity-0 data-enter:duration-300 data-leave:duration-200 data-enter:ease-out data-leave:ease-in sm:motion-safe:data-closed:translate-y-0 sm:motion-safe:data-closed:scale-95"
         >
           <DialogTitle className="text-lg font-semibold text-stone-900 mb-2">
             Sign in to save favorites

--- a/app/components/SearchFAB.tsx
+++ b/app/components/SearchFAB.tsx
@@ -19,7 +19,7 @@ export default function SearchFAB({ handleClick }: IProps) {
     <button
       type="button"
       aria-label="Search shops"
-      className="absolute bottom-[15%] right-[5%] bg-yellow-300 hover:bg-yellow-400 rounded-full size-16 flex justify-center items-center z-10"
+      className="absolute bottom-[15%] right-[5%] bg-yellow-300 hover:bg-yellow-400 rounded-full size-16 flex justify-center items-center z-10 transition ease-out active:scale-95"
       onClick={handleFABClick}
     >
       <MagnifyingGlassIcon className="size-8" />

--- a/app/components/SearchFAB.tsx
+++ b/app/components/SearchFAB.tsx
@@ -19,7 +19,7 @@ export default function SearchFAB({ handleClick }: IProps) {
     <button
       type="button"
       aria-label="Search shops"
-      className="absolute bottom-[15%] right-[5%] bg-yellow-300 hover:bg-yellow-400 rounded-full size-16 flex justify-center items-center z-10 transition ease-out active:scale-95"
+      className="absolute bottom-[15%] right-[5%] bg-yellow-300 hover:bg-yellow-400 rounded-full size-16 flex justify-center items-center z-10 transition ease-out motion-safe:active:scale-95"
       onClick={handleFABClick}
     >
       <MagnifyingGlassIcon className="size-8" />

--- a/app/components/VisitedButton.tsx
+++ b/app/components/VisitedButton.tsx
@@ -21,8 +21,6 @@ export default function VisitedButton({ shopUUID, shopName }: VisitedButtonProps
   const [isLoading, setIsLoading] = useState(true)
   const [showToast, setShowToast] = useState(false)
   const [showLoginModal, setShowLoginModal] = useState(false)
-  // Pop only when the user marks a visit, never on initial render of an
-  // already-visited shop.
   const [justAdded, setJustAdded] = useState(false)
 
   useEffect(() => {

--- a/app/components/VisitedButton.tsx
+++ b/app/components/VisitedButton.tsx
@@ -21,6 +21,9 @@ export default function VisitedButton({ shopUUID, shopName }: VisitedButtonProps
   const [isLoading, setIsLoading] = useState(true)
   const [showToast, setShowToast] = useState(false)
   const [showLoginModal, setShowLoginModal] = useState(false)
+  // Pop only when the user marks a visit, never on initial render of an
+  // already-visited shop.
+  const [justAdded, setJustAdded] = useState(false)
 
   useEffect(() => {
     const checkVisitedStatus = async () => {
@@ -74,6 +77,7 @@ export default function VisitedButton({ shopUUID, shopName }: VisitedButtonProps
         })
         if (!wasAlreadyVisited) {
           setShowToast(true)
+          setJustAdded(true)
         }
       }
     } catch (error) {
@@ -91,9 +95,12 @@ export default function VisitedButton({ shopUUID, shopName }: VisitedButtonProps
         aria-label={isVisited ? 'Visited' : 'Mark as visited'}
         aria-pressed={isVisited}
         title={isVisited ? 'Visited' : 'Mark as visited'}
-        className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-200 bg-white text-stone-700 hover:bg-stone-100 transition-colors disabled:opacity-50"
+        className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-200 bg-white text-stone-700 hover:bg-stone-100 transition ease-out active:scale-95 disabled:opacity-50"
       >
-        <Stamp className={`size-[18px] transition-colors ${isVisited ? 'fill-green-500 text-white' : ''}`} />
+        <Stamp
+          onAnimationEnd={() => setJustAdded(false)}
+          className={`size-[18px] transition-colors ${isVisited ? 'fill-green-500 text-white' : ''} ${justAdded ? 'animate-pop motion-reduce:animate-none' : ''}`}
+        />
       </button>
 
       <VisitedToast isOpen={showToast} onClose={() => setShowToast(false)} shopName={shopName} />

--- a/app/components/VisitedToast.tsx
+++ b/app/components/VisitedToast.tsx
@@ -35,7 +35,7 @@ export default function VisitedToast({ isOpen, onClose, shopName }: VisitedToast
               leaveTo="opacity-0 translate-y-4"
             >
               <DialogPanel className="bg-stone-900 text-white rounded-xl px-4 py-3 shadow-lg flex flex-col lg:flex-row items-center gap-3">
-                <Stamp className="w-5 h-5 fill-green-500 text-white flex-shrink-0" />
+                <Stamp className="w-5 h-5 fill-green-500 text-white flex-shrink-0 animate-stamp motion-reduce:animate-none" />
                 <p className="text-sm">
                   <span className="font-medium">{shopName}</span> marked as visited
                 </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,31 @@
 
 @config '../tailwind.config.ts';
 
+@theme {
+  --animate-stamp: stamp 350ms ease-out 150ms backwards;
+  --animate-pop: pop 300ms ease-out;
+
+  @keyframes stamp {
+    from {
+      transform: scale(1.6) rotate(-10deg);
+      opacity: 0;
+    }
+    70% {
+      transform: scale(0.95) rotate(2deg);
+      opacity: 1;
+    }
+    to {
+      transform: scale(1) rotate(0deg);
+    }
+  }
+
+  @keyframes pop {
+    50% {
+      transform: scale(1.3);
+    }
+  }
+}
+
 :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;


### PR DESCRIPTION
Output of an animation-opportunity sweep: four moments where the UI changed state with no acknowledgment, plus deliberate rejections (map markers, search results, skeleton swaps stay animation-free — they're core-loop surfaces).

## Changes

- **IssueModal / LoginPromptModal**: these were the only two dialogs in the app that popped in with no transition. Now use `DialogBackdrop`/`DialogPanel` with the same enter/leave classes as `IssueSuccessDialog`, `PhotoDialog`, and `SuccessDialog`.
- **VisitedToast**: the stamp icon lands like a passport stamp — scales down from 1.6 with a slight rotation and overshoot (350ms, delayed 150ms so the toast settles first).
- **FavoriteButton / VisitedButton**: `active:scale-95` press feedback, and the heart/stamp icon pops once when toggled on. Gated by a `justAdded` flag set only on user-initiated adds, so already-favorited shops don't animate on page load.
- **SearchFAB**: press feedback and a hover-color transition on the mobile search button.

Keyframes live in `@theme` in `globals.css` (first ones in the repo) and carry `motion-reduce:animate-none`; dialog/toast fades remain as the reduced-motion fallback.

## Testing

- `npm run lint` clean (one pre-existing warning in `app/u/[id]/page.tsx`)
- `npm test`: 306 passed
- `npm run build` passes; compiled CSS verified to contain the `stamp`/`pop` keyframes and utilities