### PR TITLE
Add neighborhood landing pages

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -1,0 +1,6 @@
+# Papercuts
+
+Small frictions hit while working in this repo. Append-only.
+
+- **2026-07-23** — Verifying SSR output with `grep -c` on Next.js HTML → counted 1 because the whole page is one line; `grep -o | wc -l` needed for per-match counts. _Generic grep gotcha, but bit here because Next emits single-line HTML._
+- **2026-07-23** — Widened `ShopListEntry` in `app/utils/seo.ts` → `tests/unit/seo.test.ts` fixtures broke because they hand-build entry objects instead of using a factory. _A `makeShopListEntry()` helper in the test would absorb future field additions._

--- a/app/(map)/shops/[slug]/page.tsx
+++ b/app/(map)/shops/[slug]/page.tsx
@@ -1,13 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import {
-  getShopForSeo,
-  getNeighborhoodAreas,
-  buildShopMetadata,
-  buildShopJsonLd,
-  jsonLdToString,
-} from '@/app/utils/seo'
+import { getShopForSeo, buildShopMetadata, buildShopJsonLd, jsonLdToString } from '@/app/utils/seo'
 import { areaForNeighborhood, areaPath } from '@/app/utils/neighborhoodAreas'
 import { formatDBShopAsFeature } from '@/app/utils/utils'
 import ShopSeed from './ShopSeed'
