### PR TITLE
Stop the event/news bottom bar from covering the end of the body text

### DIFF
--- a/app/components/EventDetails.tsx
+++ b/app/components/EventDetails.tsx
@@ -210,8 +210,8 @@ export const EventDetails = ({ event }: EventDetailsProps) => {
         </div>
       </div>
 
-      {/* Fixed Bottom Section — the bar overlaps the scroll region above it, so it
-          needs an explicit stacking order rather than default paint order. */}
+      {/* Fixed Bottom Section — z-10 is a guard, not a confirmed fix: the bar overlaps
+          the scroll region, and no repro of it losing paint order exists in Chrome. */}
       <div className="absolute bottom-0 left-0 right-0 z-10 p-6 bg-neutral-50 border-t border-gray-100">
         <div className="flex flex-col gap-4">
           <div className="flex gap-2">

--- a/app/components/EventDetails.tsx
+++ b/app/components/EventDetails.tsx
@@ -92,7 +92,7 @@ export const EventDetails = ({ event }: EventDetailsProps) => {
   return (
     <div className={`flex flex-col ${event.image_url ? 'h-full' : 'mt-24 h-[calc(100%-6rem)] lg:mt-16 lg:h-[calc(100%-4rem)]'} ${eventIsPast ? 'opacity-60' : ''}`}>
       {/* Scrollable Content */}
-      <div className="flex-grow overflow-y-auto pb-56">
+      <div className="flex-grow overflow-y-auto pb-6">
         {event.image_url ? (
           <div className="relative h-56 sm:h-64">
             <img
@@ -210,9 +210,8 @@ export const EventDetails = ({ event }: EventDetailsProps) => {
         </div>
       </div>
 
-      {/* Fixed Bottom Section — z-10 is a guard, not a confirmed fix: the bar overlaps
-          the scroll region, and no repro of it losing paint order exists in Chrome. */}
-      <div className="absolute bottom-0 left-0 right-0 z-10 p-6 bg-neutral-50 border-t border-gray-100">
+      {/* Bottom Section — a flex sibling, not an overlay, so no stacking order to lose */}
+      <div className="shrink-0 p-6 bg-neutral-50 border-t border-gray-100">
         <div className="flex flex-col gap-4">
           <div className="flex gap-2">
             {event.url && (

--- a/app/components/EventDetails.tsx
+++ b/app/components/EventDetails.tsx
@@ -90,7 +90,7 @@ export const EventDetails = ({ event }: EventDetailsProps) => {
   }
 
   return (
-    <div className={`flex h-full flex-col ${event.image_url ? '' : 'mt-24 lg:mt-16'} ${eventIsPast ? 'opacity-60' : ''}`}>
+    <div className={`flex flex-col ${event.image_url ? 'h-full' : 'mt-24 h-[calc(100%-6rem)] lg:mt-16 lg:h-[calc(100%-4rem)]'} ${eventIsPast ? 'opacity-60' : ''}`}>
       {/* Scrollable Content */}
       <div className="flex-grow overflow-y-auto pb-56">
         {event.image_url ? (
@@ -210,8 +210,9 @@ export const EventDetails = ({ event }: EventDetailsProps) => {
         </div>
       </div>
 
-      {/* Fixed Bottom Section */}
-      <div className="absolute bottom-0 left-0 right-0 p-6 bg-neutral-50 border-t border-gray-100">
+      {/* Fixed Bottom Section — the bar overlaps the scroll region above it, so it
+          needs an explicit stacking order rather than default paint order. */}
+      <div className="absolute bottom-0 left-0 right-0 z-10 p-6 bg-neutral-50 border-t border-gray-100">
         <div className="flex flex-col gap-4">
           <div className="flex gap-2">
             {event.url && (

--- a/app/components/NewsDetails.tsx
+++ b/app/components/NewsDetails.tsx
@@ -106,7 +106,7 @@ export const NewsDetails = ({ id }: { id: string; title?: string }) => {
   return (
     <div className={`flex flex-col ${news.image_url ? 'h-full' : 'mt-24 h-[calc(100%-6rem)] lg:mt-16 lg:h-[calc(100%-4rem)]'}`}>
       {/* Scrollable Content */}
-      <div className="flex-grow overflow-y-auto pb-56">
+      <div className="flex-grow overflow-y-auto pb-6">
         {news.image_url ? (
           <div className="relative h-56 sm:h-64">
             <img
@@ -200,9 +200,8 @@ export const NewsDetails = ({ id }: { id: string; title?: string }) => {
         </div>
       </div>
 
-      {/* Fixed Bottom Section — z-10 is a guard, not a confirmed fix: the bar overlaps
-          the scroll region, and no repro of it losing paint order exists in Chrome. */}
-      <div className="absolute bottom-0 left-0 right-0 z-10 p-6 bg-neutral-50 border-t border-gray-100">
+      {/* Bottom Section — a flex sibling, not an overlay, so no stacking order to lose */}
+      <div className="shrink-0 p-6 bg-neutral-50 border-t border-gray-100">
         <div className="flex flex-col gap-4">
           <div className="flex gap-2">
             {news.url && (

--- a/app/components/NewsDetails.tsx
+++ b/app/components/NewsDetails.tsx
@@ -200,8 +200,8 @@ export const NewsDetails = ({ id }: { id: string; title?: string }) => {
         </div>
       </div>
 
-      {/* Fixed Bottom Section — the bar overlaps the scroll region above it, so it
-          needs an explicit stacking order rather than default paint order. */}
+      {/* Fixed Bottom Section — z-10 is a guard, not a confirmed fix: the bar overlaps
+          the scroll region, and no repro of it losing paint order exists in Chrome. */}
       <div className="absolute bottom-0 left-0 right-0 z-10 p-6 bg-neutral-50 border-t border-gray-100">
         <div className="flex flex-col gap-4">
           <div className="flex gap-2">

--- a/app/components/NewsDetails.tsx
+++ b/app/components/NewsDetails.tsx
@@ -104,7 +104,7 @@ export const NewsDetails = ({ id }: { id: string; title?: string }) => {
   }
 
   return (
-    <div className={`flex h-full flex-col ${news.image_url ? '' : 'mt-24 lg:mt-16'}`}>
+    <div className={`flex flex-col ${news.image_url ? 'h-full' : 'mt-24 h-[calc(100%-6rem)] lg:mt-16 lg:h-[calc(100%-4rem)]'}`}>
       {/* Scrollable Content */}
       <div className="flex-grow overflow-y-auto pb-56">
         {news.image_url ? (
@@ -200,8 +200,9 @@ export const NewsDetails = ({ id }: { id: string; title?: string }) => {
         </div>
       </div>
 
-      {/* Fixed Bottom Section */}
-      <div className="absolute bottom-0 left-0 right-0 p-6 bg-neutral-50 border-t border-gray-100">
+      {/* Fixed Bottom Section — the bar overlaps the scroll region above it, so it
+          needs an explicit stacking order rather than default paint order. */}
+      <div className="absolute bottom-0 left-0 right-0 z-10 p-6 bg-neutral-50 border-t border-gray-100">
         <div className="flex flex-col gap-4">
           <div className="flex gap-2">
             {news.url && (


### PR DESCRIPTION
## What do these changes accomplish?

Makes the bottom action bar on event and news panels part of the layout instead of an overlay, so it can no longer end up underneath the description text.

## Why?

Closes #193.

Two things were wrong, and the second is the one from the screenshot.

**The bar floated over the scroll region.** `absolute bottom-0` only works while the bar wins paint order against the content scrolling beneath it. On iOS it doesn't — the description draws straight over the button, opaque `bg-neutral-50` and an added `z-index` both notwithstanding. Confirmed on a deploy preview on the reporter's phone. Making it a flex sibling means the scroll column simply ends where the bar begins: there is no overlap left for anything to get the stacking order wrong for.

**The reserved space was short by ~23px.** The panel root applied `mt-24` on top of `h-full`, so the scroll column ran 96px past the bottom of the sheet, eating into the `pb-56` set aside for the bar. At full scroll the last line of a long description sat permanently under the button. Subtracting the margin from the height fixes that, and `pb-56` goes away entirely — the bar's height no longer has to be mirrored in a padding value by hand.

Worth knowing for review: the bug only shows on *past* events, because `eventIsPast` adds `opacity-60` to the root. That branch is why it took a real device to see — a future-dated event renders the same layout without it.

`NewsDetails` had the identical structure and is fixed the same way.

## Screenshots

| Before | After |
|---|---|
| <img width="660" height="1434" alt="IMG_7786" src="https://github.com/user-attachments/assets/d8a90533-f4d2-4c29-8c41-4c335d4bd35b" /> | <img width="660" height="1434" alt="IMG_7785" src="https://github.com/user-attachments/assets/5f90c85d-beb2-42c2-b923-6f39dfddc95b" /> |


Preview: https://pr-358--comfy-custard-bdea2e.netlify.app