### PR TITLE
Report what actually goes stale, not what never changes

### DIFF
--- a/app/api/shops/report/route.ts
+++ b/app/api/shops/report/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { metrics } from '@/lib/metrics'
+import { REPORT_TYPES, isReportType } from '@/lib/reportTypes'
 
 const supabaseUrl = process.env.SUPABASE_URL as string
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
@@ -9,10 +10,20 @@ const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
 export async function POST(request: Request) {
   const body = await request.json()
-  const { shop_id, reported_name, reported_address, reported_neighborhood, reported_website } = body
+  const { shop_id, report_type, details, reported_website } = body
 
   if (!shop_id) {
     return NextResponse.json({ error: 'Missing shop_id' }, { status: 400 })
+  }
+
+  if (!isReportType(report_type)) {
+    return NextResponse.json({ error: 'Invalid report_type' }, { status: 400 })
+  }
+
+  // Without this the table collects rows that say a shop is wrong but not how.
+  const required = REPORT_TYPES[report_type].requires
+  if (required && !String(body[required] ?? '').trim()) {
+    return NextResponse.json({ error: `Missing ${required}` }, { status: 400 })
   }
 
   // Validate that the shop exists
@@ -28,13 +39,7 @@ export async function POST(request: Request) {
 
   const { data, error } = await supabase
     .from('shop_reports')
-    .insert([{
-      shop_id,
-      reported_name,
-      reported_address,
-      reported_neighborhood,
-      reported_website,
-    }])
+    .insert([{ shop_id, report_type, details, reported_website }])
 
   if (error) {
     logger.error('Error submitting report', { error: error.message })
@@ -42,7 +47,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Error submitting report' }, { status: 500 })
   }
 
-  logger.info('Shop report submitted', { shop_id, reported_name, reported_address, reported_neighborhood, reported_website })
+  logger.info('Shop report submitted', { shop_id, report_type })
   metrics.shopReportSubmitted()
   return NextResponse.json(data, { status: 201 })
 }

--- a/app/components/IssueForm.tsx
+++ b/app/components/IssueForm.tsx
@@ -3,158 +3,126 @@
 import { useState } from 'react'
 import { TShop } from '@/types/shop-types'
 import { getFaro } from '@/lib/faro'
+import { REPORT_TYPES, ReportType } from '@/lib/reportTypes'
 
 interface IProps {
   shop: TShop
   onSuccess: () => void
 }
 
+const inputClasses =
+  'block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm'
+
+const DETAILS_PLACEHOLDER: Record<string, string> = {
+  hours: 'e.g. Closes at 3pm on Sundays, not 6pm',
+  other: 'What should we know?',
+}
+
 export default function IssueForm({ shop, onSuccess }: IProps) {
+  const [reportType, setReportType] = useState<ReportType>('hours')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const requires = REPORT_TYPES[reportType].requires
+
+  async function postReport(payload: Record<string, unknown>) {
+    const response = await fetch('/api/shops/report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+  }
 
   async function handleForm(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
     setError(null)
     const formData = new FormData(event.currentTarget)
 
-    const formValues = {
-      name: formData.get('name') as string,
-      address: formData.get('address') as string,
-      neighborhood: formData.get('neighborhood') as string,
-      website: formData.get('website') as string,
-    }
-
-    const originalValues = {
-      name: shop.properties.name,
-      address: shop.properties.address,
-      neighborhood: shop.properties.neighborhood,
-      website: shop.properties.website ?? '',
-    }
-
-    // Build object with only changed fields
-    const changes: Record<string, string> = {}
-    if (formValues.name !== originalValues.name) {
-      changes.reported_name = formValues.name
-    }
-    if (formValues.address !== originalValues.address) {
-      changes.reported_address = formValues.address
-    }
-    if (formValues.neighborhood !== originalValues.neighborhood) {
-      changes.reported_neighborhood = formValues.neighborhood
-    }
-    if (formValues.website !== originalValues.website) {
-      changes.reported_website = formValues.website
-    }
-
-    if (Object.keys(changes).length === 0) {
-      setError('Please change at least one field to report a correction.')
+    if (requires && !String(formData.get(requires) ?? '').trim()) {
+      setError('Please tell us what to fix.')
       return
     }
 
     setIsSubmitting(true)
-    const data = {
-      shop_id: shop.properties.uuid,
-      ...changes,
-    }
-
     try {
-      const response = await fetch('/api/shops/report', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
+      await postReport({
+        shop_id: shop.properties.uuid,
+        report_type: reportType,
+        details: formData.get('details') || null,
+        reported_website: formData.get('reported_website') || null,
       })
-
-      if (!response.ok) {
-        const errorResponse = await response.json()
-        console.error('Error:', errorResponse.error)
-        setError('Something went wrong submitting your correction. Please try again.')
-        setIsSubmitting(false)
-      } else {
-        getFaro()?.api.pushEvent('shop_reported', { shop_id: shop.properties.uuid })
-        setIsSubmitting(false)
-        onSuccess()
-      }
-    } catch (error) {
-      console.error('Unexpected error:', error)
-      setError('Something went wrong submitting your correction. Please try again.')
+      getFaro()?.api.pushEvent('shop_reported', { shop_id: shop.properties.uuid, report_type: reportType })
+      onSuccess()
+    } catch (err) {
+      console.error('Error submitting report:', err)
+      setError('Something went wrong submitting your report. Please try again.')
+    } finally {
       setIsSubmitting(false)
     }
   }
 
   return (
-    <section className="max-w-7xl mx-auto px-6 pb-20">
-      <div className="md:pt-4">
-        <form onSubmit={handleForm} className="space-y-6">
-          <div>
-            <label htmlFor="name" className="block text-sm font-medium text-gray-900 mb-2">
-              Name
+    <form onSubmit={handleForm} className="space-y-5">
+      <fieldset>
+        <legend className="sr-only">What&apos;s wrong?</legend>
+        <div className="space-y-2">
+          {Object.entries(REPORT_TYPES).map(([value, { label }]) => (
+            <label key={value} className="flex items-center gap-3 text-sm text-gray-900">
+              <input
+                type="radio"
+                name="report_type"
+                value={value}
+                checked={reportType === value}
+                onChange={() => setReportType(value as ReportType)}
+                className="size-4 border-gray-300 text-yellow-400 focus:ring-yellow-400"
+              />
+              {label}
             </label>
-            <input
-              id="name"
-              name="name"
-              type="text"
-              defaultValue={shop.properties.name}
-              className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
-            />
-          </div>
+          ))}
+        </div>
+      </fieldset>
 
-          <div>
-            <label htmlFor="address" className="block text-sm font-medium text-gray-900 mb-2">
-              Address
-            </label>
-            <input
-              id="address"
-              name="address"
-              type="text"
-              defaultValue={shop.properties.address}
-              className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
-            />
-          </div>
+      {requires === 'details' && (
+        <div>
+          <label htmlFor="details" className="block text-sm font-medium text-gray-900 mb-2">
+            Details
+          </label>
+          <textarea
+            id="details"
+            name="details"
+            rows={3}
+            placeholder={DETAILS_PLACEHOLDER[reportType]}
+            className={inputClasses}
+          />
+        </div>
+      )}
 
-          <div>
-            <label htmlFor="neighborhood" className="block text-sm font-medium text-gray-900 mb-2">
-              Neighborhood
-            </label>
-            <input
-              id="neighborhood"
-              name="neighborhood"
-              type="text"
-              defaultValue={shop.properties.neighborhood}
-              className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
-            />
-          </div>
+      {requires === 'reported_website' && (
+        <div>
+          <label htmlFor="reported_website" className="block text-sm font-medium text-gray-900 mb-2">
+            Website
+          </label>
+          <input
+            id="reported_website"
+            name="reported_website"
+            type="url"
+            defaultValue={shop.properties.website ?? ''}
+            className={inputClasses}
+          />
+        </div>
+      )}
 
-          <div>
-            <label htmlFor="website" className="block text-sm font-medium text-gray-900 mb-2">
-              Website
-            </label>
-            <input
-              id="website"
-              name="website"
-              type="text"
-              defaultValue={shop.properties.website}
-              className="block w-full rounded-lg border-0 py-3 px-4 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-yellow-400 sm:text-sm"
-            />
-          </div>
+      {error && <p role="alert" className="text-sm text-red-600">{error}</p>}
 
-          {error && (
-            <p className="text-sm text-red-600">{error}</p>
-          )}
-
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className={`w-full rounded-lg py-3 px-4 text-sm font-semibold text-black shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-400 ${
-              isSubmitting ? 'bg-yellow-100 cursor-not-allowed' : 'bg-yellow-300 hover:bg-yellow-400'
-            }`}
-          >
-            {isSubmitting ? 'Submitting…' : 'Submit'}
-          </button>
-        </form>
-      </div>
-    </section>
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className={`w-full rounded-lg py-3 px-4 text-sm font-semibold text-black shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-400 ${
+          isSubmitting ? 'bg-yellow-100 cursor-not-allowed' : 'bg-yellow-300 hover:bg-yellow-400'
+        }`}
+      >
+        {isSubmitting ? 'Submitting…' : 'Submit'}
+      </button>
+    </form>
   )
 }

--- a/app/components/IssueModal.tsx
+++ b/app/components/IssueModal.tsx
@@ -33,8 +33,8 @@ export default function IssueModal({ isOpen, onClose, onSuccess, shop }: Props) 
               <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
             </svg>
           </button>
-          <DialogTitle className="text-lg font-semibold text-stone-900 mb-2">Suggest a correction</DialogTitle>
-          <p className="text-sm text-stone-600 mb-4">Only update what&apos;s incorrect.</p>
+          <DialogTitle className="text-lg font-semibold text-stone-900 mb-2">Report an issue</DialogTitle>
+          <p className="text-sm text-stone-600 mb-4">Tell us what&apos;s out of date and we&apos;ll take a look.</p>
           <IssueForm shop={shop} onSuccess={onSuccess} />
         </DialogPanel>
       </div>

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,64 @@
+{
+  "version": "5",
+  "remote": {
+    "https://edge.netlify.com/": "fd941d61d88673d5f28aab283fb86fcc50f08a3bc80ee5470498fcfa88c65cfb",
+    "https://edge.netlify.com/bootstrap/config.ts": "6a2ce0e544e15e8f8883a5c18da5948e37fd0f2619f68cb31f3af53c51817025",
+    "https://edge.netlify.com/bootstrap/context.ts": "e97240232121e2f369f6546ce961490f34d961ea1ea54be3ff09633e3f08373f",
+    "https://edge.netlify.com/bootstrap/cookie.ts": "8b0baae708989ca183c6f3b4ab3d029e6abcbc2e43f93edeb0ff447b3bbc3a05",
+    "https://edge.netlify.com/bootstrap/edge_function.ts": "b8253e86aa83c67341f5cfedeba5049d77fbf84dcab7eceff7566b7728ae9b39",
+    "https://edge.netlify.com/bootstrap/globals/types.ts": "eaa6148ded3121d8dee62dd91c86e7fe76601df0f3ca8d7962243a30f4c8935f"
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@grafana/faro-web-sdk@^2.8.2",
+        "npm:@grafana/faro-web-tracing@^2.8.2",
+        "npm:@headlessui/react@^2.2.0",
+        "npm:@heroicons/react@^2.1.1",
+        "npm:@netlify/functions@^5.1.5",
+        "npm:@next/bundle-analyzer@^15.1.7",
+        "npm:@scalar/api-reference-react@~0.9.58",
+        "npm:@silk-hq/components@~0.9.11",
+        "npm:@supabase/ssr@0.8",
+        "npm:@supabase/supabase-js@^2.52.0",
+        "npm:@tailwindcss/forms@~0.5.9",
+        "npm:@tailwindcss/postcss@4",
+        "npm:@testing-library/jest-dom@^6.6.3",
+        "npm:@testing-library/react@^16.2.0",
+        "npm:@types/jest@^29.5.14",
+        "npm:@types/mapbox-gl@^3.4.0",
+        "npm:@types/node@20",
+        "npm:@types/react-dom@19.0.4",
+        "npm:@types/react@19.0.10",
+        "npm:@types/snappyjs@~0.7.1",
+        "npm:@vitejs/plugin-react@^6.0.2",
+        "npm:eslint-config-next@15.1.7",
+        "npm:eslint@8",
+        "npm:haversine-distance@^1.2.3",
+        "npm:jsdom-testing-mocks@^1.13.1",
+        "npm:jsdom@26",
+        "npm:lucide-react@0.562",
+        "npm:mapbox-gl@^3.6.0",
+        "npm:next-plausible@^3.12.4",
+        "npm:next@15.5.22",
+        "npm:postcss@^8.5.18",
+        "npm:react-dom@19.0.0",
+        "npm:react-map-gl@^7.1.7",
+        "npm:react@19.0.0",
+        "npm:schema-dts@2",
+        "npm:snappyjs@0.7",
+        "npm:tailwindcss@4",
+        "npm:typescript@5.7.3",
+        "npm:vitest@^4.1.8",
+        "npm:zustand@^5.0.0-rc.2"
+      ],
+      "overrides": {
+        "@types/react": "19.0.10",
+        "@types/react-dom": "19.0.4",
+        "postcss": "^8.5.18",
+        "sharp": "^0.35.3",
+        "brace-expansion": "^5.0.8"
+      }
+    }
+  }
+}

--- a/lib/reportTypes.ts
+++ b/lib/reportTypes.ts
@@ -1,0 +1,14 @@
+// `requires` names the column the report is worthless without, so the form knows
+// which input to reveal and the route knows what to reject. 'closed' needs nothing
+// beyond the shop id — the report type *is* the content.
+export const REPORT_TYPES = {
+  hours: { label: 'The hours are wrong', requires: 'details' },
+  closed: { label: 'This shop has permanently closed', requires: null },
+  website: { label: 'The website is wrong', requires: 'reported_website' },
+  other: { label: 'Something else', requires: 'details' },
+} as const
+
+export type ReportType = keyof typeof REPORT_TYPES
+
+export const isReportType = (value: unknown): value is ReportType =>
+  typeof value === 'string' && value in REPORT_TYPES

--- a/migrations/shop-reports-types-rollback.sql
+++ b/migrations/shop-reports-types-rollback.sql
@@ -1,0 +1,15 @@
+-- Rollback for shop-reports-types.sql
+--
+-- Restores the three dropped columns as nullable text, which is exactly how they
+-- were. This does NOT recover their values — they were NULL in every row when the
+-- up script ran, so there was nothing to preserve.
+--
+-- WARNING: dropping `details` discards the text of every report submitted since
+-- the up script was applied. Read shop_reports before running this.
+
+ALTER TABLE shop_reports
+  ADD COLUMN IF NOT EXISTS reported_name text,
+  ADD COLUMN IF NOT EXISTS reported_address text,
+  ADD COLUMN IF NOT EXISTS reported_neighborhood text,
+  DROP COLUMN IF EXISTS report_type,
+  DROP COLUMN IF EXISTS details;

--- a/migrations/shop-reports-types.sql
+++ b/migrations/shop-reports-types.sql
@@ -1,0 +1,25 @@
+-- Turn shop_reports from a field editor into a typed report queue.
+--
+-- Apply by hand (no migration framework in this repo).
+--
+-- The old shape let users retype name/address/neighborhood/website. In practice
+-- nobody ever did: every row that existed at migration time had NULL in all four
+-- columns. What actually goes stale is hours and whether the shop still exists,
+-- so reports are now typed and carry free text instead.
+--
+-- report_type   — what the reporter is telling us.
+-- details       — free text for 'hours' and 'other'. 'closed' needs none, and
+--                 'website' uses the surviving reported_website column.
+--
+-- APPLYING AN 'hours' REPORT: also set shop_hours_meta.source = 'shop_submitted'
+-- for that shop. Refresh authority is that column alone (a shop is protected iff
+-- source <> 'google_places'), so writing shop_hours by itself is reverted by the
+-- next Google refresh within 14 days.
+
+ALTER TABLE shop_reports
+  ADD COLUMN IF NOT EXISTS report_type text NOT NULL DEFAULT 'other'
+    CHECK (report_type IN ('hours','closed','website','other')),
+  ADD COLUMN IF NOT EXISTS details text,
+  DROP COLUMN IF EXISTS reported_name,
+  DROP COLUMN IF EXISTS reported_address,
+  DROP COLUMN IF EXISTS reported_neighborhood;

--- a/tests/unit/IssueForm.test.tsx
+++ b/tests/unit/IssueForm.test.tsx
@@ -19,6 +19,9 @@ const mockShop: TShop = {
   },
 }
 
+const submit = () => fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+const choose = (label: RegExp) => fireEvent.click(screen.getByLabelText(label))
+
 describe('IssueForm', () => {
   const onSuccess = vi.fn()
 
@@ -27,109 +30,105 @@ describe('IssueForm', () => {
     vi.stubGlobal('fetch', vi.fn())
   })
 
-  it('renders fields prefilled with the shop’s current values', () => {
+  const mockResponse = (ok: boolean) =>
+    vi.mocked(fetch).mockResolvedValueOnce({ ok, json: () => Promise.resolve({}) } as Response)
+
+  it('reveals the website input only for a website report', () => {
     render(<IssueForm shop={mockShop} onSuccess={onSuccess} />)
 
-    expect(screen.getByLabelText(/name/i)).toHaveValue('Test Shop')
-    expect(screen.getByLabelText(/address/i)).toHaveValue('456 Murray Ave, Pittsburgh, PA 15217')
-    expect(screen.getByLabelText(/neighborhood/i)).toHaveValue('Downtown')
-    expect(screen.getByLabelText(/website/i)).toHaveValue('https://testshop.com')
+    expect(screen.queryByLabelText(/^website$/i)).not.toBeInTheDocument()
+
+    choose(/the website is wrong/i)
+
+    expect(screen.getByLabelText(/^website$/i)).toHaveValue('https://testshop.com')
   })
 
-  it('shows an error and does not submit when nothing changed', async () => {
+  it('reveals no input at all for a permanently-closed report', () => {
     render(<IssueForm shop={mockShop} onSuccess={onSuccess} />)
 
-    fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+    choose(/permanently closed/i)
 
-    await waitFor(() => {
-      expect(screen.getByText('Please change at least one field to report a correction.')).toBeInTheDocument()
-    })
-
-    expect(fetch).not.toHaveBeenCalled()
-    expect(onSuccess).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText(/details/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/^website$/i)).not.toBeInTheDocument()
   })
 
-  it('submits only the changed fields', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({}),
-    } as Response)
-
+  it('submits an hours report with its details', async () => {
+    mockResponse(true)
     render(<IssueForm shop={mockShop} onSuccess={onSuccess} />)
 
-    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'New Name' } })
-    fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+    fireEvent.change(screen.getByLabelText(/details/i), { target: { value: 'Closes at 3pm Sundays' } })
+    submit()
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith('/api/shops/report', expect.objectContaining({
         method: 'POST',
-        body: JSON.stringify({ shop_id: 'shop-uuid-123', reported_name: 'New Name' }),
+        body: JSON.stringify({
+          shop_id: 'shop-uuid-123',
+          report_type: 'hours',
+          details: 'Closes at 3pm Sundays',
+          reported_website: null,
+        }),
+      }))
+    })
+    expect(onSuccess).toHaveBeenCalled()
+  })
+
+  it('submits a closed report with no free text', async () => {
+    mockResponse(true)
+    render(<IssueForm shop={mockShop} onSuccess={onSuccess} />)
+
+    choose(/permanently closed/i)
+    submit()
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/shops/report', expect.objectContaining({
+        body: JSON.stringify({
+          shop_id: 'shop-uuid-123',
+          report_type: 'closed',
+          details: null,
+          reported_website: null,
+        }),
       }))
     })
   })
 
