### PR TITLE
fix(settings): stop first-visit render from disagreeing with localStorage

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -4,22 +4,41 @@ import { useEffect, useState } from 'react'
 import { TUnits } from '@/types/unit-types'
 import DistanceUnitsDialog, { DISTANCE_UNITS } from '@/app/settings/DistanceUnitsDialog'
 
+const DISTANCE_PREFERENCE_KEY = 'distanceUnits'
+const DEFAULT_UNIT = DISTANCE_UNITS.Miles as TUnits
+
+// A storage write can throw (e.g. private browsing with storage disabled), and
+// this seed is a best-effort default, not the read path — swallow it the same
+// way handleUnitChange already does, rather than let it fail the mount effect.
+const seedDefaultUnit = () => {
+  try {
+    window.localStorage.setItem(DISTANCE_PREFERENCE_KEY, DEFAULT_UNIT)
+  } catch (error) {
+    console.error('Failed to seed default unit preference:', error)
+  }
+}
+
+// Read once and reuse the same value for both the write and the state, so a
+// first visit (nothing stored yet) can't leave localStorage and the render
+// disagreeing about what the default is. One `stored` check drives both
+// branches, so an empty string is treated as "nothing stored" everywhere,
+// not just in the write, or it would render blank forever without self-healing.
+const readStoredUnitOrSeedDefault = () => {
+  const stored = window.localStorage.getItem(DISTANCE_PREFERENCE_KEY)
+  if (stored) return stored as TUnits
+  seedDefaultUnit()
+  return DEFAULT_UNIT
+}
+
 export default function Settings() {
   const [distanceUnitsDialogIsOpen, setDistanceUnitsDialogIsOpen] = useState(false)
   const [unitFromLocalStorage, setUnitFromLocalStorage] = useState<TUnits>('miles')
   const [isLoading, setIsLoading] = useState(true)
-  const DEFAULT_UNIT = DISTANCE_UNITS.Miles
-  const DISTANCE_PREFERENCE_KEY = 'distanceUnits'
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      setUnitFromLocalStorage(window.localStorage.getItem(DISTANCE_PREFERENCE_KEY) as TUnits)
-      if (!window.localStorage.getItem(DISTANCE_PREFERENCE_KEY)) {
-        window.localStorage.setItem(DISTANCE_PREFERENCE_KEY, DEFAULT_UNIT)
-      }
-      setIsLoading(false)
-    }
-  // eslint-disable-next-line
+    if (typeof window === 'undefined') return
+    setUnitFromLocalStorage(readStoredUnitOrSeedDefault())
+    setIsLoading(false)
   }, [])
 
   const handleUnitChange = (newUnit: string) => {
@@ -65,7 +84,7 @@ export default function Settings() {
       </div>
 
       <DistanceUnitsDialog
-        currentUnit={unitFromLocalStorage || DEFAULT_UNIT}
+        currentUnit={unitFromLocalStorage}
         isOpen={distanceUnitsDialogIsOpen}
         handleClose={() => setDistanceUnitsDialogIsOpen(false)}
         onUnitChange={handleUnitChange}

--- a/tests/unit/SettingsPage.test.tsx
+++ b/tests/unit/SettingsPage.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import Settings from '@/app/settings/page'
+
+describe('Settings page', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  // Regression for S19: the page used to read `null` from localStorage on a
+  // first visit, write the default in, but leave state holding the `null` it
+  // had already read — so the unit rendered blank, disagreeing with what a
+  // reload would then read back from the now-seeded localStorage.
+  it('renders the same default unit on a first visit that it persists for a reload', async () => {
+    render(<Settings />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Miles')).toBeInTheDocument()
+    })
+    expect(window.localStorage.getItem('distanceUnits')).toBe('Miles')
+  })
+
+  it('renders a previously stored unit unchanged', async () => {
+    window.localStorage.setItem('distanceUnits', 'Meters')
+
+    render(<Settings />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Meters')).toBeInTheDocument()
+    })
+  })
+
+  // An empty string is a stored-but-blank value, not "nothing stored" — it must
+  // self-heal to the default rather than rendering blank forever.
+  it('treats an empty stored value the same as nothing stored', async () => {
+    window.localStorage.setItem('distanceUnits', '')
+
+    render(<Settings />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Miles')).toBeInTheDocument()
+    })
+    expect(window.localStorage.getItem('distanceUnits')).toBe('Miles')
+  })
+})


### PR DESCRIPTION
## What do these changes accomplish?

Fixes the Settings page rendering a blank units value on a first visit by computing the stored-or-default unit once and reusing that same value for both the localStorage write and the React state.

## Why?

On a first visit `distanceUnits` isn't set yet: the old code set state to the `null` it had just read from localStorage, then separately wrote the default into localStorage — leaving state, storage, and the render disagreeing, so the "Units for distance" row showed blank instead of "Miles" until something else re-rendered the page.

Also treats an empty string the same as "nothing stored" (so it self-heals instead of persisting a blank value forever), and wraps the seed write in try/catch so a throwing `localStorage.setItem` (e.g. Safari private browsing) can't leave the page stuck on "Loading…" indefinitely — both found during code review of this same fix.

Adds `tests/unit/SettingsPage.test.tsx` (no prior coverage existed) covering the first-visit case, a previously-stored value, and the empty-string edge case.



## Screenshots

Before:
<img width="900" height="260" alt="image" src="https://github.com/user-attachments/assets/0762cfd3-165f-4a52-8251-8ef437f138ff" />

After:
<img width="900" height="260" alt="image" src="https://github.com/user-attachments/assets/0cd036c1-0556-4a79-ae09-d65e6e651591" />
