### PR TITLE
Fix broken OG image on public profile pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,11 @@ const nextConfig = {
   env: {
     MAPBOX_ACCESS_TOKEN: process.env.MAPBOX_ACCESS_TOKEN,
   },
+  // Static OG routes read these at build time, but /u/[id] renders on demand and
+  // file tracing doesn't follow readFileSync(process.cwd()) into the bundle.
+  outputFileTracingIncludes: {
+    '/u/[id]/opengraph-image': ['./public/logo_with_no_text_transparent*.png'],
+  },
 }
 
 module.exports = withBundleAnalyzer(nextConfig)


### PR DESCRIPTION
## What do these changes accomplish?

Shares of a public coffee passport (`/u/{id}`) now show the passport preview image instead of no image at all.

## Why?

Every profile link shared to Slack, Facebook, LinkedIn, or WhatsApp was rendering with a broken image. The page's social tags were correct, but the image URL they pointed at returned a 500 for every profile.

The profile OG image is the only one in the app generated on demand — the rest are baked at build time, when the logo files are sitting right there on the build machine. The on-demand one runs in a deployed function, and the build never copied the logo files into it, so it failed every time it tried to draw them. This tells the build to include them.
