### PR TITLE
Remove dead DbShop.roaster field

### DIFF
--- a/types/shop-types.ts
+++ b/types/shop-types.ts
@@ -30,7 +30,6 @@ export interface DbShop {
   uuid: string
   latitude: number | null
   longitude: number | null
-  roaster?: boolean | string
   // Embedded roaster (joined via roaster_id) whose coffee the shop serves.
   roasterRef?: { name: string; slug: string; company_id: string | null } | null
   amenities?: string[]


### PR DESCRIPTION
## What do these changes accomplish?

Removes the unused `roaster?: boolean | string` field from `DbShop`.

## Why?

This field was a leftover from before `roasterRef` (the joined roaster object) replaced it. A repo-wide search confirms nothing reads or writes it — it's dead weight in the type.