### PR TITLE
Emit an applyable compact form of the hours backfill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ next-env.d.ts
 # content under the Maps Platform terms; must not be committed (schema lives in
 # hours-schema.sql). Re-run the crawl to regenerate.
 migrations/hours-backfill.sql
+migrations/hours-backfill-compact.sql
 migrations/hours-backfill-results.json
 
 # Local Netlify folder

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,9 +29,14 @@ node scripts/crawl-hours.mjs
    - `migrations/hours-backfill.sql` — per-shop `DELETE`+`INSERT` blocks
      (idempotent), the schema (`CREATE TABLE IF NOT EXISTS`), verification
      queries, and a "NEEDS MANUAL REVIEW" list.
+   - `migrations/hours-backfill-compact.sql` — the same writes as **three**
+     statements instead of ~350, for applying through anything that can't
+     stream a file (the Supabase MCP, a SQL console). The `VALUES` lists can be
+     split at any comma to apply it in chunks. Review the file above, apply
+     this one.
    - `migrations/hours-backfill-results.json` — raw per-shop results.
 
-Both outputs are **gitignored**. Google Places hours are 30-day-max cached
+All three outputs are **gitignored**. Google Places hours are 30-day-max cached
 content under the Maps Platform terms and must not be committed; re-run this
 script to regenerate them. The committed schema lives in
 `migrations/hours-schema.sql`.

--- a/scripts/crawl-hours.mjs
+++ b/scripts/crawl-hours.mjs
@@ -22,11 +22,14 @@ function loadEnv() {
   }
   return env;
 }
-const env = loadEnv();
+// Importing this file (the SQL renderers are tested) must not read .env.local
+// or start a crawl, so everything with a side effect waits on being run directly.
+const RUN_DIRECTLY = process.argv[1] === fileURLToPath(import.meta.url);
+const env = RUN_DIRECTLY ? loadEnv() : {};
 const KEY = env.GOOGLE_MAPS_API_KEY;
 const SUPABASE_URL = env.SUPABASE_URL || env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_ANON = env.SUPABASE_ANON_KEY || env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-if (!KEY) throw new Error("GOOGLE_MAPS_API_KEY missing from .env.local");
+if (RUN_DIRECTLY && !KEY) throw new Error("GOOGLE_MAPS_API_KEY missing from .env.local");
 
 // ---- helpers ---------------------------------------------------------------
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -323,18 +326,25 @@ function renderCompactSql(results) {
     `-- Same guards: the shop must still exist, and manual/shop_submitted hours are never touched.`,
     ``,
   ];
-  const withHours = results.filter((r) => r.status === "ok" && r.rows.length);
-  return [...header, ...replaceHours(withHours), ...upsertMeta(results)].join("\n");
+  // no_hours shops are cleared but not repopulated — Google dropped their hours,
+  // so keeping the old rows would leave a wrong schedule on the site forever.
+  const cleared = results.filter((r) => r.status === "ok" || r.status === "no_hours");
+  const withHours = results.filter((r) => r.rows.length);
+  return [...header, ...replaceHours(cleared, withHours), ...upsertMeta(results)].join("\n");
 }
 
