### PR TITLE
fix(api): add missing roaster join to shops and batch routes

### DIFF
--- a/app/api/companies/[company]/route.ts
+++ b/app/api/companies/[company]/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { publicCacheHeaders, SHOP_DATA_TTL } from '@/lib/cacheHeaders'
 import { getCompanyBySlug } from '@/app/utils/companies'
+import { SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
 
 // Supabase configuration
 const supabaseUrl = process.env.SUPABASE_URL as string
@@ -12,7 +13,7 @@ const supabase = createClient(supabaseUrl, supabaseAnonKey)
 const getCompanyShops = async (companyId: string) => {
   const { data, error } = await supabase
     .from('shops')
-    .select('*, company:company_id(*), roasterRef:roaster_id(name, slug, company_id)')
+    .select(SHOP_WITH_ROASTER_SELECT)
     .eq('company_id', companyId)
 
   if (error) {

--- a/app/api/featured-shop/route.ts
+++ b/app/api/featured-shop/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import crypto from 'crypto'
-import { formatDBShopAsFeature } from '@/app/utils/utils'
+import { formatDBShopAsFeature, SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
 import { DbShop } from '@/types/shop-types'
 
 // Disable Next's fixed ISR window; we'll control TTL via Cache-Control
@@ -74,7 +74,7 @@ export async function GET() {
 
   const { data, error } = await supabase
     .from('shops')
-    .select('*, company:company_id(*), roasterRef:roaster_id(name, slug, company_id)')
+    .select(SHOP_WITH_ROASTER_SELECT)
     .eq('uuid', winnerUuid)
 
   if (error || !data?.[0]) {

--- a/app/api/roasters/[slug]/route.ts
+++ b/app/api/roasters/[slug]/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { publicCacheHeaders, SHOP_DATA_TTL } from '@/lib/cacheHeaders'
 import { getRoasterBySlug } from '@/app/utils/roasters'
+import { SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
 
 const supabaseUrl = process.env.SUPABASE_URL as string
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
@@ -13,7 +14,7 @@ const supabase = createClient(supabaseUrl, supabaseAnonKey)
 const getRoasterShops = async (roasterId: string) => {
   const { data, error } = await supabase
     .from('shops')
-    .select('*, company:company_id(*), roasterRef:roaster_id(name, slug, company_id)')
+    .select(SHOP_WITH_ROASTER_SELECT)
     .eq('roaster_id', roasterId)
 
   if (error) {

--- a/app/api/shops/batch/route.ts
+++ b/app/api/shops/batch/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
-import { formatDataToGeoJSON } from '../../../utils/utils'
+import { formatDataToGeoJSON, SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
 import { logger } from '@/lib/logger'
 
 // Supabase configuration
@@ -11,7 +11,7 @@ const supabase = createClient(supabaseUrl, supabaseAnonKey)
 const fetchShopsByIds = async (ids: string[]) => {
   const { data, error } = await supabase
     .from('shops')
-    .select('*, company:company_id(*)')
+    .select(SHOP_WITH_ROASTER_SELECT)
     .in('uuid', ids)
     .order('name', { ascending: true })
 

--- a/app/api/shops/geojson/route.ts
+++ b/app/api/shops/geojson/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
-import { formatDataToGeoJSON } from '../../../utils/utils'
+import { formatDataToGeoJSON, SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
 import { logger } from '@/lib/logger'
 import { withMetrics } from '@/lib/withMetrics'
 import { publicCacheHeaders, SHOP_DATA_TTL } from '@/lib/cacheHeaders'
@@ -13,7 +13,7 @@ const supabase = createClient(supabaseUrl, supabaseAnonKey)
 const fetchShops = async () => {
   const { data, error } = await supabase
     .from('shops')
-    .select('*, company:company_id(*), roasterRef:roaster_id(name, slug, company_id)')
+    .select(SHOP_WITH_ROASTER_SELECT)
     .order('name', { ascending: true })
   if (error) {
     logger.error('Error fetching shops', { error: error.message })

--- a/app/api/shops/route.ts
+++ b/app/api/shops/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { withMetrics } from '@/lib/withMetrics'
+import { SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
 
 // Supabase configuration
 const supabaseUrl = process.env.SUPABASE_URL as string
@@ -9,7 +10,7 @@ const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
 const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
 const fetchShops = async (neighborhood?: string) => {
-  let query = supabase.from('shops').select('*, company:company_id(*)').order('name', { ascending: true })
+  let query = supabase.from('shops').select(SHOP_WITH_ROASTER_SELECT).order('name', { ascending: true })
 
   if (neighborhood) {
     query = query.eq('neighborhood', neighborhood)

--- a/app/utils/shops.ts
+++ b/app/utils/shops.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 import { DbShop } from '@/types/shop-types'
 import { logger } from '@/lib/logger'
+import { SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
 
 const supabaseUrl = process.env.SUPABASE_URL as string
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
@@ -13,7 +14,7 @@ export const getShopByUuidPrefix = async (prefix: string): Promise<DbShop | null
   // matches every uuid sharing that prefix while still using the uuid index.
   const { data, error } = await supabase
     .from('shops')
-    .select('*, company:company_id(*), roasterRef:roaster_id(name, slug, company_id)')
+    .select(SHOP_WITH_ROASTER_SELECT)
     .gte('uuid', `${prefix}-0000-0000-0000-000000000000`)
     .lte('uuid', `${prefix}-ffff-ffff-ffff-ffffffffffff`)
     .limit(1)

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -1,5 +1,9 @@
 import { DbShop, TFeatureCollection, TShop, TShopRoaster } from '@/types/shop-types'
 
+// One definition shared by every route that queries `shops`, so a roaster join
+// added to one query can't silently drift missing from another.
+export const SHOP_WITH_ROASTER_SELECT = '*, company:company_id(*), roasterRef:roaster_id(name, slug, company_id)'
+
 // The roaster a shop serves (joined via roaster_id), flagged in-house when it
 // belongs to the same company as the shop. Shared by every shop→feature path so
 // the roaster card shows regardless of how a shop was selected (map vs. direct).

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -1,7 +1,5 @@
 import { DbShop, TFeatureCollection, TShop, TShopRoaster } from '@/types/shop-types'
 
-// One definition shared by every route that queries `shops`, so a roaster join
-// added to one query can't silently drift missing from another.
 export const SHOP_WITH_ROASTER_SELECT = '*, company:company_id(*), roasterRef:roaster_id(name, slug, company_id)'
 
 // The roaster a shop serves (joined via roaster_id), flagged in-house when it

--- a/tests/unit/shopsBatchRoute.test.ts
+++ b/tests/unit/shopsBatchRoute.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
+
+const mockOrder = vi.fn()
+const mockIn = vi.fn(() => ({ order: mockOrder }))
+const mockSelect = vi.fn((_select: string) => ({ in: mockIn }))
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: mockSelect,
+    }),
+  }),
+}))
+
+describe('Shops Batch API Route - GET', () => {
+  let GET: typeof import('@/app/api/shops/batch/route').GET
+
+  beforeAll(async () => {
+    GET = (await import('@/app/api/shops/batch/route')).GET
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns 400 when ids param is missing', async () => {
+    const response = await GET(new Request('http://localhost/api/shops/batch'))
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Missing ids parameter')
+  })
+
+  test('returns an empty FeatureCollection when ids param has no usable ids', async () => {
+    const response = await GET(new Request('http://localhost/api/shops/batch?ids=,,'))
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.features).toEqual([])
+    expect(mockSelect).not.toHaveBeenCalled()
+  })
+
+  // Regression for S12: the batch query dropped the roaster join that
+  // geojson/route.ts and by-slug/route.ts both carry, so every shop in the
+  // batch response silently lost its `roaster` property.
+  test('queries the roaster join and surfaces it on each shop', async () => {
+    mockOrder.mockResolvedValueOnce({
+      data: [{
+        name: 'Test Coffee',
+        neighborhood: 'Downtown',
+        website: 'https://example.com',
+        address: '123 Main St',
+        uuid: 'shop-1',
+        latitude: 40.4363,
+        longitude: -79.925,
+        company: null,
+        roasterRef: { name: 'Test Roasters', slug: 'test-roasters', company_id: null },
+      }],
+      error: null,
+    })
+
+    const response = await GET(new Request('http://localhost/api/shops/batch?ids=shop-1'))
+    const data = await response.json()
+
+    const [selectArg] = mockSelect.mock.calls[0]
+    expect(selectArg).toContain('roasterRef:roaster_id')
+
+    expect(response.status).toBe(200)
+    expect(data.features[0].properties.roaster).toEqual({
+      name: 'Test Roasters',
+      slug: 'test-roasters',
+      inHouse: false,
+    })
+  })
+
+  test('returns 500 on database error', async () => {
+    mockOrder.mockResolvedValueOnce({ data: null, error: { message: 'boom' } })
+
+    const response = await GET(new Request('http://localhost/api/shops/batch?ids=shop-1'))
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Error fetching shops')
+  })
+})

--- a/tests/unit/shopsBatchRoute.test.ts
+++ b/tests/unit/shopsBatchRoute.test.ts
@@ -40,9 +40,6 @@ describe('Shops Batch API Route - GET', () => {
     expect(mockSelect).not.toHaveBeenCalled()
   })
 
-  // Regression for S12: the batch query dropped the roaster join that
-  // geojson/route.ts and by-slug/route.ts both carry, so every shop in the
-  // batch response silently lost its `roaster` property.
   test('queries the roaster join and surfaces it on each shop', async () => {
     mockOrder.mockResolvedValueOnce({
       data: [{

--- a/tests/unit/shopsRoute.test.ts
+++ b/tests/unit/shopsRoute.test.ts
@@ -5,19 +5,20 @@ import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
 // so `order` returns an object that is both awaitable and exposes `eq`.
 const mockOrderResult = vi.fn()
 const mockEqResult = vi.fn()
+const mockSelect = vi.fn((_select: string) => ({
+  // `order` is awaited directly when no filter is applied, and also exposes
+  // `.eq` for the filtered path. Make it both thenable and chainable.
+  order: () => ({
+    eq: mockEqResult,
+    then: (...args: unknown[]) =>
+      (mockOrderResult() as Promise<unknown>).then(...(args as [never, never])),
+  }),
+}))
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: () => ({
     from: () => ({
-      select: () => ({
-        // `order` is awaited directly when no filter is applied, and also exposes
-        // `.eq` for the filtered path. Make it both thenable and chainable.
-        order: () => ({
-          eq: mockEqResult,
-          then: (...args: unknown[]) =>
-            (mockOrderResult() as Promise<unknown>).then(...(args as [never, never])),
-        }),
-      }),
+      select: mockSelect,
     }),
   }),
 }))
@@ -42,6 +43,16 @@ describe('Shops API Route - GET', () => {
 
     expect(response.status).toBe(200)
     expect(data).toEqual(shops)
+  })
+
+  // Regression: this route once queried '*, company:company_id(*)' with no
+  // roaster join, so every shop it returned was silently missing roaster data.
+  test('queries the roaster join', async () => {
+    mockOrderResult.mockResolvedValueOnce({ data: [], error: null })
+
+    await GET(new Request('http://localhost/api/shops'))
+
+    expect(mockSelect.mock.calls[0][0]).toContain('roasterRef:roaster_id')
   })
 
   test('applies neighborhood filter when query param is present', async () => {

--- a/tests/unit/shopsRoute.test.ts
+++ b/tests/unit/shopsRoute.test.ts
@@ -45,8 +45,6 @@ describe('Shops API Route - GET', () => {
     expect(data).toEqual(shops)
   })
 
-  // Regression: this route once queried '*, company:company_id(*)' with no
-  // roaster join, so every shop it returned was silently missing roaster data.
   test('queries the roaster join', async () => {
     mockOrderResult.mockResolvedValueOnce({ data: [], error: null })
 


### PR DESCRIPTION
## What do these changes accomplish?

Extracts the shop-with-roaster select string into a shared `SHOP_WITH_ROASTER_SELECT` constant and uses it in every route that queries `shops`, fixing the roaster join that was silently missing from `/api/shops/batch` and (found during review of this same fix) `/api/shops`.


## Why?

`app/api/shops/batch/route.ts` was missing the `roasterRef:roaster_id(...)` join that `geojson/route.ts` and the by-slug route already had, so every shop returned by the batch endpoint silently lost its roaster info. Extracting one shared constant and using it everywhere means this join can't drift out of sync between routes again.

Also added a test file for `batch/route.ts` (previously had none) and a regression assertion on the existing `/api/shops` test, both of which pin the roaster join so this can't silently regress.