### PR TITLE
Render a branded OG card for shop pages

### DIFF
--- a/app/(map)/shops/[slug]/opengraph-image.tsx
+++ b/app/(map)/shops/[slug]/opengraph-image.tsx
@@ -1,0 +1,110 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { ImageResponse } from 'next/og'
+import { getShopForSeo } from '@/app/utils/seo'
+
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+export const alt = 'pgh.coffee shop'
+
+const logoSrc = `data:image/png;base64,${readFileSync(
+  join(process.cwd(), 'public', 'logo_with_no_text_transparent_108.png'),
+).toString('base64')}`
+
+const yellow = '#fde047' // matches nav bg-yellow-300
+const gray900 = '#111827'
+const gray500 = '#6b7280'
+
+// Cream + dot grid stands in for the photo when a shop has none, matching the
+// passport OG image. Satori won't tile a radial-gradient, hence the SVG tile.
+const noPhotoBackground = {
+  backgroundColor: '#fffbeb',
+  backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(
+    `<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32'><circle cx='4' cy='4' r='2.5' fill='#e0ddd2'/></svg>`,
+  )}")`,
+  backgroundSize: '32px 32px',
+  backgroundRepeat: 'repeat',
+}
+
+/* eslint-disable @next/next/no-img-element */
+
+function Background({ photo }: { photo: string | null }) {
+  if (!photo) return <div style={{ ...noPhotoBackground, display: 'flex', width: '100%', height: '100%' }} />
+  return <img src={photo} width={size.width} height={size.height} alt="" style={{ objectFit: 'cover' }} />
+}
+
+function Header() {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 14,
+        background: yellow,
+        padding: '20px 56px',
+        fontSize: 44,
+        fontWeight: 700,
+        color: gray900,
+      }}
+    >
+      <img src={logoSrc} width={44} height={44} alt="" />
+      pgh.coffee
+    </div>
+  )
+}
+
+function InfoCard({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 48,
+        bottom: 44,
+        maxWidth: 1000,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        background: 'white',
+        padding: '28px 40px',
+        borderLeft: `12px solid ${yellow}`,
+      }}
+    >
+      <div style={{ fontSize: 58, fontWeight: 700, color: gray900, lineHeight: 1.1 }}>{title}</div>
+      <div style={{ fontSize: 30, color: gray500 }}>{subtitle}</div>
+    </div>
+  )
+}
+
+export default async function Image({ params }: { params: Promise<{ slug: string }> }) {
+  const shop = await getShopForSeo((await params).slug)
+
+  return new ImageResponse(
+    (
+      <div style={{ display: 'flex', width: '100%', height: '100%', position: 'relative' }}>
+        <Background photo={shop?.photo ?? null} />
+        {/* Keeps the card readable against a bright or busy storefront photo. */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            display: 'flex',
+            backgroundImage: 'linear-gradient(to bottom, rgba(0,0,0,0) 45%, rgba(0,0,0,0.45) 100%)',
+          }}
+        />
+        <Header />
+        <InfoCard
+          title={shop?.name ?? 'pgh.coffee'}
+          subtitle={shop?.address ?? "Pittsburgh's independent coffee map"}
+        />
+      </div>
+    ),
+    size,
+  )
+}

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -103,9 +103,9 @@ export const getAllShopsForSeo = cache(async (): Promise<ShopListEntry[]> => {
  * Builds OG/Twitter metadata for a shop page from real shop data. Now that shops
  * live at a real `/shops/{slug}` path, canonical/og:url are expressed through the
  * metadata API (resolved against metadataBase in the root layout).
- * This openGraph object replaces the layout's wholesale, so a photo-less shop
- * falls back to the site-default OG image rather than emitting no og:image
- * (photo is nullable in the DB even though every shop currently has one).
+ * No images here: the sibling opengraph-image.tsx supplies og:image for every
+ * shop, photo-less ones included, so the card is always branded rather than a
+ * bare storefront photo cropped to whatever the crawler decides.
  */
 export function buildShopMetadata(shop: DbShop): Metadata {
   const title = `${shop.name} | ${shop.neighborhood} | pgh.coffee`
@@ -114,7 +114,7 @@ export function buildShopMetadata(shop: DbShop): Metadata {
     `${shop.name} is an independent coffee shop in ${shop.neighborhood}, Pittsburgh — ${shop.address}.`
   const path = buildShopPath(shop)
 
-  const metadata: Metadata = {
+  return {
     title,
     description,
     alternates: { canonical: path },
@@ -128,12 +128,6 @@ export function buildShopMetadata(shop: DbShop): Metadata {
     // No twitter object: the layout's { card: 'summary_large_image' } is
     // inherited and X falls back to these og:* tags for title/description/image.
   }
-
-  metadata.openGraph!.images = shop.photo
-    ? [{ url: shop.photo, alt: shop.name }]
-    : ['/opengraph-image']
-
-  return metadata
 }
 
 /**

--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,7 @@ const nextConfig = {
   // file tracing doesn't follow readFileSync(process.cwd()) into the bundle.
   outputFileTracingIncludes: {
     '/u/[id]/opengraph-image': ['./public/logo_with_no_text_transparent*.png'],
+    '/shops/[slug]/opengraph-image': ['./public/logo_with_no_text_transparent_108.png'],
   },
 }
 

--- a/tests/unit/seo.test.ts
+++ b/tests/unit/seo.test.ts
@@ -187,19 +187,11 @@ describe('buildShopMetadata', () => {
     expect(metadata.title).toBe('61B Cafe | Regent Square | pgh.coffee')
     expect(metadata.alternates?.canonical).toBe('/shops/61b-cafe-regent-square-00000000')
     expect(metadata.openGraph?.url).toBe('/shops/61b-cafe-regent-square-00000000')
-    expect(metadata.openGraph?.images).toEqual([{ url: baseShop.photo, alt: baseShop.name }])
+    // No images: the route's opengraph-image.tsx supplies og:image. Setting one
+    // here would win over the file convention and put us back on raw photos.
+    expect(metadata.openGraph?.images).toBeUndefined()
     // No twitter object: the layout's { card: 'summary_large_image' } is inherited
     // and X falls back to the og:* tags.
-    expect(metadata.twitter).toBeUndefined()
-  })
-
-  test('falls back to the site-default OG image when the shop has no photo', () => {
-    // The openGraph object replaces the layout's wholesale, so without an
-    // explicit fallback a photo-less shop would emit no og:image at all.
-    const shop: DbShop = { ...baseShop, photo: null }
-    const metadata = buildShopMetadata(shop)
-
-    expect(metadata.openGraph?.images).toEqual(['/opengraph-image'])
     expect(metadata.twitter).toBeUndefined()
   })
 

--- a/tests/unit/shopOgImage.test.tsx
+++ b/tests/unit/shopOgImage.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test, vi } from 'vitest'
+import type { DbShop } from '@/types/shop-types'
+
+vi.mock('@/app/utils/seo', () => ({ getShopForSeo: vi.fn() }))
+
+import Image from '@/app/(map)/shops/[slug]/opengraph-image'
+import { getShopForSeo } from '@/app/utils/seo'
+
+const mockShop = vi.mocked(getShopForSeo)
+
+const params = Promise.resolve({ slug: 'any-slug-00000000' })
+
+// Every shop currently has a photo, so the photo-less and missing-shop branches
+// can't be reached with real data — but satori throws on a malformed layout, and
+// a throwing OG route is a 500 the crawler caches.
+// The body has to be consumed: ImageResponse streams, so a layout satori can't
+// render still returns a 200 whose stream throws on read.
+const renderedBytes = async () => new Uint8Array(await (await Image({ params })).arrayBuffer())
+
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47]
+
+describe('shop opengraph-image', () => {
+  test('renders a PNG for a shop with no photo', async () => {
+    mockShop.mockResolvedValue({ name: '61B Cafe', address: '1108 S Braddock Ave', photo: null } as DbShop)
+
+    expect([...(await renderedBytes()).slice(0, 4)]).toEqual(PNG_MAGIC)
+  })
+
+  test('renders a PNG when the slug matches no shop', async () => {
+    mockShop.mockResolvedValue(null)
+
+    expect([...(await renderedBytes()).slice(0, 4)]).toEqual(PNG_MAGIC)
+  })
+})


### PR DESCRIPTION
## What do these changes accomplish?

Shop pages have branded OG images


## Why?

Sharing a shop link handed the crawler the raw photo, so the card was whatever a 1.91:1 crop of an arbitrary-orientation image turned out to be. Portrait photos got guillotined, nothing identified the site, and no dimensions were sent for crawlers to lay the card out with. Every other page on the site already renders the yellow bar and logo; shop pages, the ones people actually share, were the exception.

Photo-less shops (the column is nullable) get the same card over the cream dot-grid background used on the passport image.

## Screenshots

| Before | After |
|---|---|
|<img width="1000" height="750" alt="image" src="https://github.com/user-attachments/assets/8dbd0ca9-cc01-4cd2-9ccc-3cb4a0942a44" /> | <img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/4041c436-f3df-463d-a046-bd2440ab7625" /> |

_Locally: `open "$(curl -s localhost:3000/shops/<slug> | grep -o 'content="[^"]*opengraph-image[^"]*"' | head -1 | cut -d'"' -f2)"` — the OG URL carries a content hash, so it has to come from the meta tag._