### PR TITLE
refactor(og-images): extract shared ogTheme.ts for brand colors and logo loading

### DIFF
--- a/app/(map)/shops/[slug]/opengraph-image.tsx
+++ b/app/(map)/shops/[slug]/opengraph-image.tsx
@@ -1,39 +1,21 @@
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { ImageResponse } from 'next/og'
 import { getShopForSeo } from '@/app/utils/seo'
+import { OG_COLORS, OG_IMAGE_SIZE, OG_CONTENT_TYPE, getOgLogoSrc, OG_NO_PHOTO_BACKGROUND } from '@/app/utils/ogTheme'
 
-export const size = { width: 1200, height: 630 }
-export const contentType = 'image/png'
+export const size = OG_IMAGE_SIZE
+export const contentType = OG_CONTENT_TYPE
 export const alt = 'pgh.coffee shop'
-
-const logoSrc = `data:image/png;base64,${readFileSync(
-  join(process.cwd(), 'public', 'logo_with_no_text_transparent_108.png'),
-).toString('base64')}`
-
-const yellow = '#fde047' // matches nav bg-yellow-300
-const gray900 = '#111827'
-const gray500 = '#6b7280'
-
-// Cream + dot grid stands in for the photo when a shop has none, matching the
-// passport OG image. Satori won't tile a radial-gradient, hence the SVG tile.
-const noPhotoBackground = {
-  backgroundColor: '#fffbeb',
-  backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(
-    `<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32'><circle cx='4' cy='4' r='2.5' fill='#e0ddd2'/></svg>`,
-  )}")`,
-  backgroundSize: '32px 32px',
-  backgroundRepeat: 'repeat',
-}
 
 /* eslint-disable @next/next/no-img-element */
 
 function Background({ photo }: { photo: string | null }) {
-  if (!photo) return <div style={{ ...noPhotoBackground, display: 'flex', width: '100%', height: '100%' }} />
+  if (!photo) return <div style={{ ...OG_NO_PHOTO_BACKGROUND, display: 'flex', width: '100%', height: '100%' }} />
   return <img src={photo} width={size.width} height={size.height} alt="" style={{ objectFit: 'cover' }} />
 }
 
 function Header() {
+  const logoSrc = getOgLogoSrc()
+
   return (
     <div
       style={{
@@ -44,11 +26,11 @@ function Header() {
         display: 'flex',
         alignItems: 'center',
         gap: 14,
-        background: yellow,
+        background: OG_COLORS.yellow,
         padding: '20px 56px',
         fontSize: 44,
         fontWeight: 700,
-        color: gray900,
+        color: OG_COLORS.gray900,
       }}
     >
       <img src={logoSrc} width={44} height={44} alt="" />
@@ -70,11 +52,11 @@ function InfoCard({ title, subtitle }: { title: string; subtitle: string }) {
         gap: 8,
         background: 'white',
         padding: '28px 40px',
-        borderLeft: `12px solid ${yellow}`,
+        borderLeft: `12px solid ${OG_COLORS.yellow}`,
       }}
     >
-      <div style={{ fontSize: 58, fontWeight: 700, color: gray900, lineHeight: 1.1 }}>{title}</div>
-      <div style={{ fontSize: 30, color: gray500 }}>{subtitle}</div>
+      <div style={{ fontSize: 58, fontWeight: 700, color: OG_COLORS.gray900, lineHeight: 1.1 }}>{title}</div>
+      <div style={{ fontSize: 30, color: OG_COLORS.gray500 }}>{subtitle}</div>
     </div>
   )
 }

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,20 +1,12 @@
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { ImageResponse } from 'next/og'
+import { OG_COLORS, OG_IMAGE_SIZE, OG_CONTENT_TYPE, getOgLogoSrc } from '@/app/utils/ogTheme'
 
-export const size = { width: 1200, height: 630 }
-export const contentType = 'image/png'
+export const size = OG_IMAGE_SIZE
+export const contentType = OG_CONTENT_TYPE
 export const alt = 'pgh.coffee — a guide to independent coffee in Pittsburgh, PA'
 
