### PR TITLE
fix(shop-news): use shared NewsItem type, drop dead client-side filter/sort

### DIFF
--- a/app/components/ShopNews.tsx
+++ b/app/components/ShopNews.tsx
@@ -1,79 +1,57 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { TShop } from '@/types/shop-types'
 import { NewsCard } from '@/app/components/NewsCard'
 import { NewsItem } from '@/types/news-types'
 
-type UpdateEntry = {
-  id?: string | number
-  title: string
-  description?: string | null
-  url?: string | null
-  post_date?: string | null
-  event_date?: string | null
-  postDate?: string | null
-  eventDate?: string | null
-  tags?: string[] | null
-  shop_id?: string | null
-  shopId?: string | null
-}
-
 type Props = { shop: TShop }
 
+// /api/updates already filters by shop_id and orders by post_date, so this
+// hands back exactly what ShopNews should render — no client-side re-derive.
+async function fetchShopUpdates(shopId: string, signal: AbortSignal) {
+  const qs = new URLSearchParams({ shop_id: shopId })
+  const res = await fetch(`/api/updates?${qs.toString()}`, { signal })
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json() as Promise<NewsItem[]>
+}
+
 export const ShopNews = ({ shop }: Props) => {
-  const [updates, setUpdates] = useState<UpdateEntry[] | null>(null)
+  const [updates, setUpdates] = useState<NewsItem[]>([])
   const shopId = shop.properties.uuid
 
   useEffect(() => {
-    if (!shopId) {
-      setUpdates([])
-      return
-    }
+    // Clear the previous shop's list before fetching the new one, so a
+    // switch between shops can't leave shop A's news rendered under shop B's
+    // header — whether B has no updates yet, or its fetch fails outright.
+    setUpdates([])
+    if (!shopId) return
 
-    let cancelled = false
-    const ac = new AbortController()
+    const controller = new AbortController()
+    fetchShopUpdates(shopId, controller.signal)
+      // abort() can't un-settle a request that already resolved, so this
+      // guards against that response landing after a newer shop took over.
+      .then(data => {
+        if (!controller.signal.aborted) setUpdates(data)
+      })
+      .catch(err => {
+        if (err.name !== 'AbortError') console.error(err)
+      })
 
-    ;(async () => {
-      try {
-        const qs = new URLSearchParams({ shop_id: String(shopId) })
-        const res = await fetch(`/api/updates?${qs.toString()}`)
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        const data: UpdateEntry[] = await res.json()
-        if (!cancelled) setUpdates(data)
-      } catch {}
-    })()
-
-    return () => {
-      cancelled = true
-      ac.abort()
-    }
-  }, [shop, shopId])
-
-  const relevantNews = useMemo(() => {
-    if (!updates) return []
-    // Filter before normalizing - only show updates tied to THIS shop
-    const filtered = shopId
-      ? updates.filter(e => (e.shopId ?? e.shop_id) === String(shopId))
-      : updates
-    return filtered.sort((a, b) => {
-      const aDate = new Date((a.postDate ?? a.post_date) ?? (a.eventDate ?? a.event_date) ?? 0).getTime()
-      const bDate = new Date((b.postDate ?? b.post_date) ?? (b.eventDate ?? b.event_date) ?? 0).getTime()
-      return bDate - aDate
-    })
-  }, [updates, shopId])
+    return () => controller.abort()
+  }, [shopId])
 
   // Nothing to show? render nothing.