-  it('calls onSuccess when the submission succeeds', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({}),
-    } as Response)
-
+  it('blocks submission when a report that needs details has none', async () => {
     render(<IssueForm shop={mockShop} onSuccess={onSuccess} />)
 
-    fireEvent.change(screen.getByLabelText(/address/i), { target: { value: 'New Address' } })
-    fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+    fireEvent.change(screen.getByLabelText(/details/i), { target: { value: '   ' } })
+    submit()
 
     await waitFor(() => {
-      expect(onSuccess).toHaveBeenCalled()
+      expect(screen.getByRole('alert')).toHaveTextContent('Please tell us what to fix.')
     })
-  })
-
-  it('shows an error message when the server rejects the submission', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: false,
-      json: () => Promise.resolve({ error: 'Shop not found' }),
-    } as Response)
-
-    render(<IssueForm shop={mockShop} onSuccess={onSuccess} />)
-
-    fireEvent.change(screen.getByLabelText(/address/i), { target: { value: 'New Address' } })
-    fireEvent.click(screen.getByRole('button', { name: /submit/i }))
-
-    await waitFor(() => {
-      expect(screen.getByText(/something went wrong submitting your correction/i)).toBeInTheDocument()
-    })
-
+    expect(fetch).not.toHaveBeenCalled()
     expect(onSuccess).not.toHaveBeenCalled()
   })
 