@@ -29,7 +23,6 @@ export default async function ShopPage({ params }: Props) {
   if (!shop) notFound()
 
   const area = areaForNeighborhood(shop.neighborhood)
-  const areaHasPage = (await getNeighborhoodAreas()).some(a => a.area === area)
 
   return (
     <>
@@ -40,11 +33,9 @@ export default async function ShopPage({ params }: Props) {
       <h1 className="sr-only">{shop.name}</h1>
       {/* Crawlable (no-JS) internal link to the neighborhood landing page;
           the visible equivalent lives in the client-rendered PanelHeader. */}
-      {areaHasPage && (
-        <Link className="sr-only" href={areaPath(area)}>
-          Coffee shops in {area}
-        </Link>
-      )}
+      <Link className="sr-only" href={areaPath(area)}>
+        Coffee shops in {area}
+      </Link>
       {/* Seed the client store with the shop the server already fetched so
           useShopRouteSync short-circuits instead of re-fetching over the API. */}
       <ShopSeed shop={formatDBShopAsFeature(shop)} />

--- a/app/(map)/shops/[slug]/page.tsx
+++ b/app/(map)/shops/[slug]/page.tsx
@@ -1,6 +1,14 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { getShopForSeo, buildShopMetadata, buildShopJsonLd, jsonLdToString } from '@/app/utils/seo'
+import {
+  getShopForSeo,
+  getNeighborhoodAreas,
+  buildShopMetadata,
+  buildShopJsonLd,
+  jsonLdToString,
+} from '@/app/utils/seo'
+import { areaForNeighborhood, areaPath } from '@/app/utils/neighborhoodAreas'
 import { formatDBShopAsFeature } from '@/app/utils/utils'
 import ShopSeed from './ShopSeed'
 
@@ -20,6 +28,9 @@ export default async function ShopPage({ params }: Props) {
 
   if (!shop) notFound()
 
+  const area = areaForNeighborhood(shop.neighborhood)
+  const areaHasPage = (await getNeighborhoodAreas()).some(a => a.area === area)
+
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLdToString(buildShopJsonLd(shop)) }} />
@@ -27,6 +38,13 @@ export default async function ShopPage({ params }: Props) {
           client-side data fetching completes, so the server-rendered HTML
           has none. */}
       <h1 className="sr-only">{shop.name}</h1>
+      {/* Crawlable (no-JS) internal link to the neighborhood landing page;
+          the visible equivalent lives in the client-rendered PanelHeader. */}
+      {areaHasPage && (
+        <Link className="sr-only" href={areaPath(area)}>
+          Coffee shops in {area}
+        </Link>
+      )}
       {/* Seed the client store with the shop the server already fetched so
           useShopRouteSync short-circuits instead of re-fetching over the API. */}
       <ShopSeed shop={formatDBShopAsFeature(shop)} />

--- a/app/components/Explore/NeighborhoodsCTA.tsx
+++ b/app/components/Explore/NeighborhoodsCTA.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import Link from 'next/link'
+import { ChevronRight } from 'lucide-react'
+import { useAnalytics } from '@/hooks'
+import useShopsStore from '@/stores/coffeeShopsStore'
+import { areaPath, groupShopsIntoAreas, shopNoun } from '@/app/utils/neighborhoodAreas'
+
+export const NeighborhoodsCTA = () => {
+  const plausible = useAnalytics()
+  const allShops = useShopsStore(s => s.allShops)
+  const topAreas = groupShopsIntoAreas(allShops.features.map(f => f.properties)).slice(0, 4)
+
+  if (topAreas.length === 0) return null
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <h3 className="flex-1 text-xs font-semibold uppercase tracking-wider text-stone-500">Neighborhoods</h3>
+        <Link
+          href="/neighborhoods"
+          className="flex gap-0.5 items-center text-sm font-medium transition-colors hover:opacity-80"
+          style={{ color: 'lab(45 10 50)' }}
+          onClick={() => plausible('ViewAllClick', { props: { section: 'neighborhoods' } })}
+        >
+          View all
+          <ChevronRight className="size-5" />
+        </Link>
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-3">
+        {topAreas.map(({ area, shops }) => {
+          const cover = shops.find(shop => shop.photo)?.photo
+          return (
+            <Link
+              key={area}
+              href={areaPath(area)}
+              className="group relative flex h-24 items-end overflow-hidden rounded-md shadow-sm"
+            >
+              {cover ? (
+                <img
+                  src={cover}
+                  alt=""
+                  loading="lazy"
+                  className="absolute inset-0 h-full w-full object-cover object-center transition group-hover:scale-105"
+                />
+              ) : (
+                <div className="absolute inset-0 bg-yellow-200" />
+              )}
+              <div className="absolute inset-0 bg-gradient-to-t from-black/75 to-transparent" />
+              <div className="relative p-2.5 text-white">
+                <p className="font-medium leading-tight">{area}</p>
+                <p className="text-xs text-white/80">
+                  {shops.length} {shopNoun(shops.length)}
+                </p>
+              </div>
+            </Link>
+          )
+        })}
+      </div>
+    </>
+  )
+}

--- a/app/components/ExploreContent.tsx
+++ b/app/components/ExploreContent.tsx
@@ -5,6 +5,7 @@ import { TShop } from '@/types/shop-types'
 import FeaturedShop from './Explore/FeaturedShop'
 import { EventsCTA } from './Explore/EventsCTA'
 import { NewsCTA } from './Explore/NewsCTA'
+import { NeighborhoodsCTA } from './Explore/NeighborhoodsCTA'
 import useShopsStore from '@/stores/coffeeShopsStore'
 import { AmenityFilterList } from './AmenityFilterList'
 
@@ -26,6 +27,9 @@ export const ExploreContent = () => {
     <div className="flex h-full flex-col overflow-y-auto">
       <div className="flex flex-col sm:grid gap-3 px-6 lg:px-4 mt-16 mb-8">
         <AmenityFilterList />
+        <div>
+          <NeighborhoodsCTA />
+        </div>
         <div>
           <NewsCTA />
         </div>

--- a/app/components/MapContainer.tsx
+++ b/app/components/MapContainer.tsx
@@ -70,6 +70,41 @@ export default function MapContainer({ currentShopCoordinates }: MapContainerPro
 
   useEffect(panToCurrentShop, [currentShopCoordinates])
 
+  // On arrival via `?neighborhood=`, fit the camera to that neighborhood's shops
+  // (displayedShops is already filtered to them). react-map-gl attaches mapRef
+  // asynchronously without a re-render, so poll via rAF until the map's style is
+  // loaded and the filtered shops have arrived, then fit once. Give up after a
+  // few seconds so a name that filters to nothing can't loop forever.
+  const displayedShopsRef = useRef(displayedShops)
+  displayedShopsRef.current = displayedShops
+  useEffect(() => {
+    if (!new URLSearchParams(window.location.search).has('neighborhood')) return
+    let raf = 0
+    let attempts = 0
+    const tryFit = () => {
+      const map = mapRef.current?.getMap()
+      const points = displayedShopsRef.current.features
+        .map(f => f.geometry.coordinates)
+        .filter(([lng, lat]) => Number.isFinite(lng) && Number.isFinite(lat))
+      if ((!map || !map.isStyleLoaded() || points.length === 0) && attempts++ < 180) {
+        raf = requestAnimationFrame(tryFit)
+        return
+      }
+      if (!map || points.length === 0) return
+      const lngs = points.map(p => p[0])
+      const lats = points.map(p => p[1])
+      map.fitBounds(
+        [
+          [Math.min(...lngs), Math.min(...lats)],
+          [Math.max(...lngs), Math.max(...lats)],
+        ],
+        { padding: 80, maxZoom: 15, duration: 1000 }
+      )
+    }
+    tryFit()
+    return () => cancelAnimationFrame(raf)
+  }, [])
+
   const shopsWithHoverState = useMemo(() => {
     if (!displayedShops?.features) return displayedShops
 

--- a/app/components/MobileNavDrawer.tsx
+++ b/app/components/MobileNavDrawer.tsx
@@ -2,7 +2,7 @@
 
 import { Sheet } from '@silk-hq/components'
 import Link from 'next/link'
-import { Info, User, ChevronRight, Plus } from 'lucide-react'
+import { Info, User, ChevronRight, Plus, MapPin } from 'lucide-react'
 import { useAuth } from '@/app/components/AuthProvider'
 
 interface IProps {
@@ -35,6 +35,18 @@ export default function MobileNavDrawer({ presented, onPresentedChange }: IProps
             <div className="px-6 pb-6 pt-2">
               {/* Navigation Links */}
               <nav className="flex flex-col">
+                <Link
+                  href="/neighborhoods"
+                  onClick={handleLinkClick}
+                  className="flex items-center py-4 border-b border-gray-100"
+                >
+                  <span className="flex items-center justify-center size-10 rounded-full bg-gray-100">
+                    <MapPin className="size-5 text-gray-600" />
+                  </span>
+                  <span className="flex-1 ml-4 text-base font-medium text-gray-900">Neighborhoods</span>
+                  <ChevronRight className="size-5 text-gray-400" />
+                </Link>
+
                 <Link
                   href="/about"
                   onClick={handleLinkClick}

--- a/app/components/Nav.tsx
+++ b/app/components/Nav.tsx
@@ -26,6 +26,9 @@ export default function Nav() {
         </Link>
       </span>
       <div className="hidden sm:flex items-center gap-6">
+        <Link className="flex gap-1 text-md hover:bg-black/5 p-2 hover:rounded-lg" href="/neighborhoods">
+          Neighborhoods
+        </Link>
         <Link className="flex gap-1 text-md hover:bg-black/5 p-2 hover:rounded-lg" href="/about">
           About
         </Link>

--- a/app/components/PanelHeader.tsx
+++ b/app/components/PanelHeader.tsx
@@ -1,9 +1,12 @@
 'use client'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useAnalytics } from '@/hooks'
 import { TShop } from '@/types/shop-types'
 import VerifiedBadge from './VerifiedBadge'
 import { BuildingStorefrontIcon } from '@heroicons/react/24/outline'
+import useShopsStore from '@/stores/coffeeShopsStore'
+import { areaForNeighborhood, areaPath, MIN_SHOPS_FOR_AREA_PAGE } from '@/app/utils/neighborhoodAreas'
 
 interface IProps {
   shop: TShop
@@ -17,6 +20,14 @@ export default function PanelHeader(props: IProps) {
   const isVerified = verified || company?.is_verified
 
   const hasPhoto = !!photo
+
+  // Only link the neighborhood when its area landing page exists (same
+  // shop-count threshold the server uses to decide which pages to render).
+  const area = areaForNeighborhood(neighborhood)
+  const areaShopCount = useShopsStore(
+    state => state.allShops.features.filter(f => areaForNeighborhood(f.properties.neighborhood) === area).length
+  )
+  const areaHasPage = areaShopCount >= MIN_SHOPS_FOR_AREA_PAGE
 
   return (
     <div id="header" data-testid="header">
@@ -50,7 +61,19 @@ export default function PanelHeader(props: IProps) {
             {name}
             {isVerified && <VerifiedBadge className="mt-0.5" />}
           </h1>
-          <p className="text-base text-white/80 mt-0.5">{neighborhood}</p>
+          <p className="text-base text-white/80 mt-0.5">
+            {areaHasPage ? (
+              <Link
+                href={areaPath(area)}
+                onClick={e => e.stopPropagation()}
+                className="underline underline-offset-2 hover:text-white"
+              >
+                {neighborhood}
+              </Link>
+            ) : (
+              neighborhood
+            )}
+          </p>
         </div>
       </div>
     </div>

--- a/app/components/PanelHeader.tsx
+++ b/app/components/PanelHeader.tsx
@@ -5,8 +5,7 @@ import { useAnalytics } from '@/hooks'
 import { TShop } from '@/types/shop-types'
 import VerifiedBadge from './VerifiedBadge'
 import { BuildingStorefrontIcon } from '@heroicons/react/24/outline'
-import useShopsStore from '@/stores/coffeeShopsStore'
-import { areaForNeighborhood, areaPath, MIN_SHOPS_FOR_AREA_PAGE } from '@/app/utils/neighborhoodAreas'
+import { areaForNeighborhood, areaPath } from '@/app/utils/neighborhoodAreas'
 
 interface IProps {
   shop: TShop
@@ -21,13 +20,8 @@ export default function PanelHeader(props: IProps) {
 
   const hasPhoto = !!photo
 
-  // Only link the neighborhood when its area landing page exists (same
-  // shop-count threshold the server uses to decide which pages to render).
+  // Every neighborhood with a shop has a landing page, so this shop's always does.
   const area = areaForNeighborhood(neighborhood)
-  const areaShopCount = useShopsStore(
-    state => state.allShops.features.filter(f => areaForNeighborhood(f.properties.neighborhood) === area).length
-  )
-  const areaHasPage = areaShopCount >= MIN_SHOPS_FOR_AREA_PAGE
 
   return (
     <div id="header" data-testid="header">
@@ -62,17 +56,13 @@ export default function PanelHeader(props: IProps) {
             {isVerified && <VerifiedBadge className="mt-0.5" />}
           </h1>
           <p className="text-base text-white/80 mt-0.5">
-            {areaHasPage ? (
-              <Link
-                href={areaPath(area)}
-                onClick={e => e.stopPropagation()}
-                className="underline underline-offset-2 hover:text-white"
-              >
-                {neighborhood}
-              </Link>
-            ) : (
-              neighborhood
-            )}
+            <Link
+              href={areaPath(area)}
+              onClick={e => e.stopPropagation()}
+              className="underline underline-offset-2 hover:text-white"
+            >
+              {neighborhood}
+            </Link>
           </p>
         </div>
       </div>

--- a/app/components/ShopSearch.tsx
+++ b/app/components/ShopSearch.tsx
@@ -1,20 +1,49 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import { useDisplayedShops } from '@/stores/coffeeShopsStore'
+import Link from 'next/link'
+import useShopsStore, { useDisplayedShops } from '@/stores/coffeeShopsStore'
 import ShopList from '@/app/components/ShopList'
+import { areaPath, groupShopsIntoAreas } from '@/app/utils/neighborhoodAreas'
+import { slugify } from '@/app/utils/shopSlug'
+import { MapPinIcon } from '@heroicons/react/24/outline'
 
 const AmenityFilterList = dynamic(() => import('./AmenityFilterList').then(m => ({ default: m.AmenityFilterList })), {
   ssr: false,
 })
 
+// Areas whose name starts with the search query, so typing "squi" surfaces the
+// Squirrel Hill guide. Requires 3+ chars to keep single-letter queries quiet.
+function matchingAreaLinks(searchValue: string, features: { properties: { neighborhood: string } }[]) {
+  const query = slugify(searchValue)
+  if (query.length < 3) return []
+  const areas = groupShopsIntoAreas(features.map(f => f.properties))
+  return areas.filter(({ area }) => slugify(area).startsWith(query))
+}
+
 export default function ShopSearch() {
   const displayedShops = useDisplayedShops()
+  const searchValue = useShopsStore(s => s.searchValue)
+  const allShops = useShopsStore(s => s.allShops)
+  const areaLinks = matchingAreaLinks(searchValue, allShops.features)
 
   return (
     <div className="flex h-full flex-col overflow-y-auto px-4 sm:px-6">
       <div className="mt-12">
         <AmenityFilterList />
+        {areaLinks.map(({ area, shops }) => (
+          <Link
+            key={area}
+            href={areaPath(area)}
+            className="mt-4 flex items-center gap-2 rounded-lg border border-stone-200 px-4 py-3 text-sm hover:bg-stone-50"
+          >
+            <MapPinIcon className="h-4 w-4 shrink-0" />
+            <span>
+              <span className="font-medium">Coffee shops in {area}</span>
+              <span className="ml-2 text-stone-500">{shops.length} shops</span>
+            </span>
+          </Link>
+        ))}
         <ShopList coffeeShops={displayedShops.features} />
       </div>
     </div>

--- a/app/components/ShopSearch.tsx
+++ b/app/components/ShopSearch.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import useShopsStore, { useDisplayedShops } from '@/stores/coffeeShopsStore'
 import ShopList from '@/app/components/ShopList'
-import { areaPath, groupShopsIntoAreas } from '@/app/utils/neighborhoodAreas'
+import { areaPath, groupShopsIntoAreas, shopNoun } from '@/app/utils/neighborhoodAreas'
 import { slugify } from '@/app/utils/shopSlug'
 import { MapPinIcon } from '@heroicons/react/24/outline'
 
@@ -40,7 +40,7 @@ export default function ShopSearch() {
             <MapPinIcon className="h-4 w-4 shrink-0" />
             <span>
               <span className="font-medium">Coffee shops in {area}</span>
-              <span className="ml-2 text-stone-500">{shops.length} shops</span>
+              <span className="ml-2 text-stone-500">{shops.length} {shopNoun(shops.length)}</span>
             </span>
           </Link>
         ))}

--- a/app/neighborhoods/[slug]/page.tsx
+++ b/app/neighborhoods/[slug]/page.tsx
@@ -3,12 +3,13 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import {
   getAreaBySlug,
+  getNeighborhoodAreas,
   buildAreaMetadata,
   buildAreaJsonLd,
   buildShopPath,
   jsonLdToString,
 } from '@/app/utils/seo'
-import { shopNoun } from '@/app/utils/neighborhoodAreas'
+import { areaPath, nearestAreas, shopNoun } from '@/app/utils/neighborhoodAreas'
 import VerifiedBadge from '@/app/components/VerifiedBadge'
 import { Footer } from '@/app/components/about'
 
@@ -24,6 +25,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function NeighborhoodPage({ params }: Props) {
   const area = await getAreaBySlug((await params).slug)
   if (!area) notFound()
+
+  const nearby = nearestAreas(area, await getNeighborhoodAreas(), 5)
 
   return (
     <div className="flex min-h-[calc(100vh-4rem)] flex-col">
@@ -57,13 +60,38 @@ export default async function NeighborhoodPage({ params }: Props) {
           </li>
         ))}
       </ul>
+
+      {/* Plain <a> forces a full load so useURLNeighborhoodSync's mount effect
+          runs — a soft Link navigation fires neither mount nor popstate, so the
+          neighborhood filter would never apply. */}
+      <a
+        href={`/?neighborhood=${encodeURIComponent(area.area)}`}
+        className="mt-10 inline-flex items-center gap-2 rounded-full bg-yellow-300 px-5 py-2.5 font-medium text-stone-900 transition hover:bg-yellow-400"
+      >
+        See {area.area} on the map
+        <span aria-hidden>→</span>
+      </a>
+
+      {nearby.length > 0 && (
+        <div className="mt-10">
+          <p className="text-sm font-medium text-stone-500">Nearby neighborhoods</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {nearby.map(({ area: name, shops }) => (
+              <Link
+                key={name}
+                href={areaPath(name)}
+                className="rounded-full border border-stone-200 px-3 py-1.5 text-sm transition hover:border-stone-300 hover:bg-stone-50"
+              >
+                {name} <span className="text-stone-400">{shops.length}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
       <p className="mt-10 text-sm">
-        <Link href="/neighborhoods" className="underline underline-offset-2">
+        <Link href="/neighborhoods" className="text-stone-500 underline underline-offset-2 hover:text-stone-700">
           All neighborhoods
-        </Link>{' '}
-        ·{' '}
-        <Link href="/" className="underline underline-offset-2">
-          View the map
         </Link>
       </p>
     </div>

--- a/app/neighborhoods/[slug]/page.tsx
+++ b/app/neighborhoods/[slug]/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import {
+  getAreaBySlug,
+  buildAreaMetadata,
+  buildAreaJsonLd,
+  buildShopPath,
+  jsonLdToString,
+} from '@/app/utils/seo'
+
+type Props = {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const area = await getAreaBySlug((await params).slug)
+  return area ? buildAreaMetadata(area) : {}
+}
+
+export default async function NeighborhoodPage({ params }: Props) {
+  const area = await getAreaBySlug((await params).slug)
+  if (!area) notFound()
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-10">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLdToString(buildAreaJsonLd(area)) }} />
+      <h1 className="text-3xl font-serif tracking-tight">Coffee shops in {area.area}</h1>
+      <p className="mt-2 text-stone-600">
+        {area.shops.length} independent coffee shops in {area.area}, Pittsburgh.
+      </p>
+      <ul className="mt-8 divide-y divide-stone-200">
+        {area.shops.map(shop => (
+          <li key={shop.uuid} className="py-4">
+            <Link href={buildShopPath(shop)} className="text-lg font-medium underline underline-offset-2">
+              {shop.name}
+            </Link>
+            <p className="text-sm text-stone-600">{shop.address}</p>
+            {shop.description && <p className="mt-1 text-sm text-stone-500">{shop.description}</p>}
+          </li>
+        ))}
+      </ul>
+      <p className="mt-10 text-sm">
+        <Link href="/neighborhoods" className="underline underline-offset-2">
+          All neighborhoods
+        </Link>{' '}
+        ·{' '}
+        <Link href="/" className="underline underline-offset-2">
+          View the map
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/app/neighborhoods/[slug]/page.tsx
+++ b/app/neighborhoods/[slug]/page.tsx
@@ -8,6 +8,8 @@ import {
   buildShopPath,
   jsonLdToString,
 } from '@/app/utils/seo'
+import VerifiedBadge from '@/app/components/VerifiedBadge'
+import { Footer } from '@/app/components/about'
 
 type Props = {
   params: Promise<{ slug: string }>
@@ -23,7 +25,8 @@ export default async function NeighborhoodPage({ params }: Props) {
   if (!area) notFound()
 
   return (
-    <div className="mx-auto max-w-2xl px-4 py-10">
+    <div className="flex min-h-[calc(100vh-4rem)] flex-col">
+    <div className="mx-auto w-full max-w-2xl flex-1 px-4 py-10">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLdToString(buildAreaJsonLd(area)) }} />
       <h1 className="text-3xl font-serif tracking-tight">Coffee shops in {area.area}</h1>
       <p className="mt-2 text-stone-600">
@@ -42,7 +45,10 @@ export default async function NeighborhoodPage({ params }: Props) {
                 />
               )}
               <div>
-                <span className="text-lg font-medium underline underline-offset-2">{shop.name}</span>
+                <span className="inline-flex items-center gap-1 text-lg font-medium underline underline-offset-2">
+                  {shop.name}
+                  {shop.verified && <VerifiedBadge />}
+                </span>
                 <p className="text-sm text-stone-600">{shop.address}</p>
                 {shop.description && <p className="mt-1 text-sm text-stone-500">{shop.description}</p>}
               </div>
@@ -59,6 +65,8 @@ export default async function NeighborhoodPage({ params }: Props) {
           View the map
         </Link>
       </p>
+    </div>
+    <Footer />
     </div>
   )
 }

--- a/app/neighborhoods/[slug]/page.tsx
+++ b/app/neighborhoods/[slug]/page.tsx
@@ -8,6 +8,7 @@ import {
   buildShopPath,
   jsonLdToString,
 } from '@/app/utils/seo'
+import { shopNoun } from '@/app/utils/neighborhoodAreas'
 import VerifiedBadge from '@/app/components/VerifiedBadge'
 import { Footer } from '@/app/components/about'
 
@@ -30,7 +31,7 @@ export default async function NeighborhoodPage({ params }: Props) {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLdToString(buildAreaJsonLd(area)) }} />
       <h1 className="text-3xl font-serif tracking-tight">Coffee shops in {area.area}</h1>
       <p className="mt-2 text-stone-600">
-        {area.shops.length} independent coffee shops in {area.area}, Pittsburgh.
+        {area.shops.length} independent coffee {shopNoun(area.shops.length)} in {area.area}, Pittsburgh.
       </p>
       <ul className="mt-8 divide-y divide-stone-200">
         {area.shops.map(shop => (

--- a/app/neighborhoods/[slug]/page.tsx
+++ b/app/neighborhoods/[slug]/page.tsx
@@ -32,11 +32,21 @@ export default async function NeighborhoodPage({ params }: Props) {
       <ul className="mt-8 divide-y divide-stone-200">
         {area.shops.map(shop => (
           <li key={shop.uuid} className="py-4">
-            <Link href={buildShopPath(shop)} className="text-lg font-medium underline underline-offset-2">
-              {shop.name}
+            <Link href={buildShopPath(shop)} className="flex gap-4">
+              {shop.photo && (
+                <img
+                  src={shop.photo}
+                  alt=""
+                  loading="lazy"
+                  className="h-20 w-20 shrink-0 rounded-md object-cover object-center"
+                />
+              )}
+              <div>
+                <span className="text-lg font-medium underline underline-offset-2">{shop.name}</span>
+                <p className="text-sm text-stone-600">{shop.address}</p>
+                {shop.description && <p className="mt-1 text-sm text-stone-500">{shop.description}</p>}
+              </div>
             </Link>
-            <p className="text-sm text-stone-600">{shop.address}</p>
-            {shop.description && <p className="mt-1 text-sm text-stone-500">{shop.description}</p>}
           </li>
         ))}
       </ul>

--- a/app/neighborhoods/page.tsx
+++ b/app/neighborhoods/page.tsx
@@ -15,17 +15,40 @@ export default async function NeighborhoodsPage() {
 
   return (
     <div className="flex min-h-[calc(100vh-4rem)] flex-col">
-    <div className="mx-auto w-full max-w-2xl flex-1 px-4 py-10">
+    <div className="mx-auto w-full max-w-5xl flex-1 px-4 py-10">
       <h1 className="text-3xl font-serif tracking-tight">Coffee shops by neighborhood</h1>
-      <ul className="mt-8 space-y-3">
-        {areas.map(({ area, shops }) => (
-          <li key={area}>
-            <Link href={areaPath(area)} className="text-lg underline underline-offset-2">
-              {area}
-            </Link>
-            <span className="ml-2 text-sm text-stone-500">{shops.length} shops</span>
-          </li>
-        ))}
+      <p className="mt-2 max-w-2xl text-stone-600">
+        Browse Pittsburgh&rsquo;s independent coffee shops by where they are — {areas.length} neighborhoods, from
+        Lawrenceville to the South Hills.
+      </p>
+      <ul className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {areas.map(({ area, shops }) => {
+          const cover = shops.find(shop => shop.photo)?.photo
+          return (
+            <li key={area}>
+              <Link
+                href={areaPath(area)}
+                className="group relative flex h-28 items-end overflow-hidden rounded-lg shadow-sm"
+              >
+                {cover ? (
+                  <img
+                    src={cover}
+                    alt=""
+                    loading="lazy"
+                    className="absolute inset-0 h-full w-full object-cover object-center transition group-hover:scale-105"
+                  />
+                ) : (
+                  <div className="absolute inset-0 bg-yellow-200" />
+                )}
+                <div className="absolute inset-0 bg-gradient-to-t from-black/75 to-transparent" />
+                <div className="relative p-3 text-white">
+                  <p className="text-lg font-medium leading-tight">{area}</p>
+                  <p className="text-xs text-white/80">{shops.length} shops</p>
+                </div>
+              </Link>
+            </li>
+          )
+        })}
       </ul>
     </div>
     <Footer />

--- a/app/neighborhoods/page.tsx
+++ b/app/neighborhoods/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { getNeighborhoodAreas } from '@/app/utils/seo'
-import { areaPath } from '@/app/utils/neighborhoodAreas'
+import { areaPath, shopNoun } from '@/app/utils/neighborhoodAreas'
 import { Footer } from '@/app/components/about'
 
 export const metadata: Metadata = {
@@ -43,7 +43,7 @@ export default async function NeighborhoodsPage() {
                 <div className="absolute inset-0 bg-gradient-to-t from-black/75 to-transparent" />
                 <div className="relative p-3 text-white">
                   <p className="text-lg font-medium leading-tight">{area}</p>
-                  <p className="text-xs text-white/80">{shops.length} shops</p>
+                  <p className="text-xs text-white/80">{shops.length} {shopNoun(shops.length)}</p>
                 </div>
               </Link>
             </li>

--- a/app/neighborhoods/page.tsx
+++ b/app/neighborhoods/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { getNeighborhoodAreas } from '@/app/utils/seo'
 import { areaPath } from '@/app/utils/neighborhoodAreas'
+import { Footer } from '@/app/components/about'
 
 export const metadata: Metadata = {
   title: 'Coffee shops by neighborhood | pgh.coffee',
@@ -13,7 +14,8 @@ export default async function NeighborhoodsPage() {
   const areas = await getNeighborhoodAreas()
 
   return (
-    <div className="mx-auto max-w-2xl px-4 py-10">
+    <div className="flex min-h-[calc(100vh-4rem)] flex-col">
+    <div className="mx-auto w-full max-w-2xl flex-1 px-4 py-10">
       <h1 className="text-3xl font-serif tracking-tight">Coffee shops by neighborhood</h1>
       <ul className="mt-8 space-y-3">
         {areas.map(({ area, shops }) => (
@@ -25,6 +27,8 @@ export default async function NeighborhoodsPage() {
           </li>
         ))}
       </ul>
+    </div>
+    <Footer />
     </div>
   )
 }

--- a/app/neighborhoods/page.tsx
+++ b/app/neighborhoods/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { getNeighborhoodAreas } from '@/app/utils/seo'
+import { areaPath } from '@/app/utils/neighborhoodAreas'
+
+export const metadata: Metadata = {
+  title: 'Coffee shops by neighborhood | pgh.coffee',
+  description: 'Independent Pittsburgh coffee shops, organized by neighborhood.',
+  alternates: { canonical: '/neighborhoods' },
+}
+
+export default async function NeighborhoodsPage() {
+  const areas = await getNeighborhoodAreas()
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-10">
+      <h1 className="text-3xl font-serif tracking-tight">Coffee shops by neighborhood</h1>
+      <ul className="mt-8 space-y-3">
+        {areas.map(({ area, shops }) => (
+          <li key={area}>
+            <Link href={areaPath(area)} className="text-lg underline underline-offset-2">
+              {area}
+            </Link>
+            <span className="ml-2 text-sm text-stone-500">{shops.length} shops</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,19 +1,26 @@
 import type { MetadataRoute } from 'next'
-import { SITE_URL, buildShopUrl, getAllShopsForSeo } from '@/app/utils/seo'
+import { SITE_URL, buildShopUrl, getAllShopsForSeo, getNeighborhoodAreas } from '@/app/utils/seo'
+import { areaPath } from '@/app/utils/neighborhoodAreas'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const shops = await getAllShopsForSeo()
+  const areas = await getNeighborhoodAreas()
 
   const staticPages: MetadataRoute.Sitemap = [
     { url: SITE_URL },
     { url: `${SITE_URL}/about` },
     { url: `${SITE_URL}/submit-a-shop` },
     { url: `${SITE_URL}/stickers` },
+    { url: `${SITE_URL}/neighborhoods` },
   ]
+
+  const areaPages: MetadataRoute.Sitemap = areas.map(({ area }) => ({
+    url: `${SITE_URL}${areaPath(area)}`,
+  }))
 
   const shopPages: MetadataRoute.Sitemap = shops.map(shop => ({
     url: buildShopUrl(shop),
   }))
 
-  return [...staticPages, ...shopPages]
+  return [...staticPages, ...areaPages, ...shopPages]
 }

--- a/app/utils/neighborhoodAreas.ts
+++ b/app/utils/neighborhoodAreas.ts
@@ -31,6 +31,38 @@ export function shopNoun(count: number): string {
   return count === 1 ? 'shop' : 'shops'
 }
 
+type Located = { latitude: number | null; longitude: number | null }
+
+function centroid(shops: Located[]): [number, number] | null {
+  const pts = shops.filter(s => s.latitude != null && s.longitude != null)
+  if (pts.length === 0) return null
+  const lat = pts.reduce((sum, s) => sum + s.latitude!, 0) / pts.length
+  const lng = pts.reduce((sum, s) => sum + s.longitude!, 0) / pts.length
+  return [lat, lng]
+}
+
+// Squared distance with longitude scaled by cos(latitude) so it's comparable to
+// latitude degrees at Pittsburgh's latitude — enough to rank nearest areas
+// without the cost of haversine.
+function squaredDistance(a: [number, number], b: [number, number]): number {
+  const dLat = a[0] - b[0]
+  const dLng = (a[1] - b[1]) * Math.cos((a[0] * Math.PI) / 180)
+  return dLat * dLat + dLng * dLng
+}
+
+/** The `count` areas geographically closest to `current`, nearest first. */
+export function nearestAreas<T extends { area: string; shops: Located[] }>(current: T, all: T[], count: number): T[] {
+  const origin = centroid(current.shops)
+  if (!origin) return []
+  return all
+    .filter(other => other.area !== current.area)
+    .map(other => ({ other, c: centroid(other.shops) }))
+    .filter((x): x is { other: T; c: [number, number] } => x.c !== null)
+    .sort((x, y) => squaredDistance(origin, x.c) - squaredDistance(origin, y.c))
+    .slice(0, count)
+    .map(x => x.other)
+}
+
 /**
  * Groups shops into searchable areas, sorted by shop count so index pages lead
  * with the densest areas.

--- a/app/utils/neighborhoodAreas.ts
+++ b/app/utils/neighborhoodAreas.ts
@@ -19,8 +19,9 @@ const AREA_GROUPS: Record<string, string> = {
   'Central Business District': 'Downtown',
 }
 
-// Below this an area page is thin content: it won't rank and dilutes the site.
-export const MIN_SHOPS_FOR_AREA_PAGE = 3
+// Every area with at least one shop gets a page: with a photo, address, and
+// description per shop, even a single-shop listing carries real content.
+export const MIN_SHOPS_FOR_AREA_PAGE = 1
 
 export function areaForNeighborhood(neighborhood: string): string {
   return AREA_GROUPS[neighborhood] ?? neighborhood

--- a/app/utils/neighborhoodAreas.ts
+++ b/app/utils/neighborhoodAreas.ts
@@ -19,10 +19,6 @@ const AREA_GROUPS: Record<string, string> = {
   'Central Business District': 'Downtown',
 }
 
-// Every area with at least one shop gets a page: with a photo, address, and
-// description per shop, even a single-shop listing carries real content.
-export const MIN_SHOPS_FOR_AREA_PAGE = 1
-
 export function areaForNeighborhood(neighborhood: string): string {
   return AREA_GROUPS[neighborhood] ?? neighborhood
 }
@@ -32,9 +28,8 @@ export function areaPath(area: string): string {
 }
 
 /**
- * Groups shops into searchable areas, dropping areas too small to make a
- * substantive landing page. Sorted by shop count so index pages lead with the
- * densest areas.
+ * Groups shops into searchable areas, sorted by shop count so index pages lead
+ * with the densest areas.
  */
 export function groupShopsIntoAreas<T extends { neighborhood: string }>(shops: T[]): { area: string; shops: T[] }[] {
   const byArea = new Map<string, T[]>()
@@ -43,7 +38,6 @@ export function groupShopsIntoAreas<T extends { neighborhood: string }>(shops: T
     byArea.set(area, [...(byArea.get(area) ?? []), shop])
   }
   return Array.from(byArea)
-    .filter(([, areaShops]) => areaShops.length >= MIN_SHOPS_FOR_AREA_PAGE)
     .map(([area, areaShops]) => ({ area, shops: areaShops }))
     .sort((a, b) => b.shops.length - a.shops.length)
 }

--- a/app/utils/neighborhoodAreas.ts
+++ b/app/utils/neighborhoodAreas.ts
@@ -27,6 +27,10 @@ export function areaPath(area: string): string {
   return `/neighborhoods/${slugify(area)}`
 }
 
+export function shopNoun(count: number): string {
+  return count === 1 ? 'shop' : 'shops'
+}
+
 /**
  * Groups shops into searchable areas, sorted by shop count so index pages lead
  * with the densest areas.

--- a/app/utils/neighborhoodAreas.ts
+++ b/app/utils/neighborhoodAreas.ts
@@ -1,0 +1,48 @@
+import { slugify } from '@/app/utils/shopSlug'
+
+// Granular DB neighborhoods folded into the area names people actually search
+// for ("coffee shops in Lawrenceville", not "Central Lawrenceville").
+const AREA_GROUPS: Record<string, string> = {
+  'Central Lawrenceville': 'Lawrenceville',
+  'Lower Lawrenceville': 'Lawrenceville',
+  'Upper Lawrenceville': 'Lawrenceville',
+  'Squirrel Hill North': 'Squirrel Hill',
+  'Squirrel Hill South': 'Squirrel Hill',
+  'Central Oakland': 'Oakland',
+  'North Oakland': 'Oakland',
+  'South Oakland': 'Oakland',
+  'West Oakland': 'Oakland',
+  'South Side Flats': 'South Side',
+  'South Side Slopes': 'South Side',
+  'North Point Breeze': 'Point Breeze',
+  'South Point Breeze': 'Point Breeze',
+  'Central Business District': 'Downtown',
+}
+
+// Below this an area page is thin content: it won't rank and dilutes the site.
+export const MIN_SHOPS_FOR_AREA_PAGE = 3
+
+export function areaForNeighborhood(neighborhood: string): string {
+  return AREA_GROUPS[neighborhood] ?? neighborhood
+}
+
+export function areaPath(area: string): string {
+  return `/neighborhoods/${slugify(area)}`
+}
+
+/**
+ * Groups shops into searchable areas, dropping areas too small to make a
+ * substantive landing page. Sorted by shop count so index pages lead with the
+ * densest areas.
+ */
+export function groupShopsIntoAreas<T extends { neighborhood: string }>(shops: T[]): { area: string; shops: T[] }[] {
+  const byArea = new Map<string, T[]>()
+  for (const shop of shops) {
+    const area = areaForNeighborhood(shop.neighborhood)
+    byArea.set(area, [...(byArea.get(area) ?? []), shop])
+  }
+  return Array.from(byArea)
+    .filter(([, areaShops]) => areaShops.length >= MIN_SHOPS_FOR_AREA_PAGE)
+    .map(([area, areaShops]) => ({ area, shops: areaShops }))
+    .sort((a, b) => b.shops.length - a.shops.length)
+}

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -80,6 +80,7 @@ export interface ShopListEntry {
   uuid: string
   address: string
   description: string | null
+  photo: string | null
 }
 
 /**
@@ -91,7 +92,7 @@ export const getAllShopsForSeo = cache(async (): Promise<ShopListEntry[]> => {
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('shops')
-    .select('name, neighborhood, uuid, address, description')
+    .select('name, neighborhood, uuid, address, description, photo')
     .order('name', { ascending: true })
 
   if (error || !data) {

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -82,6 +82,8 @@ export interface ShopListEntry {
   description: string | null
   photo: string | null
   verified: boolean
+  latitude: number | null
+  longitude: number | null
 }
 
 /**
@@ -93,7 +95,9 @@ export const getAllShopsForSeo = cache(async (): Promise<ShopListEntry[]> => {
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('shops')
-    .select('name, neighborhood, uuid, address, description, photo, is_verified, company:company_id(is_verified)')
+    .select(
+      'name, neighborhood, uuid, address, description, photo, latitude, longitude, is_verified, company:company_id(is_verified)'
+    )
     .order('name', { ascending: true })
 
   if (error || !data) {

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -5,7 +5,7 @@ import type { CafeOrCoffeeShopLeaf, CollectionPageLeaf, OrganizationLeaf, WebSit
 import { DbShop } from '@/types/shop-types'
 import { logger } from '@/lib/logger'
 import { buildShopSlug, extractUuidPrefix, slugify } from '@/app/utils/shopSlug'
-import { areaPath, groupShopsIntoAreas } from '@/app/utils/neighborhoodAreas'
+import { areaPath, groupShopsIntoAreas, shopNoun } from '@/app/utils/neighborhoodAreas'
 import { getShopByUuidPrefix } from '@/app/utils/shops'
 
 export const SITE_URL = 'https://pgh.coffee'
@@ -231,7 +231,7 @@ export const getAreaBySlug = cache(async (slug: string): Promise<NeighborhoodAre
 
 export function buildAreaMetadata({ area, shops }: NeighborhoodArea): Metadata {
   const title = `Coffee shops in ${area} | pgh.coffee`
-  const description = `${shops.length} independent coffee shops in ${area}, Pittsburgh — an up-to-date local guide with addresses and a map for each.`
+  const description = `${shops.length} independent coffee ${shopNoun(shops.length)} in ${area}, Pittsburgh — an up-to-date local guide with addresses and a map for each.`
   const path = areaPath(area)
 
   return {

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -81,6 +81,7 @@ export interface ShopListEntry {
   address: string
   description: string | null
   photo: string | null
+  verified: boolean
 }
 
 /**
@@ -92,7 +93,7 @@ export const getAllShopsForSeo = cache(async (): Promise<ShopListEntry[]> => {
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('shops')
-    .select('name, neighborhood, uuid, address, description, photo')
+    .select('name, neighborhood, uuid, address, description, photo, is_verified, company:company_id(is_verified)')
     .order('name', { ascending: true })
 
   if (error || !data) {
@@ -100,7 +101,12 @@ export const getAllShopsForSeo = cache(async (): Promise<ShopListEntry[]> => {
     return []
   }
 
-  return data as ShopListEntry[]
+  // A shop shows the badge when it's claimed directly or its company is
+  // verified — the same rule PanelHeader/ShopCard apply on the client.
+  return data.map(({ is_verified, company, ...shop }) => ({
+    ...shop,
+    verified: Boolean(is_verified || (company as { is_verified?: boolean } | null)?.is_verified),
+  })) as ShopListEntry[]
 })
 
 /**

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -4,7 +4,8 @@ import type { Metadata } from 'next'
 import type { CafeOrCoffeeShopLeaf, CollectionPageLeaf, OrganizationLeaf, WebSite, WithContext } from 'schema-dts'
 import { DbShop } from '@/types/shop-types'
 import { logger } from '@/lib/logger'
-import { buildShopSlug, extractUuidPrefix } from '@/app/utils/shopSlug'
+import { buildShopSlug, extractUuidPrefix, slugify } from '@/app/utils/shopSlug'
+import { areaPath, groupShopsIntoAreas } from '@/app/utils/neighborhoodAreas'
 import { getShopByUuidPrefix } from '@/app/utils/shops'
 
 export const SITE_URL = 'https://pgh.coffee'
@@ -77,6 +78,8 @@ export interface ShopListEntry {
   name: string
   neighborhood: string
   uuid: string
+  address: string
+  description: string | null
 }
 
 /**
@@ -88,7 +91,7 @@ export const getAllShopsForSeo = cache(async (): Promise<ShopListEntry[]> => {
   const supabase = getSupabase()
   const { data, error } = await supabase
     .from('shops')
-    .select('name, neighborhood, uuid')
+    .select('name, neighborhood, uuid, address, description')
     .order('name', { ascending: true })
 
   if (error || !data) {
@@ -202,6 +205,52 @@ export function buildWebsiteJsonLd(): WithContext<WebSite> {
     '@type': 'WebSite',
     name: SITE_NAME,
     url: SITE_URL,
+  }
+}
+
+export interface NeighborhoodArea {
+  area: string
+  shops: ShopListEntry[]
+}
+
+export const getNeighborhoodAreas = cache(async (): Promise<NeighborhoodArea[]> => {
+  return groupShopsIntoAreas(await getAllShopsForSeo())
+})
+
+export const getAreaBySlug = cache(async (slug: string): Promise<NeighborhoodArea | null> => {
+  const areas = await getNeighborhoodAreas()
+  return areas.find(({ area }) => slugify(area) === slug) ?? null
+})
+
+export function buildAreaMetadata({ area, shops }: NeighborhoodArea): Metadata {
+  const title = `Coffee shops in ${area} | pgh.coffee`
+  const description = `${shops.length} independent coffee shops in ${area}, Pittsburgh — an up-to-date local guide with addresses and a map for each.`
+  const path = areaPath(area)
+
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    openGraph: { title, description, type: 'website', url: path },
+    twitter: { title, description },
+  }
+}
+
+export function buildAreaJsonLd({ area, shops }: NeighborhoodArea): WithContext<CollectionPageLeaf> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: `Coffee shops in ${area}`,
+    url: `${SITE_URL}${areaPath(area)}`,
+    mainEntity: {
+      '@type': 'ItemList',
+      itemListElement: shops.map((shop, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: shop.name,
+        url: buildShopUrl(shop),
+      })),
+    },
   }
 }
 

--- a/tests/unit/neighborhoodAreas.test.ts
+++ b/tests/unit/neighborhoodAreas.test.ts
@@ -12,7 +12,7 @@ describe('neighborhood areas', () => {
     expect(areaForNeighborhood('Shadyside')).toBe('Shadyside')
   })
 
-  it('merges grouped neighborhoods and drops areas below the page threshold', () => {
+  it('merges grouped neighborhoods and sorts areas by shop count', () => {
     const shop = (neighborhood: string) => ({ neighborhood })
     const areas = groupShopsIntoAreas([
       shop('Central Lawrenceville'),
@@ -22,9 +22,10 @@ describe('neighborhood areas', () => {
       shop('Shadyside'),
     ])
 
-    expect(areas).toHaveLength(1)
-    expect(areas[0].area).toBe('Lawrenceville')
-    expect(areas[0].shops).toHaveLength(3)
+    expect(areas.map(a => [a.area, a.shops.length])).toEqual([
+      ['Lawrenceville', 3],
+      ['Shadyside', 2],
+    ])
   })
 
   it('builds slugged area paths', () => {

--- a/tests/unit/neighborhoodAreas.test.ts
+++ b/tests/unit/neighborhoodAreas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { areaForNeighborhood, areaPath, groupShopsIntoAreas } from '@/app/utils/neighborhoodAreas'
+import { areaForNeighborhood, areaPath, groupShopsIntoAreas, nearestAreas } from '@/app/utils/neighborhoodAreas'
 
 describe('neighborhood areas', () => {
   it('folds granular neighborhoods into their searchable area', () => {
@@ -26,6 +26,20 @@ describe('neighborhood areas', () => {
       ['Lawrenceville', 3],
       ['Shadyside', 2],
     ])
+  })
+
+  it('ranks areas by distance from the current area centroid', () => {
+    const at = (latitude: number, longitude: number) => ({ latitude, longitude })
+    const current = { area: 'Here', shops: [at(40.44, -79.99)] }
+    const all = [
+      current,
+      { area: 'Near', shops: [at(40.45, -79.98)] },
+      { area: 'Far', shops: [at(40.6, -80.2)] },
+      { area: 'NoCoords', shops: [{ latitude: null, longitude: null }] },
+    ]
+
+    // excludes the current area and areas with no coordinates
+    expect(nearestAreas(current, all, 5).map(a => a.area)).toEqual(['Near', 'Far'])
   })
 
   it('builds slugged area paths', () => {

--- a/tests/unit/neighborhoodAreas.test.ts
+++ b/tests/unit/neighborhoodAreas.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { areaForNeighborhood, areaPath, groupShopsIntoAreas } from '@/app/utils/neighborhoodAreas'
+
+describe('neighborhood areas', () => {
+  it('folds granular neighborhoods into their searchable area', () => {
+    expect(areaForNeighborhood('Central Lawrenceville')).toBe('Lawrenceville')
+    expect(areaForNeighborhood('Squirrel Hill South')).toBe('Squirrel Hill')
+    expect(areaForNeighborhood('Central Business District')).toBe('Downtown')
+  })
+
+  it('passes ungrouped neighborhoods through unchanged', () => {
+    expect(areaForNeighborhood('Shadyside')).toBe('Shadyside')
+  })
+
+  it('merges grouped neighborhoods and drops areas below the page threshold', () => {
+    const shop = (neighborhood: string) => ({ neighborhood })
+    const areas = groupShopsIntoAreas([
+      shop('Central Lawrenceville'),
+      shop('Lower Lawrenceville'),
+      shop('Upper Lawrenceville'),
+      shop('Shadyside'),
+      shop('Shadyside'),
+    ])
+
+    expect(areas).toHaveLength(1)
+    expect(areas[0].area).toBe('Lawrenceville')
+    expect(areas[0].shops).toHaveLength(3)
+  })
+
+  it('builds slugged area paths', () => {
+    expect(areaPath('Squirrel Hill')).toBe('/neighborhoods/squirrel-hill')
+    expect(areaPath("O'Hara")).toBe('/neighborhoods/o-hara')
+  })
+})

--- a/tests/unit/seo.test.ts
+++ b/tests/unit/seo.test.ts
@@ -161,8 +161,8 @@ describe('buildOrganizationJsonLd / buildWebsiteJsonLd', () => {
 describe('buildShopListJsonLd', () => {
   test('builds a CollectionPage with one ListItem per shop, 1-indexed', () => {
     const entries = [
-      { name: '61B Cafe', neighborhood: 'Regent Square', uuid: '00000000-0000-0000-0000-000000000000', address: '1108 S Braddock Ave, Pittsburgh, PA 15218', description: null, photo: null, verified: false },
-      { name: 'Afters Cafe', neighborhood: 'Squirrel Hill South', uuid: '11111111-1111-1111-1111-111111111111', address: '2124 Murray Ave, Pittsburgh, PA 15217', description: null, photo: null, verified: false },
+      { name: '61B Cafe', neighborhood: 'Regent Square', uuid: '00000000-0000-0000-0000-000000000000', address: '1108 S Braddock Ave, Pittsburgh, PA 15218', description: null, photo: null, verified: false, latitude: null, longitude: null },
+      { name: 'Afters Cafe', neighborhood: 'Squirrel Hill South', uuid: '11111111-1111-1111-1111-111111111111', address: '2124 Murray Ave, Pittsburgh, PA 15217', description: null, photo: null, verified: false, latitude: null, longitude: null },
     ]
     const jsonLd = buildShopListJsonLd(entries)
 

--- a/tests/unit/seo.test.ts
+++ b/tests/unit/seo.test.ts
@@ -161,8 +161,8 @@ describe('buildOrganizationJsonLd / buildWebsiteJsonLd', () => {
 describe('buildShopListJsonLd', () => {
   test('builds a CollectionPage with one ListItem per shop, 1-indexed', () => {
     const entries = [
-      { name: '61B Cafe', neighborhood: 'Regent Square', uuid: '00000000-0000-0000-0000-000000000000', address: '1108 S Braddock Ave, Pittsburgh, PA 15218', description: null },
-      { name: 'Afters Cafe', neighborhood: 'Squirrel Hill South', uuid: '11111111-1111-1111-1111-111111111111', address: '2124 Murray Ave, Pittsburgh, PA 15217', description: null },
+      { name: '61B Cafe', neighborhood: 'Regent Square', uuid: '00000000-0000-0000-0000-000000000000', address: '1108 S Braddock Ave, Pittsburgh, PA 15218', description: null, photo: null },
+      { name: 'Afters Cafe', neighborhood: 'Squirrel Hill South', uuid: '11111111-1111-1111-1111-111111111111', address: '2124 Murray Ave, Pittsburgh, PA 15217', description: null, photo: null },
     ]
     const jsonLd = buildShopListJsonLd(entries)
 

--- a/tests/unit/seo.test.ts
+++ b/tests/unit/seo.test.ts
@@ -161,8 +161,8 @@ describe('buildOrganizationJsonLd / buildWebsiteJsonLd', () => {
 describe('buildShopListJsonLd', () => {
   test('builds a CollectionPage with one ListItem per shop, 1-indexed', () => {
     const entries = [
-      { name: '61B Cafe', neighborhood: 'Regent Square', uuid: '00000000-0000-0000-0000-000000000000' },
-      { name: 'Afters Cafe', neighborhood: 'Squirrel Hill South', uuid: '11111111-1111-1111-1111-111111111111' },
+      { name: '61B Cafe', neighborhood: 'Regent Square', uuid: '00000000-0000-0000-0000-000000000000', address: '1108 S Braddock Ave, Pittsburgh, PA 15218', description: null },
+      { name: 'Afters Cafe', neighborhood: 'Squirrel Hill South', uuid: '11111111-1111-1111-1111-111111111111', address: '2124 Murray Ave, Pittsburgh, PA 15217', description: null },
     ]
     const jsonLd = buildShopListJsonLd(entries)
 

--- a/tests/unit/seo.test.ts
+++ b/tests/unit/seo.test.ts
@@ -161,8 +161,8 @@ describe('buildOrganizationJsonLd / buildWebsiteJsonLd', () => {
 describe('buildShopListJsonLd', () => {
   test('builds a CollectionPage with one ListItem per shop, 1-indexed', () => {
     const entries = [
-      { name: '61B Cafe', neighborhood: 'Regent Square', uuid: '00000000-0000-0000-0000-000000000000', address: '1108 S Braddock Ave, Pittsburgh, PA 15218', description: null, photo: null },
-      { name: 'Afters Cafe', neighborhood: 'Squirrel Hill South', uuid: '11111111-1111-1111-1111-111111111111', address: '2124 Murray Ave, Pittsburgh, PA 15217', description: null, photo: null },
+      { name: '61B Cafe', neighborhood: 'Regent Square', uuid: '00000000-0000-0000-0000-000000000000', address: '1108 S Braddock Ave, Pittsburgh, PA 15218', description: null, photo: null, verified: false },
+      { name: 'Afters Cafe', neighborhood: 'Squirrel Hill South', uuid: '11111111-1111-1111-1111-111111111111', address: '2124 Murray Ave, Pittsburgh, PA 15217', description: null, photo: null, verified: false },
     ]
     const jsonLd = buildShopListJsonLd(entries)
 


### PR DESCRIPTION
## What do these changes accomplish?

Adds server-rendered landing pages (`/neighborhoods` and `/neighborhoods/{area}`) listing the coffee shops in each Pittsburgh neighborhood, cross-linked with shop pages, the search bar, and the sitemap.

## Why?

Searches like "lawrenceville coffee shops" are how new people find a site like this, and there was no page that could rank for them — the map is one client-rendered page Google can't index by neighborhood, and shop pages only rank for people who already know the shop's name. Each area page carries a photo, address, and description per shop, so even a single-shop neighborhood is substantive enough to earn the long-tail query. Granular neighborhoods are grouped into the names people actually search (Lawrenceville, Squirrel Hill, Oakland, South Side, Downtown, Point Breeze), and typing a neighborhood into the search bar now surfaces a link to its guide.

## Screenshots

| Before | After |
|---|---|
| `/neighborhoods/lawrenceville` was a 404 | Server-rendered list of shops with photos, metadata, and ItemList JSON-LD |
