### PR TITLE
Let pointer devices expand the bottom sheet past the middle detent

### DIFF
--- a/app/components/Panel.tsx
+++ b/app/components/Panel.tsx
@@ -98,6 +98,24 @@ export default function Panel(props: IProps) {
     }
   }, [isTouch, activeDetent, middleDetentIndex, lastDetentIndex])
 
+  // Pointer devices get the same middle -> full expansion as the touch gesture
+  // above. Without it the sheet is stuck at 60vh in a desktop browser, so a
+  // narrow-viewport check never reaches the state mobile users are actually in.
+  useEffect(() => {
+    if (isTouch) return
+    const el = contentRef.current
+    if (!el) return
+
+    const onWheel = (e: WheelEvent) => {
+      if (activeDetent !== middleDetentIndex || e.deltaY <= 0) return
+      e.preventDefault()
+      setActiveDetent(lastDetentIndex)
+    }
+
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [isTouch, activeDetent, middleDetentIndex, lastDetentIndex])
+
   if (largeViewport) {
     return (
       <div data-testid="shop-panel" className="relative z-10">
@@ -135,7 +153,7 @@ export default function Panel(props: IProps) {
               action="dismiss"
               className="block mx-auto focus:outline-none focus:ring-0 mt-2 mb-3 bg-gray-300"
             >
-              Drag to expand
+              Drag to dismiss
             </Sheet.Handle>
 
             <SearchBar />

--- a/tests/unit/ShopPanel.test.tsx
+++ b/tests/unit/ShopPanel.test.tsx
@@ -5,7 +5,13 @@ import { TShop } from '@/types/shop-types'
 // Mock the Silk components
 vi.mock('@silk-hq/components', () => ({
   Sheet: {
-    Root: ({ children, presented }: any) => presented ? <div data-testid="sheet-root">{children}</div> : null,
+    Root: ({ children, presented, activeDetent, onActiveDetentChange }: any) =>
+      presented ? (
+        <div data-testid="sheet-root" data-active-detent={activeDetent}>
+          <button data-testid="set-middle-detent" onClick={() => onActiveDetentChange(1)} />
+          {children}
+        </div>
+      ) : null,
     Portal: ({ children }: any) => <div data-testid="sheet-portal">{children}</div>,
     View: ({ children }: any) => <div data-testid="sheet-view">{children}</div>,
     Backdrop: () => <div data-testid="sheet-backdrop" />,
@@ -100,5 +106,24 @@ describe('Panel Component', () => {
     fireEvent.click(button)
 
     expect(mockHandlePanelContentClick).toHaveBeenCalledWith(mockShop)
+  })
+
+  // jsdom reports no touch support, so this exercises the pointer-device path.
+  it('expands from the middle detent to full when the content is scrolled down', () => {
+    render(<Panel {...defaultProps} />)
+    fireEvent.click(screen.getByTestId('set-middle-detent'))
+
+    fireEvent.wheel(screen.getByTestId('sheet-content'), { deltaY: 40 })
+
+    expect(screen.getByTestId('sheet-root')).toHaveAttribute('data-active-detent', '2')
+  })
+
+  it('stays at the middle detent when the content is scrolled up', () => {
+    render(<Panel {...defaultProps} />)
+    fireEvent.click(screen.getByTestId('set-middle-detent'))
+
+    fireEvent.wheel(screen.getByTestId('sheet-content'), { deltaY: -40 })
+
+    expect(screen.getByTestId('sheet-root')).toHaveAttribute('data-active-detent', '1')
   })
 })


### PR DESCRIPTION
## What do these changes accomplish?

Scrolling down inside the mobile bottom sheet now expands it from the 60vh detent to full on pointer devices, matching the existing touch gesture, and the drag handle no longer says "Drag to expand" when dragging it dismisses.

## Why?

The expand-to-full handler only listened for touch events. In a desktop browser at a narrow viewport — how the mobile layout actually gets checked — the sheet stayed at 60vh no matter how much you scrolled, and the handle's "Drag to expand" label led you to drag it, which closed the sheet instead. Anything that only happens in the expanded state was effectively unreachable outside a real phone.

## Screenshots

| Before | After |
|---|---|
| Sheet stuck at 60vh; handle reads "Drag to expand" but dismisses | Scroll expands to full; handle reads "Drag to dismiss" |