### PR TITLE
fix(scripts): read hours-schema.sql at runtime instead of hand-copying its DDL

### DIFF
--- a/scripts/crawl-hours.mjs
+++ b/scripts/crawl-hours.mjs
@@ -28,13 +28,6 @@ const SUPABASE_URL = env.SUPABASE_URL || env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_ANON = env.SUPABASE_ANON_KEY || env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 if (!KEY) throw new Error("GOOGLE_MAPS_API_KEY missing from .env.local");
 
-// Read straight from the migration rather than hand-copying its CREATE TABLE
-// statements here, so the two can't silently drift out of sync. Only the DDL
-// is embedded — the migration file's own prose header describes itself (e.g.
-// "see the generated hours-backfill.sql"), which reads as self-referential
-// nonsense once copied into that very generated file. Checked after the env
-// vars above, so a missing API key still surfaces its own actionable error
-// first rather than being preempted by this newer filesystem dependency.
 const MIGRATION = stripLeadingSqlComment(
   readFileSync(`${ROOT}/migrations/hours-schema.sql`, "utf8")
 );

--- a/scripts/crawl-hours.mjs
+++ b/scripts/crawl-hours.mjs
@@ -6,6 +6,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve as resolvePath } from "node:path";
+import { stripLeadingSqlComment } from "./lib/sql.mjs";
 
 // Repo root, derived from this script's location (scripts/ -> repo root).
 const ROOT = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
@@ -26,6 +27,17 @@ const KEY = env.GOOGLE_MAPS_API_KEY;
 const SUPABASE_URL = env.SUPABASE_URL || env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_ANON = env.SUPABASE_ANON_KEY || env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 if (!KEY) throw new Error("GOOGLE_MAPS_API_KEY missing from .env.local");
+
+// Read straight from the migration rather than hand-copying its CREATE TABLE
+// statements here, so the two can't silently drift out of sync. Only the DDL
+// is embedded — the migration file's own prose header describes itself (e.g.
+// "see the generated hours-backfill.sql"), which reads as self-referential
+// nonsense once copied into that very generated file. Checked after the env
+// vars above, so a missing API key still surfaces its own actionable error
+// first rather than being preempted by this newer filesystem dependency.
+const MIGRATION = stripLeadingSqlComment(
+  readFileSync(`${ROOT}/migrations/hours-schema.sql`, "utf8")
+);
 
 // ---- helpers ---------------------------------------------------------------
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -330,35 +342,6 @@ function metaUpsert(uuid, status, placeId, dist) {
     `WHERE shop_hours_meta.source='google_places';`
   );
 }