-const logoSrc = `data:image/png;base64,${readFileSync(
-  join(process.cwd(), 'public', 'logo_with_no_text_transparent_108.png'),
-).toString('base64')}`
-
-const yellow = '#fde047' // matches nav bg-yellow-300
-const gray900 = '#111827'
-const gray500 = '#6b7280'
-
 export default function Image() {
+  const logoSrc = getOgLogoSrc()
   return new ImageResponse(
     (
       <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', background: 'white' }}>
@@ -23,11 +15,11 @@ export default function Image() {
             display: 'flex',
             alignItems: 'center',
             gap: 16,
-            background: yellow,
+            background: OG_COLORS.yellow,
             padding: '24px 64px',
             fontSize: 40,
             fontWeight: 700,
-            color: gray900,
+            color: OG_COLORS.gray900,
           }}
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -44,13 +36,13 @@ export default function Image() {
             gap: 32,
           }}
         >
-          <div style={{ fontSize: 64, fontWeight: 700, color: gray900 }}>
+          <div style={{ fontSize: 64, fontWeight: 700, color: OG_COLORS.gray900 }}>
             Pittsburgh&apos;s independent coffee map
           </div>
-          <div style={{ fontSize: 34, color: gray500 }}>
+          <div style={{ fontSize: 34, color: OG_COLORS.gray500 }}>
             Explore shops across the city&apos;s neighborhoods and track your visits.
           </div>
-          <div style={{ fontSize: 30, fontWeight: 600, color: gray900 }}>Find your next favorite shop &rarr;</div>
+          <div style={{ fontSize: 30, fontWeight: 600, color: OG_COLORS.gray900 }}>Find your next favorite shop &rarr;</div>
         </div>
       </div>
     ),

--- a/app/u/[id]/opengraph-image.tsx
+++ b/app/u/[id]/opengraph-image.tsx
@@ -1,42 +1,31 @@
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { ImageResponse } from 'next/og'
 import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { getPublicProfile } from '@/app/utils/profiles'
 import { computeStats } from '@/app/utils/visitStats'
+import { OG_COLORS, OG_IMAGE_SIZE, OG_CONTENT_TYPE, getOgLogoSrc, OG_NO_PHOTO_BACKGROUND, getOgWatermarkSrc } from '@/app/utils/ogTheme'
 
-export const size = { width: 1200, height: 630 }
-export const contentType = 'image/png'
+export const size = OG_IMAGE_SIZE
+export const contentType = OG_CONTENT_TYPE
 export const alt = 'pgh.coffee passport'
 
 const supabaseUrl = process.env.SUPABASE_URL as string
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
 const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
-const logoSrc = `data:image/png;base64,${readFileSync(
-  join(process.cwd(), 'public', 'logo_with_no_text_transparent_108.png'),
-).toString('base64')}`
-
-// Full-size (2000px) logo so the oversized watermark stays crisp.
-const watermarkSrc = `data:image/png;base64,${readFileSync(
-  join(process.cwd(), 'public', 'logo_with_no_text_transparent.png'),
-).toString('base64')}`
-
-const yellow = '#fde047' // matches nav bg-yellow-300
-const gray900 = '#111827'
-const gray500 = '#6b7280'
-
 function Stat({ value, label, valueSize = 64 }: { value: string; label: string; valueSize?: number }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'flex-end' }}>