-  if (!relevantNews.length) return null
+  if (!updates.length) return null
 
   return (
     <section className="flex flex-col border-b border-stone-200 px-4 py-5 sm:px-6">
       <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">Updates</p>
 
       <ul className="divide-y divide-gray-100 rounded-lg border border-gray-100 bg-white">
-        {relevantNews.map((entry) => (
+        {updates.map((entry) => (
           <NewsCard
             key={entry.id ?? entry.title}
             asLink={true}
-            item={entry as NewsItem}
+            item={entry}
             variant="inline"
             showPastOpacity
           />

--- a/app/components/ShopNews.tsx
+++ b/app/components/ShopNews.tsx
@@ -5,8 +5,6 @@ import { NewsItem } from '@/types/news-types'
 
 type Props = { shop: TShop }
 
-// /api/updates already filters by shop_id and orders by post_date, so this
-// hands back exactly what ShopNews should render — no client-side re-derive.
 async function fetchShopUpdates(shopId: string, signal: AbortSignal) {
   const qs = new URLSearchParams({ shop_id: shopId })
   const res = await fetch(`/api/updates?${qs.toString()}`, { signal })
@@ -19,9 +17,6 @@ export const ShopNews = ({ shop }: Props) => {
   const shopId = shop.properties.uuid
 
   useEffect(() => {
-    // Clear the previous shop's list before fetching the new one, so a
-    // switch between shops can't leave shop A's news rendered under shop B's
-    // header — whether B has no updates yet, or its fetch fails outright.
     setUpdates([])
     if (!shopId) return
 
@@ -39,7 +34,6 @@ export const ShopNews = ({ shop }: Props) => {
     return () => controller.abort()
   }, [shopId])
 
-  // Nothing to show? render nothing.
   if (!updates.length) return null
 
   return (

--- a/tests/unit/ShopNews.test.tsx
+++ b/tests/unit/ShopNews.test.tsx
@@ -1,0 +1,118 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { ShopNews } from '@/app/components/ShopNews'
+import type { TShop } from '@/types/shop-types'
+import type { NewsItem } from '@/types/news-types'
+
+vi.mock('@/app/components/NewsCard', () => ({
+  NewsCard: ({ item }: { item: NewsItem }) => <div data-testid="news-item">{item.title}</div>,
+}))
+
+const shop: TShop = {
+  type: 'Feature',
+  properties: {
+    company: null,
+    name: 'Commonplace Coffee',
+    neighborhood: 'Bloomfield',
+    address: '123 Main St',
+    website: 'https://example.com',
+    uuid: 'shop-uuid-1',
+  },
+  geometry: { type: 'Point', coordinates: [-79.925, 40.4363] },
+}
+
+const otherShop: TShop = { ...shop, properties: { ...shop.properties, uuid: 'shop-uuid-2' } }
+
+describe('ShopNews', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn()
+  })
+
+  test('queries /api/updates scoped to this shop', async () => {
+    ;(fetch as any).mockResolvedValueOnce({ ok: true, json: async () => [] })
+
+    render(<ShopNews shop={shop} />)
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/updates?shop_id=shop-uuid-1', expect.objectContaining({ signal: expect.anything() }))
+    })
+  })
+
+  test('aborts the in-flight request when the shop changes before it resolves', async () => {
+    let capturedSignal: AbortSignal | undefined
+    ;(fetch as any).mockImplementationOnce((_url: string, opts: RequestInit) => {
+      capturedSignal = opts.signal as AbortSignal
+      return new Promise(() => {}) // never resolves, standing in for a slow request
+    })
+
+    const { rerender } = render(<ShopNews shop={shop} />)
+    await waitFor(() => expect(capturedSignal).toBeDefined())
+
+    ;(fetch as any).mockResolvedValueOnce({ ok: true, json: async () => [] })
+    rerender(<ShopNews shop={otherShop} />)
+
+    expect(capturedSignal?.aborted).toBe(true)
+  })
+
+  test('clears the previous shop\'s updates immediately on switch, before the new fetch settles', async () => {
+    const shopAUpdates: NewsItem[] = [{ id: '1', title: 'Shop A update' }]
+    ;(fetch as any).mockResolvedValueOnce({ ok: true, json: async () => shopAUpdates })
+
+    const { rerender } = render(<ShopNews shop={shop} />)
+    await waitFor(() => expect(screen.getByText('Shop A update')).toBeInTheDocument())
+
+    // Shop B's fetch never settles in this test — the previous shop's list
+    // must already be gone rather than lingering under shop B's panel.
+    ;(fetch as any).mockImplementationOnce(() => new Promise(() => {}))
+    rerender(<ShopNews shop={otherShop} />)
+
+    expect(screen.queryByText('Shop A update')).not.toBeInTheDocument()
+  })
+
+  test('ignores a stale response that resolves after the shop already changed', async () => {
+    // abort() can't un-settle a request that already resolved at the network
+    // layer — this mock ignores its signal entirely to simulate exactly that,
+    // so the fix must be the `signal.aborted` check, not the abort call itself.
+    let resolveShopA: (value: unknown) => void = () => {}
+    ;(fetch as any).mockImplementationOnce(
+      () => new Promise(resolve => { resolveShopA = resolve }),
+    )
+
+    const { rerender } = render(<ShopNews shop={shop} />)
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+
+    ;(fetch as any).mockResolvedValueOnce({ ok: true, json: async () => [] })
+    rerender(<ShopNews shop={otherShop} />)
+
+    resolveShopA({ ok: true, json: async () => [{ id: '1', title: 'Shop A update' }] })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(screen.queryByText('Shop A update')).not.toBeInTheDocument()
+  })
+
+  test('renders nothing when the shop has no updates', async () => {
+    ;(fetch as any).mockResolvedValueOnce({ ok: true, json: async () => [] })
+
+    const { container } = render(<ShopNews shop={shop} />)
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  // The API already filters by shop_id and orders by post_date, so this locks
+  // in that ShopNews renders exactly what it's given, in that order, with no
+  // client-side re-filter/re-sort.
+  test('renders the server-provided updates in the order returned', async () => {
+    const updates: NewsItem[] = [
+      { id: '1', title: 'Newest update' },
+      { id: '2', title: 'Older update' },
+    ]
+    ;(fetch as any).mockResolvedValueOnce({ ok: true, json: async () => updates })
+
+    render(<ShopNews shop={shop} />)
+
+    await waitFor(() => expect(screen.getByText('Newest update')).toBeInTheDocument())
+    const rendered = screen.getAllByTestId('news-item').map(el => el.textContent)
+    expect(rendered).toEqual(['Newest update', 'Older update'])
+  })
+})

--- a/tests/unit/ShopNews.test.tsx
+++ b/tests/unit/ShopNews.test.tsx
@@ -61,8 +61,6 @@ describe('ShopNews', () => {
     const { rerender } = render(<ShopNews shop={shop} />)
     await waitFor(() => expect(screen.getByText('Shop A update')).toBeInTheDocument())
 
-    // Shop B's fetch never settles in this test — the previous shop's list
-    // must already be gone rather than lingering under shop B's panel.
     ;(fetch as any).mockImplementationOnce(() => new Promise(() => {}))
     rerender(<ShopNews shop={otherShop} />)
 
@@ -70,9 +68,6 @@ describe('ShopNews', () => {
   })
 
   test('ignores a stale response that resolves after the shop already changed', async () => {
-    // abort() can't un-settle a request that already resolved at the network
-    // layer — this mock ignores its signal entirely to simulate exactly that,
-    // so the fix must be the `signal.aborted` check, not the abort call itself.
     let resolveShopA: (value: unknown) => void = () => {}
     ;(fetch as any).mockImplementationOnce(
       () => new Promise(resolve => { resolveShopA = resolve }),
@@ -99,9 +94,6 @@ describe('ShopNews', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  // The API already filters by shop_id and orders by post_date, so this locks
-  // in that ShopNews renders exactly what it's given, in that order, with no
-  // client-side re-filter/re-sort.
   test('renders the server-provided updates in the order returned', async () => {
     const updates: NewsItem[] = [
       { id: '1', title: 'Newest update' },


### PR DESCRIPTION
## What do these changes accomplish?

`ShopNews.tsx` now uses the shared `NewsItem` type directly and deletes the client-side filter/sort that was redundantly redoing work `/api/updates` already does server-side.

## Why?

`ShopNews` declared its own `UpdateEntry` type with `postDate`/`eventDate`/`shopId` camelCase fields that neither the API nor the real `NewsItem` type ever produce — pure dead code — and then re-filtered by shop and re-sorted by date on every render, even though the API call it makes is already scoped by `shop_id` and already ordered by `post_date`.