-function replaceHours(withHours) {
-  if (withHours.length === 0) return ["-- No shops returned hours; nothing to replace.", ""];
-  const uuids = withHours.map((r) => sqlStr(r.shop.uuid)).join(", ");
+function replaceHours(cleared, withHours) {
+  if (cleared.length === 0) return ["-- No shops resolved; nothing to replace.", ""];
+  const uuids = cleared.map((r) => sqlStr(r.shop.uuid)).join(", ");
   const rows = withHours.flatMap((r) => r.rows.map((row) => hoursValues(r.shop.uuid, row)));
-  return [
+  const clear = [
     `DELETE FROM shop_hours WHERE shop_uuid IN (${uuids})`,
     `  AND ${notProtected("shop_hours.shop_uuid")};`,
     ``,
+  ];
+  if (rows.length === 0) return [...clear, "-- No shop returned hours; nothing to insert.", ""];
+  return [
+    ...clear,
     `INSERT INTO shop_hours (shop_uuid, day_of_week, opens_at, closes_at, spans_midnight)`,
     `SELECT v.* FROM (VALUES`,
     rows.join(",\n"),
@@ -452,7 +462,11 @@ const VERIFICATION = `-- =======================================================
 -- SELECT count(*) FROM shop_hours h JOIN shop_hours_meta m ON m.shop_uuid=h.shop_uuid
 -- WHERE m.source='google_places' AND m.fetched_at < now() - interval '30 days';`;
 
-main().catch((e) => {
-  console.error("FATAL", e);
-  process.exit(1);
-});
+export { renderSql, renderCompactSql };
+
+if (RUN_DIRECTLY) {
+  main().catch((e) => {
+    console.error("FATAL", e);
+    process.exit(1);
+  });
+}

--- a/scripts/crawl-hours.mjs
+++ b/scripts/crawl-hours.mjs
@@ -10,6 +10,7 @@ import { dirname, resolve as resolvePath } from "node:path";
 // Repo root, derived from this script's location (scripts/ -> repo root).
 const ROOT = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
 const OUT = `${ROOT}/migrations/hours-backfill.sql`;
+const COMPACT_OUT = `${ROOT}/migrations/hours-backfill-compact.sql`;
 
 // ---- env -------------------------------------------------------------------
 function loadEnv() {
@@ -230,6 +231,8 @@ async function main() {
 
   writeFileSync(OUT, renderSql(results));
   console.error(`\nWrote ${OUT}`);
+  writeFileSync(COMPACT_OUT, renderCompactSql(results));
+  console.error(`Wrote ${COMPACT_OUT}`);
   // summary
   const byStatus = {};
   for (const r of results) byStatus[r.status] = (byStatus[r.status] || 0) + 1;
@@ -308,6 +311,70 @@ function renderSql(results) {
   }
   L.push("");
   return L.join("\n");
+}
+
+// The reviewable file above is ~350 statements and a quarter of a megabyte, which
+// rules out applying it through anything that can't stream a file (the Supabase
+// MCP, a SQL console). This is the same data as three statements: the VALUES
+// lists can be split at any comma to apply it in chunks.
+function renderCompactSql(results) {
+  const header = [
+    `-- Compact form of hours-backfill.sql. Generated ${new Date().toISOString()}.`,
+    `-- Same guards: the shop must still exist, and manual/shop_submitted hours are never touched.`,
+    ``,
+  ];
+  const withHours = results.filter((r) => r.status === "ok" && r.rows.length);
+  return [...header, ...replaceHours(withHours), ...upsertMeta(results)].join("\n");
+}
+
+function replaceHours(withHours) {
+  if (withHours.length === 0) return ["-- No shops returned hours; nothing to replace.", ""];
+  const uuids = withHours.map((r) => sqlStr(r.shop.uuid)).join(", ");
+  const rows = withHours.flatMap((r) => r.rows.map((row) => hoursValues(r.shop.uuid, row)));
+  return [
+    `DELETE FROM shop_hours WHERE shop_uuid IN (${uuids})`,
+    `  AND ${notProtected("shop_hours.shop_uuid")};`,
+    ``,
+    `INSERT INTO shop_hours (shop_uuid, day_of_week, opens_at, closes_at, spans_midnight)`,
+    `SELECT v.* FROM (VALUES`,
+    rows.join(",\n"),
+    `) v (shop_uuid, day_of_week, opens_at, closes_at, spans_midnight)`,
+    `WHERE ${shopExists("v.shop_uuid")} AND ${notProtected("v.shop_uuid")};`,
+    ``,
+  ];
+}
+
+function upsertMeta(results) {
+  return [
+    `INSERT INTO shop_hours_meta (shop_uuid, source, status, google_place_id, match_distance_m, fetched_at)`,
+    `SELECT v.*, now() FROM (VALUES`,
+    results.map(metaValues).join(",\n"),
+    `) v (shop_uuid, source, status, google_place_id, match_distance_m)`,
+    `WHERE ${shopExists("v.shop_uuid")}`,
+    `ON CONFLICT (shop_uuid) DO UPDATE SET`,
+    `  status=EXCLUDED.status, google_place_id=EXCLUDED.google_place_id,`,
+    `  match_distance_m=EXCLUDED.match_distance_m, fetched_at=EXCLUDED.fetched_at`,
+    `WHERE shop_hours_meta.source='google_places';`,
+    ``,
+  ];
+}
+
+function hoursValues(uuid, row) {
+  return `  (${sqlStr(uuid)}::uuid, ${row.day}::smallint, ${sqlStr(row.opens)}::time, ${sqlStr(row.closes)}::time, ${row.spans})`;
+}
+
+function metaValues(r) {
+  return `  (${sqlStr(r.shop.uuid)}::uuid, 'google_places', ${sqlStr(r.status)}, ${
+    r.placeId ? sqlStr(r.placeId) : "NULL::text"
+  }, ${r.dist != null ? r.dist : "NULL"}::double precision)`;
+}
+
+function shopExists(col) {
+  return `EXISTS (SELECT 1 FROM shops s WHERE s.uuid = ${col})`;
+}
+
+function notProtected(col) {
+  return `NOT EXISTS (SELECT 1 FROM shop_hours_meta m WHERE m.shop_uuid = ${col} AND m.source <> 'google_places')`;
 }
 
 function deleteGuard(uuid) {

--- a/tests/unit/crawlHours.test.ts
+++ b/tests/unit/crawlHours.test.ts
@@ -1,0 +1,67 @@
+// The compact SQL is what actually gets applied, so what matters is that it
+// writes the same thing as the reviewable file it's derived from. These compare
+// the two renderers' effects rather than their text.
+// @ts-expect-error - plain .mjs script, no types
+import { renderSql, renderCompactSql } from '@/scripts/crawl-hours.mjs'
+
+const uuid = (n: number) => `${String(n).repeat(8)}-1111-1111-1111-111111111111`
+
+const result = (n: number, status: string, rows: unknown[] = []) => ({
+  shop: { uuid: uuid(n), name: `Shop ${n}`, neighborhood: 'Bloomfield' },
+  status,
+  placeId: status === 'not_found' ? null : `place-${n}`,
+  dist: 10,
+  matchName: `Shop ${n}`,
+  rows,
+})
+
+const results = [
+  result(1, 'ok', [
+    { day: 0, opens: '08:00', closes: '17:00', spans: false },
+    { day: 1, opens: '09:00', closes: '18:00', spans: false },
+  ]),
+  result(2, 'no_hours'),
+  result(3, 'not_found'),
+  result(4, 'low_confidence'),
+  result(5, 'ok', [{ day: 6, opens: '07:00', closes: '23:30', spans: true }]),
+]
+
+const UUID_PATTERN = /[0-9a-f]{8}-1111-1111-1111-111111111111/g
+const uuidsIn = (sql: string) => new Set(sql.match(UUID_PATTERN) ?? [])
+const withoutCasts = (sql: string) => sql.replace(/::\w+( precision)?/g, '')
+
+const hoursRows = (sql: string) =>
+  (
+    withoutCasts(sql).match(
+      /\('[0-9a-f-]+', ?\d, ?'\d\d:\d\d', ?'\d\d:\d\d', ?(?:true|false)\)/g,
+    ) ?? []
+  )
+    .map(row => row.replace(/\s+/g, ''))
+    .sort()
+
+const metaUuids = (sql: string) => uuidsIn(sql.slice(sql.indexOf('INSERT INTO shop_hours_meta')))
+
+describe('crawl-hours SQL renderers', () => {
+  const long: string = renderSql(results)
+  const compact: string = renderCompactSql(results)
+
+  it('clears hours for the same shops in both forms', () => {
+    const perShopDeletes = long.match(/DELETE FROM shop_hours WHERE shop_uuid = '[^']+'/g) ?? []
+    const compactDeletes = compact.match(/DELETE FROM shop_hours WHERE shop_uuid IN \(([^)]*)\)/)
+
+    // no_hours shops are cleared but never repopulated — Google dropped their
+    // hours, so leaving the old rows would keep a wrong schedule on the site.
+    expect(uuidsIn(compactDeletes![1])).toEqual(uuidsIn(perShopDeletes.join(' ')))
+    expect(uuidsIn(compactDeletes![1]).size).toBe(3)
+  })
+
+  it('inserts the same hours rows in both forms', () => {
+    expect(hoursRows(compact)).toEqual(hoursRows(long))
+    expect(hoursRows(compact)).toHaveLength(3)
+  })
+
+  it('records provenance for every shop, whatever its status', () => {
+    expect(metaUuids(compact)).toEqual(metaUuids(long))
+    expect(metaUuids(compact).size).toBe(results.length)
+  })
+})


### PR DESCRIPTION
## What do these changes accomplish?

`crawl-hours.mjs` now also writes `migrations/hours-backfill-compact.sql` — the same writes as three statements instead of roughly 350.

## Why?

The reviewable output is a quarter of a megabyte of per-shop `DELETE`+`INSERT` blocks. That shape is good for reading a diff of one shop and bad for actually applying it: anything that can't stream a file — the Supabase MCP, a SQL console — needs the whole thing in hand first. Last time, an equivalent compact form had to be reconstructed by hand from the results JSON and checked against the original row-for-row.

Emitting it directly removes that step. The reviewable file stays as-is for review; the compact file is what gets applied, and its `VALUES` lists split at any comma if it still needs chunking.

The compact form also guards its hours insert on `shop_hours_meta.source`, which the per-shop blocks only do on the delete — without it a shop with hand-entered hours would hit the unique constraint.

Verified by running the generated statements against the live database with synthetic uuids: all three parse and execute, and no rows were written (`meta 171, hours 1122, fakes 0`).

## Screenshots

| Before | After |
|---|---|
| 233KB / ~350 statements, no way to apply without a file stream | 3 statements, pasteable |