-  it('shows an error message when the request throws', async () => {
+  it('shows an error and re-enables submit when the server rejects it', async () => {
+    mockResponse(false)
+    render(<IssueForm shop={mockShop} onSuccess={onSuccess} />)
+
+    choose(/permanently closed/i)
+    submit()
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/something went wrong/i)
+    })
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /^submit$/i })).not.toBeDisabled()
+  })
+
+  it('shows an error when the request throws', async () => {
     vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'))
-
     render(<IssueForm shop={mockShop} onSuccess={onSuccess} />)
 
-    fireEvent.change(screen.getByLabelText(/website/i), { target: { value: 'https://new.example.com' } })
-    fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+    choose(/permanently closed/i)
+    submit()
 
     await waitFor(() => {
-      expect(screen.getByText(/something went wrong submitting your correction/i)).toBeInTheDocument()
+      expect(screen.getByRole('alert')).toHaveTextContent(/something went wrong/i)
     })
-
     expect(onSuccess).not.toHaveBeenCalled()
-  })
-
-  it('re-enables the submit button after a failed submission', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: false,
-      json: () => Promise.resolve({ error: 'Shop not found' }),
-    } as Response)
-
-    render(<IssueForm shop={mockShop} onSuccess={onSuccess} />)
-
-    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'New Name' } })
-    fireEvent.click(screen.getByRole('button', { name: /submit/i }))
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /^submit$/i })).not.toBeDisabled()
-    })
   })
 })

