### PR TITLE
Record build and OG-verification gotchas in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,13 @@ Coffee shops must meet these criteria (enforced in submission form):
 
 User preference for distance units (miles/kilometers) is stored in localStorage with key `distanceUnits`. Default is miles.
 
+## Build & verification gotchas
+
+- **Don't `npm run build` while `npm run dev` is running.** The build overwrites `.next` under the dev server, which then 500s on every route. The app is fine; only the dev process is poisoned. Stop dev first, or `rm -rf .next` and restart it.
+- **The first build after `rm -rf .next` can die** with `PageNotFoundError: Cannot find module for page: /_document`. Re-running the identical command succeeds. The partial `.nft.json` files it leaves behind are misleading if you're inspecting them.
+- **`og:image` is an absolute `https://pgh.coffee/...` URL in a production build** (relative in dev), so `curl`ing it against a local `next start` silently fetches the deployed site. Swap the origin for localhost before fetching.
+- **Dynamic-segment OG routes aren't served at their source path.** `/shops/<slug>/opengraph-image` 404s; the real path is hashed (`/opengraph-image-11ib4g?<hash>`). Scrape it out of the page's `og:image` meta tag. Static ones like `/opengraph-image` work as written.
+
 ## Working agreement
 
 - Before saying a change is done, run `npm run lint` and `npm test` and report the actual result. Don't claim it works without exercising it.


### PR DESCRIPTION
## What do these changes accomplish?

Documents four local-build and OG-image verification traps in CLAUDE.md so they stop costing a debugging detour every time someone hits them.

## Why?

Each of these has already burned real time: running a build while the dev server is up makes the whole app 500 (but only the dev process is broken), the first build after wiping `.next` fails once and then succeeds on an identical re-run, and verifying an OG image locally silently fetches production because `og:image` is absolute in a production build and dynamic OG routes live at a hashed path. None of it is discoverable from the code — CLAUDE.md is the file that's read before the next attempt.
