### PR TITLE
Extract shared Supabase env-var check

### DIFF
--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,14 +1,8 @@
 import { createBrowserClient } from '@supabase/ssr'
+import { getSupabaseEnv } from './env'
 
 export function createClient() {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-
-  if (!supabaseUrl || !supabaseAnonKey) {
-    throw new Error(
-      'Missing Supabase environment variables. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in your .env.local file.'
-    )
-  }
+  const { supabaseUrl, supabaseAnonKey } = getSupabaseEnv()
 
   return createBrowserClient(supabaseUrl, supabaseAnonKey)
 }

--- a/lib/supabase/env.ts
+++ b/lib/supabase/env.ts
@@ -1,0 +1,12 @@
+export function getSupabaseEnv() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error(
+      'Missing Supabase environment variables. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in your .env.local file.'
+    )
+  }
+
+  return { supabaseUrl, supabaseAnonKey }
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,17 +1,11 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
+import { getSupabaseEnv } from './env'
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request })
 
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-
-  if (!supabaseUrl || !supabaseAnonKey) {
-    throw new Error(
-      'Missing Supabase environment variables. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in your .env.local file.'
-    )
-  }
+  const { supabaseUrl, supabaseAnonKey } = getSupabaseEnv()
 
   const supabase = createServerClient(
     supabaseUrl,

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,17 +1,11 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
+import { getSupabaseEnv } from './env'
 
 export async function createClient() {
   const cookieStore = await cookies()
 
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-
-  if (!supabaseUrl || !supabaseAnonKey) {
-    throw new Error(
-      'Missing Supabase environment variables. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in your .env.local file.'
-    )
-  }
+  const { supabaseUrl, supabaseAnonKey } = getSupabaseEnv()
 
   return createServerClient(
     supabaseUrl,

--- a/tests/unit/supabaseEnv.test.ts
+++ b/tests/unit/supabaseEnv.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect, afterEach, vi } from 'vitest'
+import { getSupabaseEnv } from '@/lib/supabase/env'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('getSupabaseEnv', () => {
+  test('returns the url and anon key when both are set', () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co')
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'anon-key')
+
+    expect(getSupabaseEnv()).toEqual({
+      supabaseUrl: 'https://example.supabase.co',
+      supabaseAnonKey: 'anon-key',
+    })
+  })
+
+  test('throws when the url is missing', () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', '')
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'anon-key')
+
+    expect(() => getSupabaseEnv()).toThrow('Missing Supabase environment variables')
+  })
+
+  test('throws when the anon key is missing', () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co')
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', '')
+
+    expect(() => getSupabaseEnv()).toThrow('Missing Supabase environment variables')
+  })
+})


### PR DESCRIPTION
## What do these changes accomplish?

Extracts the duplicated Supabase env-var validation in `client.ts`, `server.ts`, and `middleware.ts` into a single `getSupabaseEnv()` helper.

## Why?

The same "throw if NEXT_PUBLIC_SUPABASE_URL/ANON_KEY missing" block was copied verbatim across all three Supabase client factories.