-
-const MIGRATION = `
-CREATE TABLE IF NOT EXISTS shop_hours (
-  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  shop_uuid      uuid NOT NULL REFERENCES shops(uuid) ON DELETE CASCADE,
-  day_of_week    smallint NOT NULL CHECK (day_of_week BETWEEN 0 AND 6),
-  opens_at       time NOT NULL,
-  closes_at      time NOT NULL,
-  spans_midnight boolean NOT NULL DEFAULT false,
-  UNIQUE (shop_uuid, day_of_week, opens_at)
-);
-CREATE INDEX IF NOT EXISTS idx_shop_hours_shop ON shop_hours(shop_uuid);
-ALTER TABLE shop_hours ENABLE ROW LEVEL SECURITY;
-DO $$ BEGIN
-  CREATE POLICY "Enable read access for all users" ON shop_hours FOR SELECT TO public USING (true);
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-
-CREATE TABLE IF NOT EXISTS shop_hours_meta (
-  shop_uuid        uuid PRIMARY KEY REFERENCES shops(uuid) ON DELETE CASCADE,
-  source           text NOT NULL DEFAULT 'google_places'
-                     CHECK (source IN ('google_places','manual','shop_submitted')),
-  status           text NOT NULL
-                     CHECK (status IN ('ok','no_hours','not_found','low_confidence','not_operational','error')),
-  google_place_id  text,
-  match_distance_m double precision,
-  fetched_at       timestamptz NOT NULL DEFAULT now()
-);
-ALTER TABLE shop_hours_meta ENABLE ROW LEVEL SECURITY;
--- No policies: admin/service-role only (not readable/writable by anon).`;
 
 const VERIFICATION = `-- ============================================================================
 -- VERIFICATION

--- a/scripts/lib/sql.mjs
+++ b/scripts/lib/sql.mjs
@@ -1,12 +1,8 @@
-// Pulled out of crawl-hours.mjs so it's testable without pulling in that
-// script's env/network side effects.
 export function stripLeadingSqlComment(sql) {
   const lines = sql.split("\n");
   let i = 0;
   while (i < lines.length && (lines[i].trim() === "" || lines[i].trim().startsWith("--"))) i++;
   const ddl = lines.slice(i).join("\n").trim();
-  // A schema file that's all comments (or empty) means something's wrong with
-  // it — better to fail loudly here than silently embed no DDL at all.
   if (!ddl) throw new Error("No DDL found after stripping the leading comment header");
   return ddl;
 }

--- a/scripts/lib/sql.mjs
+++ b/scripts/lib/sql.mjs
@@ -1,0 +1,12 @@
+// Pulled out of crawl-hours.mjs so it's testable without pulling in that
+// script's env/network side effects.
+export function stripLeadingSqlComment(sql) {
+  const lines = sql.split("\n");
+  let i = 0;
+  while (i < lines.length && (lines[i].trim() === "" || lines[i].trim().startsWith("--"))) i++;
+  const ddl = lines.slice(i).join("\n").trim();
+  // A schema file that's all comments (or empty) means something's wrong with
+  // it — better to fail loudly here than silently embed no DDL at all.
+  if (!ddl) throw new Error("No DDL found after stripping the leading comment header");
+  return ddl;
+}

--- a/tests/unit/crawlHoursSql.test.ts
+++ b/tests/unit/crawlHoursSql.test.ts
@@ -4,9 +4,6 @@ import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { stripLeadingSqlComment } from '@/scripts/lib/sql.mjs'
 
-// Anchored to this test file's location, not process.cwd(), so it resolves
-// the same regardless of which directory vitest is invoked from — matching
-// how crawl-hours.mjs itself resolves ROOT.
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
 describe('stripLeadingSqlComment', () => {
@@ -36,10 +33,6 @@ describe('stripLeadingSqlComment', () => {
     expect(() => stripLeadingSqlComment('-- just a comment\n-- another line')).toThrow()
   })
 
-  // Regression for S20: crawl-hours.mjs embeds this file's DDL directly into
-  // a generated review file, so the schema's own "see the generated file"
-  // header must not leak into that generated file's contents, and nothing in
-  // the DDL itself should get dropped along with the header.
   test('strips the real hours-schema.sql header down to just its CREATE TABLE statements', () => {
     const schema = readFileSync(join(REPO_ROOT, 'migrations', 'hours-schema.sql'), 'utf8')
 

--- a/tests/unit/crawlHoursSql.test.ts
+++ b/tests/unit/crawlHoursSql.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { stripLeadingSqlComment } from '@/scripts/lib/sql.mjs'
+
+// Anchored to this test file's location, not process.cwd(), so it resolves
+// the same regardless of which directory vitest is invoked from — matching
+// how crawl-hours.mjs itself resolves ROOT.
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+describe('stripLeadingSqlComment', () => {
+  test('drops a leading prose header, keeping the DDL and its trailing inline comment', () => {
+    const input = [
+      '-- Schema for the shop hours-of-operation feature.',
+      '--',
+      '-- Apply by hand. See the generated hours-backfill.sql for data.',
+      '',
+      "CREATE TABLE IF NOT EXISTS shop_hours (id uuid PRIMARY KEY);",
+      '-- No policies: admin/service-role only.',
+    ].join('\n')
+
+    expect(stripLeadingSqlComment(input)).toBe(
+      [
+        'CREATE TABLE IF NOT EXISTS shop_hours (id uuid PRIMARY KEY);',
+        '-- No policies: admin/service-role only.',
+      ].join('\n'),
+    )
+  })
+
+  test('returns the input unchanged when there is no leading comment', () => {
+    expect(stripLeadingSqlComment('CREATE TABLE foo (id uuid);')).toBe('CREATE TABLE foo (id uuid);')
+  })
+
+  test('throws rather than silently returning no DDL when the input is all comments', () => {
+    expect(() => stripLeadingSqlComment('-- just a comment\n-- another line')).toThrow()
+  })
+
+  // Regression for S20: crawl-hours.mjs embeds this file's DDL directly into
+  // a generated review file, so the schema's own "see the generated file"
+  // header must not leak into that generated file's contents, and nothing in
+  // the DDL itself should get dropped along with the header.
+  test('strips the real hours-schema.sql header down to just its CREATE TABLE statements', () => {
+    const schema = readFileSync(join(REPO_ROOT, 'migrations', 'hours-schema.sql'), 'utf8')
+
+    const result = stripLeadingSqlComment(schema)
+
+    expect(result.startsWith('CREATE TABLE IF NOT EXISTS shop_hours (')).toBe(true)
+    expect(result).not.toContain('hours-backfill.sql')
+    expect(result).toContain('CREATE TABLE IF NOT EXISTS shop_hours_meta (')
+    expect(result.trimEnd().endsWith("-- No policies: admin/service-role only (not readable/writable by anon).")).toBe(true)
+  })
+})


### PR DESCRIPTION
## What do these changes accomplish?

`scripts/crawl-hours.mjs` now reads `migrations/hours-schema.sql` at runtime instead of maintaining a hand-copied duplicate of its `CREATE TABLE` statements.

## Why?

The script embedded a byte-for-byte copy of the migration's DDL in a JS template literal — a second copy of the schema that could silently drift from the real migration file with no error or warning.