-      <div style={{ fontSize: valueSize, fontWeight: 700, color: gray900 }}>{value}</div>
-      <div style={{ fontSize: 28, color: gray500 }}>{label}</div>
+      <div style={{ fontSize: valueSize, fontWeight: 700, color: OG_COLORS.gray900 }}>{value}</div>
+      <div style={{ fontSize: 28, color: OG_COLORS.gray500 }}>{label}</div>
     </div>
   )
 }
 
 function Card({ children }: { children: React.ReactNode }) {
+  const logoSrc = getOgLogoSrc()
+  const watermarkSrc = getOgWatermarkSrc()
+
   return (
     <div
       style={{
@@ -44,14 +33,7 @@ function Card({ children }: { children: React.ReactNode }) {
         flexDirection: 'column',
         width: '100%',
         height: '100%',
-        // Cream + dot grid: passport-page texture instead of stark white.
-        // SVG tile because satori doesn't tile radial-gradient patterns.
-        backgroundColor: '#fffbeb',
-        backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(
-          `<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32'><circle cx='4' cy='4' r='2.5' fill='#e0ddd2'/></svg>`,
-        )}")`,
-        backgroundSize: '32px 32px',
-        backgroundRepeat: 'repeat',
+        ...OG_NO_PHOTO_BACKGROUND,
       }}
     >
       {/* Faint keystone watermark; header and stats draw over it. */}
@@ -68,11 +50,11 @@ function Card({ children }: { children: React.ReactNode }) {
           display: 'flex',
           alignItems: 'center',
           gap: 16,
-          background: yellow,
+          background: OG_COLORS.yellow,
           padding: '24px 64px',
           fontSize: '4.5rem',
           fontWeight: 700,
-          color: gray900,
+          color: OG_COLORS.gray900,
         }}
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -113,7 +95,7 @@ export default async function Image({ params }: { params: Promise<{ id: string }
     return new ImageResponse(
       (
         <Card>
-          <div style={{ fontSize: 56, fontWeight: 700, color: gray900 }}>
+          <div style={{ fontSize: 56, fontWeight: 700, color: OG_COLORS.gray900 }}>
             Pittsburgh&apos;s independent coffee map
           </div>
         </Card>
@@ -131,8 +113,8 @@ export default async function Image({ params }: { params: Promise<{ id: string }
     (
       <Card>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          <div style={{ fontSize: 72, fontWeight: 700, color: gray900 }}>{name}</div>
-          <div style={{ fontSize: 32, color: gray500 }}>Coffee passport</div>
+          <div style={{ fontSize: 72, fontWeight: 700, color: OG_COLORS.gray900 }}>{name}</div>
+          <div style={{ fontSize: 32, color: OG_COLORS.gray500 }}>Coffee passport</div>
         </div>
         <div style={{ display: 'flex', gap: 80 }}>
           <Stat value={`${stats.visited} of ${stats.total}`} label="shops visited" />
@@ -141,7 +123,7 @@ export default async function Image({ params }: { params: Promise<{ id: string }
             <Stat value={stats.topNeighborhood} label="top neighborhood" valueSize={40} />
           )}
         </div>
-        <div style={{ fontSize: 30, fontWeight: 600, color: gray900 }}>
+        <div style={{ fontSize: 30, fontWeight: 600, color: OG_COLORS.gray900 }}>
           Track your own coffee passport at pgh.coffee &rarr;
         </div>
       </Card>

--- a/app/utils/ogTheme.ts
+++ b/app/utils/ogTheme.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const OG_COLORS = {
+  yellow: '#fde047', // matches nav bg-yellow-300
+  gray900: '#111827',
+  gray500: '#6b7280',
+} as const
+
+export const OG_IMAGE_SIZE = { width: 1200, height: 630 } as const
+export const OG_CONTENT_TYPE = 'image/png'
+
+const readPublicImageAsDataUri = (filename: string) =>
+  `data:image/png;base64,${readFileSync(join(process.cwd(), 'public', filename)).toString('base64')}`
+
+// Not React's cache(): that's scoped per-request, which would re-read the
+// asset on every request instead of reusing a warm instance's first read.
+function once(fn: () => string) {
+  let cached: string | undefined
+  return () => (cached ??= fn())
+}
+
+// Both logo variants are lazy: a route only pays to read and base64-encode
+// whichever asset it actually renders, and only on the first call.
+export const getOgLogoSrc = once(() => readPublicImageAsDataUri('logo_with_no_text_transparent_108.png'))
+
+// Full-size (2000px) variant, for an oversized watermark that stays crisp.
+export const getOgWatermarkSrc = once(() => readPublicImageAsDataUri('logo_with_no_text_transparent.png'))
+
+// Cream + dot grid: passport-page texture instead of stark white, shared by
+// every OG image that has no photo to show so they read as one family. SVG
+// tile because satori doesn't tile radial-gradient patterns.
+export const OG_NO_PHOTO_BACKGROUND = {
+  backgroundColor: '#fffbeb',
+  backgroundImage: `url("data:image/svg+xml,${encodeURIComponent(
+    `<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32'><circle cx='4' cy='4' r='2.5' fill='#e0ddd2'/></svg>`,
+  )}")`,
+  backgroundSize: '32px 32px',
+  backgroundRepeat: 'repeat',
+}

--- a/tests/helpers/ogImage.ts
+++ b/tests/helpers/ogImage.ts
@@ -1,0 +1,12 @@
+import { expect } from 'vitest'
+
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47]
+
+// ImageResponse streams; a layout satori can't render still returns a 200
+// whose stream throws on read, so the body has to be consumed to catch that.
+const renderedBytes = async (response: Response) => new Uint8Array(await response.arrayBuffer())
+
+export const expectPng = async (response: Response) => {
+  const bytes = await renderedBytes(response)
+  expect(Array.from(bytes.slice(0, 4))).toEqual(PNG_MAGIC)
+}

--- a/tests/unit/homeOgImage.test.tsx
+++ b/tests/unit/homeOgImage.test.tsx
@@ -1,0 +1,9 @@
+import { describe, test } from 'vitest'
+import Image from '@/app/opengraph-image'
+import { expectPng } from '../helpers/ogImage'
+
+describe('home opengraph-image', () => {
+  test('renders a PNG', async () => {
+    await expectPng(await Image())
+  })
+})

--- a/tests/unit/ogTheme.test.ts
+++ b/tests/unit/ogTheme.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({ readFileSync: vi.fn(() => Buffer.from('fake-png-bytes')) }))
+vi.mock('node:fs', () => ({ readFileSync: h.readFileSync, default: { readFileSync: h.readFileSync } }))
+
+describe('ogTheme asset loaders', () => {
+  test('reads the logo from disk at most once per process', async () => {
+    const { getOgLogoSrc } = await import('@/app/utils/ogTheme')
+
+    const first = getOgLogoSrc()
+    const second = getOgLogoSrc()
+
+    expect(second).toBe(first)
+    expect(h.readFileSync).toHaveBeenCalledTimes(1)
+  })
+
+  test('reads the watermark from disk at most once per process, independently of the logo', async () => {
+    const { getOgLogoSrc, getOgWatermarkSrc } = await import('@/app/utils/ogTheme')
+
+    getOgLogoSrc()
+    const first = getOgWatermarkSrc()
+    const second = getOgWatermarkSrc()
+
+    expect(second).toBe(first)
+    // One read for the logo (previous test) + one for the watermark, not one
+    // shared cache between the two independent once() instances.
+    expect(h.readFileSync).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/unit/ogTheme.test.ts
+++ b/tests/unit/ogTheme.test.ts
@@ -22,8 +22,6 @@ describe('ogTheme asset loaders', () => {
     const second = getOgWatermarkSrc()
 
     expect(second).toBe(first)
-    // One read for the logo (previous test) + one for the watermark, not one
-    // shared cache between the two independent once() instances.
     expect(h.readFileSync).toHaveBeenCalledTimes(2)
   })
 })

--- a/tests/unit/profileOgImage.test.tsx
+++ b/tests/unit/profileOgImage.test.tsx
@@ -1,0 +1,33 @@
+import { describe, test, vi } from 'vitest'
+import type { Visit } from '@/app/utils/visitStats'
+import type { DbShop } from '@/types/shop-types'
+import { expectPng } from '../helpers/ogImage'
+
+vi.mock('@/app/utils/profiles', () => ({ getPublicProfile: vi.fn() }))
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({ select: () => Promise.resolve({ data: [{ neighborhood: 'Bloomfield' }], error: null }) }),
+  }),
+}))
+
+import Image from '@/app/u/[id]/opengraph-image'
+import { getPublicProfile } from '@/app/utils/profiles'
+
+const mockProfile = vi.mocked(getPublicProfile)
+
+const params = Promise.resolve({ id: 'any-id' })
+
+describe('profile opengraph-image', () => {
+  test('renders a PNG for a known public profile', async () => {
+    const visit: Visit = { id: 'v1', created_at: '2024-01-01', shop: { neighborhood: 'Bloomfield' } as DbShop }
+    mockProfile.mockResolvedValue({ displayName: 'Coffee Lover', avatarUrl: null, visits: [visit] })
+
+    await expectPng(await Image({ params }))
+  })
+
+  test('renders a PNG when the id matches no public profile', async () => {
+    mockProfile.mockResolvedValue(null)
+
+    await expectPng(await Image({ params }))
+  })
+})

--- a/tests/unit/shopOgImage.test.tsx
+++ b/tests/unit/shopOgImage.test.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, test, vi } from 'vitest'
+import { describe, test, vi } from 'vitest'
 import type { DbShop } from '@/types/shop-types'
