### PR TITLE
Use shared getCompanyBySlug in company events/news routes

### DIFF
--- a/app/api/companies/[company]/events/route.ts
+++ b/app/api/companies/[company]/events/route.ts
@@ -1,25 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
+import { getCompanyBySlug } from '@/app/utils/companies'
 
 const supabaseUrl = process.env.SUPABASE_URL as string
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
 const supabase = createClient(supabaseUrl, supabaseAnonKey)
-
-const getCompany = async (slug: string) => {
-  const { data, error } = await supabase
-    .from('companies')
-    .select('*')
-    .eq('slug', slug)
-    .single()
-
-  if (error) {
-    logger.error('Error fetching company', { error: error.message })
-    return null
-  }
-
-  return data
-}
 
 const getCompanyEvents = async (companyId: string) => {
   const { data, error } = await supabase
@@ -39,7 +25,7 @@ export async function GET(req: NextRequest, props: { params: Promise<{ company: 
   const params = await props.params
   const { company } = params
 
-  const companyData = await getCompany(company)
+  const companyData = await getCompanyBySlug(company)
 
   if (!companyData) {
     return NextResponse.json({ message: 'Company not found' }, { status: 404 })

--- a/app/api/companies/[company]/news/route.ts
+++ b/app/api/companies/[company]/news/route.ts
@@ -1,25 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
+import { getCompanyBySlug } from '@/app/utils/companies'
 
 const supabaseUrl = process.env.SUPABASE_URL as string
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
 const supabase = createClient(supabaseUrl, supabaseAnonKey)
-
-const getCompany = async (slug: string) => {
-  const { data, error } = await supabase
-    .from('companies')
-    .select('*')
-    .eq('slug', slug)
-    .single()
-
-  if (error) {
-    logger.error('Error fetching company', { error: error.message })
-    return null
-  }
-
-  return data
-}
 
 const getCompanyNews = async (companyId: string) => {
   const { data, error } = await supabase
@@ -39,7 +25,7 @@ export async function GET(req: NextRequest, props: { params: Promise<{ company: 
   const params = await props.params
   const { company } = params
 
-  const companyData = await getCompany(company)
+  const companyData = await getCompanyBySlug(company)
 
   if (!companyData) {
     return NextResponse.json({ message: 'Company not found' }, { status: 404 })


### PR DESCRIPTION
## What do these changes accomplish?

Replaces the duplicated `getCompany` lookup in the company events and news routes with the canonical `getCompanyBySlug`.

## Why?

Both routes reimplemented the exact same company-by-slug lookup that already exists in `app/utils/companies.ts`.
