### PR TITLE
fix(api): stop report/route.ts reporting DB failures as 404

### DIFF
--- a/app/api/shops/claim/route.ts
+++ b/app/api/shops/claim/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { metrics } from '@/lib/metrics'
+import { isRealSupabaseError } from '@/lib/supabaseErrors'
 
 const supabaseUrl = process.env.SUPABASE_URL as string
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
@@ -47,9 +48,7 @@ export async function POST(request: Request) {
     .eq(target.idColumn, target_id)
     .single()
 
-  // PGRST116 is "no rows" — a genuine 404. Any other error is a real failure
-  // (DB down, bad query) and must not masquerade as "listing not found".
-  if (entityError && entityError.code !== 'PGRST116') {
+  if (isRealSupabaseError(entityError)) {
     logger.error('Error validating claim target', { error: entityError.message })
     metrics.apiError('shops/claim')
     return NextResponse.json({ error: 'Error submitting claim' }, { status: 500 })

--- a/app/api/shops/report-amenities/route.ts
+++ b/app/api/shops/report-amenities/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { metrics } from '@/lib/metrics'
 import { AMENITY_KEYS } from '@/lib/amenityKeys'
+import { isRealSupabaseError } from '@/lib/supabaseErrors'
 
 const supabaseUrl = process.env.SUPABASE_URL as string
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
@@ -25,8 +26,9 @@ export async function POST(request: Request) {
     .eq('uuid', shop_id)
     .single()
 
-  if (shopError && shopError.code !== 'PGRST116') {
+  if (isRealSupabaseError(shopError)) {
     logger.error('Error validating shop', { error: shopError.message })
+    metrics.apiError('shops/report-amenities')
     return NextResponse.json({ error: 'Error validating shop' }, { status: 500 })
   }
 
@@ -40,6 +42,7 @@ export async function POST(request: Request) {
 
   if (error) {
     logger.error('Error submitting amenity report', { error: error.message })
+    metrics.apiError('shops/report-amenities')
     return NextResponse.json({ error: 'Error submitting amenity report' }, { status: 500 })
   }
 

--- a/app/api/shops/report/route.ts
+++ b/app/api/shops/report/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { metrics } from '@/lib/metrics'
 import { REPORT_TYPES, isReportType } from '@/lib/reportTypes'
+import { isRealSupabaseError } from '@/lib/supabaseErrors'
 
 const supabaseUrl = process.env.SUPABASE_URL as string
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
@@ -33,7 +34,13 @@ export async function POST(request: Request) {
     .eq('uuid', shop_id)
     .single()
 
-  if (shopError || !shop) {
+  if (isRealSupabaseError(shopError)) {
+    logger.error('Error validating shop', { error: shopError.message })
+    metrics.apiError('shops/report')
+    return NextResponse.json({ error: 'Error validating shop' }, { status: 500 })
+  }
+
+  if (!shop) {
     return NextResponse.json({ error: 'Shop not found' }, { status: 404 })
   }
 

--- a/lib/supabaseErrors.ts
+++ b/lib/supabaseErrors.ts
@@ -1,10 +1,7 @@
-// PGRST116 covers both "no rows" (the routes below always query by a unique
-// id, so this is what actually happens) and "more than one row" for a query
-// expecting exactly one — either way it's `.single()` telling us the lookup
-// didn't resolve to a row, not a query failure. Every other code is a real
-// failure (DB down, bad query) and must not masquerade as a 404 the way a
-// missing row legitimately does. A type predicate (not just a boolean) so
-// callers can read `.message` on the error afterward without a redundant
-// null check.
+// Every code but PGRST116 ("no rows", the only outcome `.single()` on a
+// unique-id lookup can return besides success) is a real failure and must
+// not masquerade as a 404 the way a missing row legitimately does. A type
+// predicate (not just a boolean) so callers can read `.message` on the
+// error afterward without a redundant null check.
 export const isRealSupabaseError = <E extends { code?: string }>(error: E | null): error is E =>
   !!error && error.code !== 'PGRST116'

--- a/lib/supabaseErrors.ts
+++ b/lib/supabaseErrors.ts
@@ -1,0 +1,10 @@
+// PGRST116 covers both "no rows" (the routes below always query by a unique
+// id, so this is what actually happens) and "more than one row" for a query
+// expecting exactly one — either way it's `.single()` telling us the lookup
+// didn't resolve to a row, not a query failure. Every other code is a real
+// failure (DB down, bad query) and must not masquerade as a 404 the way a
+// missing row legitimately does. A type predicate (not just a boolean) so
+// callers can read `.message` on the error afterward without a redundant
+// null check.
+export const isRealSupabaseError = <E extends { code?: string }>(error: E | null): error is E =>
+  !!error && error.code !== 'PGRST116'

--- a/tests/unit/reportRoute.test.ts
+++ b/tests/unit/reportRoute.test.ts
@@ -116,7 +116,7 @@ describe('Report API Route - POST', () => {
   })
 
   test('returns 404 when shop_id does not exist', async () => {
-    mockShopValidationResult.mockResolvedValueOnce({ data: null, error: { message: 'No rows found' } })
+    mockShopValidationResult.mockResolvedValueOnce({ data: null, error: { code: 'PGRST116', message: 'No rows found' } })
 
     const response = await post({ shop_id: 'nonexistent-uuid', report_type: 'closed' })
     const data = await response.json()
@@ -133,6 +133,31 @@ describe('Report API Route - POST', () => {
 
     expect(response.status).toBe(404)
     expect(data.error).toBe('Shop not found')
+  })
+
+  // Regression for S11a: the route used to treat any Supabase error as "not
+  // found," so a real DB failure during shop validation was reported as a 404
+  // instead of the 500 it actually is.
+  test('returns 500, not 404, when shop validation fails for a reason other than no rows', async () => {
+    mockShopValidationResult.mockResolvedValueOnce({ data: null, error: { code: '500', message: 'connection refused' } })
+
+    const response = await post({ shop_id: 'shop-uuid-123', report_type: 'closed' })
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Error validating shop')
+  })
+
+  // An error with no `code` at all is not PGRST116, so it must be treated as a
+  // real failure the same as any other non-PGRST116 error.
+  test('returns 500 when a Supabase error has no code at all', async () => {
+    mockShopValidationResult.mockResolvedValueOnce({ data: null, error: { message: 'unexpected' } })
+
+    const response = await post({ shop_id: 'shop-uuid-123', report_type: 'closed' })
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Error validating shop')
   })
 
   test('returns 500 on Supabase insert failure', async () => {


### PR DESCRIPTION
Assume everything written below this line is AI slop

---


## What do these changes accomplish?

Fixes `report/route.ts` returning a 404 "Shop not found" for real database failures during shop validation, by reusing the PGRST116-aware check that `claim/route.ts` already had correct into one shared helper.


## Why?

`report/route.ts` treated any Supabase error during the shop-existence check as "shop not found," so a real DB failure (connection drop, timeout) looked identical to a shop that genuinely doesn't exist, and never got logged as an error or counted in metrics. `claim/route.ts` already distinguished PGRST116 ("no rows" — a real 404) from any other error code (a real failure — 500); `report-amenities/route.ts` had the same check but duplicated inline.

Extracted the check into `lib/supabaseErrors.ts`'s `isRealSupabaseError` and used it in all three routes so this can't drift apart again. Also added the `metrics.apiError` call `report-amenities/route.ts` was missing on both its error branches, for parity with its two siblings (found during code review of this fix).

**Assumption made instead of asking:** the ticket named extracting the shared helper for use in `report/route.ts`; I also switched `claim/route.ts` and `report-amenities/route.ts` onto the same shared helper (instead of leaving their inline/duplicated versions as-is) since otherwise the extraction doesn't actually remove the duplication that motivated it.

**Noticed but out of scope, logged to PAPERCUTS.md:** the same "any Supabase error collapsed into 404" pattern is still live, untouched, in `app/api/favorites/route.ts`, `app/api/visits/route.ts`, and five other routes/utils. Rolling `isRealSupabaseError` out to all of them is a bigger, separate change.

Rewrote the existing `reportRoute.test.ts` case that pinned the old "any error → 404" behavior, and added cases for a non-PGRST116 error code and for an error with no `code` at all.