+import { expectPng } from '../helpers/ogImage'
 
 vi.mock('@/app/utils/seo', () => ({ getShopForSeo: vi.fn() }))
 
@@ -13,22 +14,16 @@ const params = Promise.resolve({ slug: 'any-slug-00000000' })
 // Every shop currently has a photo, so the photo-less and missing-shop branches
 // can't be reached with real data — but satori throws on a malformed layout, and
 // a throwing OG route is a 500 the crawler caches.
-// The body has to be consumed: ImageResponse streams, so a layout satori can't
-// render still returns a 200 whose stream throws on read.
-const renderedBytes = async () => new Uint8Array(await (await Image({ params })).arrayBuffer())
-
-const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47]
-
 describe('shop opengraph-image', () => {
   test('renders a PNG for a shop with no photo', async () => {
     mockShop.mockResolvedValue({ name: '61B Cafe', address: '1108 S Braddock Ave', photo: null } as DbShop)
 
-    expect([...(await renderedBytes()).slice(0, 4)]).toEqual(PNG_MAGIC)
+    await expectPng(await Image({ params }))
   })
 
   test('renders a PNG when the slug matches no shop', async () => {
     mockShop.mockResolvedValue(null)
 
-    expect([...(await renderedBytes()).slice(0, 4)]).toEqual(PNG_MAGIC)
+    await expectPng(await Image({ params }))
   })
 })


### PR DESCRIPTION
## What do these changes accomplish?

Extracts a shared `app/utils/ogTheme.ts` (brand colors, image size/content-type, logo/watermark loaders, no-photo background) and updates the three `opengraph-image.tsx` files that were each redefining the same constants to import from it instead.

## Why?

Three of the six `opengraph-image.tsx` files each redefined the same brand colors and logo-loading code.