--- a/tests/unit/reportRoute.test.ts
+++ b/tests/unit/reportRoute.test.ts
@@ -32,6 +32,18 @@ vi.mock('@supabase/supabase-js', () => ({
 describe('Report API Route - POST', () => {
   let POST: typeof import('@/app/api/shops/report/route').POST
 
+  const post = (body: Record<string, unknown>) =>
+    POST(
+      new Request('http://localhost:3000/api/shops/report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }),
+    )
+
+  const shopExists = () =>
+    mockShopValidationResult.mockResolvedValueOnce({ data: { uuid: 'shop-uuid-123' }, error: null })
+
   beforeAll(async () => {
     const module = await import('@/app/api/shops/report/route')
     POST = module.POST
@@ -41,62 +53,72 @@ describe('Report API Route - POST', () => {
     vi.clearAllMocks()
   })
 
-  test('successfully submits a report with changed fields', async () => {
-    mockShopValidationResult.mockResolvedValueOnce({
-      data: { uuid: 'shop-uuid-123' },
-      error: null,
-    })
-    mockInsertResult.mockResolvedValueOnce({
-      data: [{ id: 'report-1' }],
-      error: null,
+  test('successfully submits an hours report', async () => {
+    shopExists()
+    mockInsertResult.mockResolvedValueOnce({ data: [{ id: 'report-1' }], error: null })
+
+    const response = await post({
+      shop_id: 'shop-uuid-123',
+      report_type: 'hours',
+      details: 'Closes at 3pm on Sundays',
     })
 
-    const request = new Request('http://localhost:3000/api/shops/report', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        shop_id: 'shop-uuid-123',
-        reported_name: 'Updated Coffee Shop',
-      }),
-    })
+    expect(response.status).toBe(201)
+  })
 
-    const response = await POST(request)
+  test('a closed report needs no details', async () => {
+    shopExists()
+    mockInsertResult.mockResolvedValueOnce({ data: [{ id: 'report-2' }], error: null })
+
+    const response = await post({ shop_id: 'shop-uuid-123', report_type: 'closed' })
 
     expect(response.status).toBe(201)
   })
 
   test('returns 400 when shop_id is missing', async () => {
-    const request = new Request('http://localhost:3000/api/shops/report', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        reported_name: 'Updated Coffee Shop',
-      }),
-    })
-
-    const response = await POST(request)
+    const response = await post({ report_type: 'closed' })
     const data = await response.json()
 
     expect(response.status).toBe(400)
     expect(data.error).toBe('Missing shop_id')
   })
 
+  test('returns 400 for an unknown report_type', async () => {
+    const response = await post({ shop_id: 'shop-uuid-123', report_type: 'bogus' })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Invalid report_type')
+  })
+
+  test('returns 400 when report_type is missing entirely', async () => {
+    const response = await post({ shop_id: 'shop-uuid-123' })
+
+    expect(response.status).toBe(400)
+  })
+
+  // The old route accepted these, which is how the table collected rows saying a
+  // shop was wrong without saying how.
+  test('returns 400 when an hours report has only whitespace for details', async () => {
+    const response = await post({ shop_id: 'shop-uuid-123', report_type: 'hours', details: '   ' })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Missing details')
+  })
+
+  test('returns 400 when a website report has no website', async () => {
+    const response = await post({ shop_id: 'shop-uuid-123', report_type: 'website' })
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Missing reported_website')
+  })
+
   test('returns 404 when shop_id does not exist', async () => {
-    mockShopValidationResult.mockResolvedValueOnce({
-      data: null,
-      error: { message: 'No rows found' },
-    })
+    mockShopValidationResult.mockResolvedValueOnce({ data: null, error: { message: 'No rows found' } })
 
-    const request = new Request('http://localhost:3000/api/shops/report', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        shop_id: 'nonexistent-uuid',
-        reported_name: 'Updated Coffee Shop',
-      }),
-    })
-
-    const response = await POST(request)
+    const response = await post({ shop_id: 'nonexistent-uuid', report_type: 'closed' })
     const data = await response.json()
 
     expect(response.status).toBe(404)
@@ -104,21 +126,9 @@ describe('Report API Route - POST', () => {
   })
 
   test('returns 404 when shop validation returns no data', async () => {
-    mockShopValidationResult.mockResolvedValueOnce({
-      data: null,
-      error: null,
-    })
+    mockShopValidationResult.mockResolvedValueOnce({ data: null, error: null })
 
-    const request = new Request('http://localhost:3000/api/shops/report', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        shop_id: 'invalid-uuid',
-        reported_name: 'Updated Coffee Shop',
-      }),
-    })
-
-    const response = await POST(request)
+    const response = await post({ shop_id: 'invalid-uuid', report_type: 'closed' })
     const data = await response.json()
 
     expect(response.status).toBe(404)
@@ -126,25 +136,10 @@ describe('Report API Route - POST', () => {
   })
 
   test('returns 500 on Supabase insert failure', async () => {
-    mockShopValidationResult.mockResolvedValueOnce({
-      data: { uuid: 'shop-uuid-123' },
-      error: null,
-    })
-    mockInsertResult.mockResolvedValueOnce({
-      data: null,
-      error: { message: 'Database error' },
-    })
+    shopExists()
+    mockInsertResult.mockResolvedValueOnce({ data: null, error: { message: 'Database error' } })
 
-    const request = new Request('http://localhost:3000/api/shops/report', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        shop_id: 'shop-uuid-123',
-        reported_name: 'Updated Coffee Shop',
-      }),
-    })
-
-    const response = await POST(request)
+    const response = await post({ shop_id: 'shop-uuid-123', report_type: 'closed' })
     const data = await response.json()
 
     expect(response.status).toBe(500)


### PR DESCRIPTION
## What do these changes accomplish?

Replaces the "suggest a correction" field editor with a typed report picker, so users can finally report stale hours or a shop that has permanently closed.

## Why?

The old form asked people to retype a shop's name, address, and neighborhood. Those effectively never change, and the data agrees — `shop_reports` held three rows, all from one day of testing, with every reported field empty. Not one real correction ever came in.

What does go stale is a shop's hours and whether it is still open at all, and neither had any way to reach us. Now a report says which of those it is, with a note attached.

The form also let an empty report through. Only the browser checked that you had actually changed something, so the server happily stored reports that said a shop was wrong without saying how. That check now lives on the server.

Closes #360

> [!IMPORTANT]
> **`migrations/shop-reports-types.sql` must be applied before this merges.** It adds `report_type`/`details` and drops the three unused `reported_*` columns; without it every report insert fails. Rollback: `migrations/shop-reports-types-rollback.sql`.

When applying an `hours` report by hand, also set `shop_hours_meta.source = 'shop_submitted'` for that shop — refresh authority is that column alone, so hours written without it get reverted by the next Google refresh within 14 days.

## Screenshots

| Before | After |
|---|---|
| <img width="597" height="774" alt="image" src="https://github.com/user-attachments/assets/562104ef-703c-4a9a-83f8-01293a2cc356" /> | <img width="505" height="492" alt="image" src="https://github.com/user-attachments/assets/149ee286-078e-4ed2-a8a1-e98c0f323904" /> |
