### PR TITLE
Point the OG asset loader at the file-tracing config it depends on

### DIFF
--- a/app/utils/ogTheme.ts
+++ b/app/utils/ogTheme.ts
@@ -10,6 +10,10 @@ export const OG_COLORS = {
 export const OG_IMAGE_SIZE = { width: 1200, height: 630 } as const
 export const OG_CONTENT_TYPE = 'image/png'
 
+// Anything read this way must also be listed under `outputFileTracingIncludes`
+// in next.config.js, per dynamic OG route that renders it — tracing doesn't
+// follow readFileSync(process.cwd(), …) into the bundle, and the miss only
+// shows up as a 500 in production.
 const readPublicImageAsDataUri = (filename: string) =>
   `data:image/png;base64,${readFileSync(join(process.cwd(), 'public', filename)).toString('base64')}`
 


### PR DESCRIPTION
## What do these changes accomplish?

Adds a comment where OG images read assets off disk, noting that each one must also be listed under `outputFileTracingIncludes` in `next.config.js`.

## Why?

Reading an asset off disk for an OG image works locally and fails in production unless the file is explicitly traced. `next.config.js` already documents the rule and already lists the logo PNGs, but nothing at the point of use pointed there — so adding a font or image costs several build cycles before the production-only 500 becomes explicable.

