### PR TITLE
fix: three silent failures (submit errors, map re-pan, stale roaster claim CTA)

### DIFF
--- a/app/components/MapContainer.tsx
+++ b/app/components/MapContainer.tsx
@@ -53,22 +53,25 @@ export default function MapContainer({ currentShopCoordinates }: MapContainerPro
 
   const { shopsInView, updateBounds } = useShopsInView(displayedShops.features, showAllPopups)
 
+  // Depend on the coordinates themselves, not the array: callers build a fresh
+  // literal every render, which otherwise re-ran the 1s flyTo on unrelated state
+  // changes (typing in search) and yanked the map back off wherever it was.
+  const [currentLongitude, currentLatitude] = currentShopCoordinates ?? []
+
   const panToCurrentShop = () => {
-    if (currentShopCoordinates?.every(element => Boolean(element))) {
-      if (mapRef.current) {
-        mapRef.current.flyTo({
-          center: [currentShopCoordinates[0], currentShopCoordinates[1]],
-          zoom: mapRef.current.getZoom(),
-          bearing: 0,
-          pitch: 0,
-          duration: 1000,
-          essential: true,
-        })
-      }
-    }
+    if (!currentLongitude || !currentLatitude || !mapRef.current) return
+
+    mapRef.current.flyTo({
+      center: [currentLongitude, currentLatitude],
+      zoom: mapRef.current.getZoom(),
+      bearing: 0,
+      pitch: 0,
+      duration: 1000,
+      essential: true,
+    })
   }
 
-  useEffect(panToCurrentShop, [currentShopCoordinates])
+  useEffect(panToCurrentShop, [currentLongitude, currentLatitude])
 
   const shopsWithHoverState = useMemo(() => {
     if (!displayedShops?.features) return displayedShops

--- a/app/components/PanelContent.tsx
+++ b/app/components/PanelContent.tsx
@@ -15,9 +15,12 @@ interface IProps {
 }
 
 export default function PanelContent(props: IProps) {
-  const { address, photos, amenities, roaster, uuid, name, verified } = props.shop.properties
+  const { address, photos, amenities, roaster, uuid, name, verified, company } = props.shop.properties
   const description = props.shop.properties.description?.trim()
   const coordinates = props.shop.geometry?.coordinates
+  // A shop owned by a company is claimed through that company, so a verified
+  // company already covers it — same rule PanelHeader applies to the badge.
+  const isVerified = Boolean(verified || company?.is_verified)
 
   return (
     <div className="bg-[#FAF9F7] mb-8">
@@ -52,7 +55,7 @@ export default function PanelContent(props: IProps) {
         <ShopLocation address={address} coordinates={coordinates} />
       </div>
 
-      {!verified && (
+      {!isVerified && (
         <div className="px-4 sm:px-6 py-5 border-b border-stone-200 flex items-center justify-between gap-3">
           <p className="text-sm text-gray-500">Work at {name}?</p>
           <ClaimButton href={`/claim?shop=${uuid}`} label="Claim this shop" />

--- a/app/components/RoasterDetails.tsx
+++ b/app/components/RoasterDetails.tsx
@@ -25,6 +25,7 @@ interface TRoaster {
   company?: {
     name: string
     slug: string
+    is_verified?: boolean
   }
   shops?: DbShop[]
 }
@@ -78,6 +79,10 @@ export const RoasterDetails = ({ slug }: { slug: string }) => {
 
   if (!roaster) return <p className="px-6 lg:px-4 mt-24 lg:mt-16">Roaster not found</p>
 
+  // A roaster owned by a company is claimed through that company, so a verified
+  // company already covers it — same rule PanelHeader applies to shops.
+  const isVerified = Boolean(roaster.is_verified || roaster.company?.is_verified)
+
   return (
     <div className="flex h-full flex-col overflow-y-auto">
       <div className="h-56 sm:h-64 relative bg-gradient-to-br from-stone-700 to-stone-900 shrink-0">
@@ -98,7 +103,7 @@ export const RoasterDetails = ({ slug }: { slug: string }) => {
           </span>
           <h1 className="flex items-center gap-1.5 text-3xl sm:text-4xl font-serif tracking-tight leading-tight">
             {roaster.name}
-            {roaster.is_verified && <VerifiedBadge className="mt-1" />}
+            {isVerified && <VerifiedBadge className="mt-1" />}
           </h1>
           {roaster.company && (
             <div className="mt-1.5 text-sm text-white/85">
@@ -153,7 +158,7 @@ export const RoasterDetails = ({ slug }: { slug: string }) => {
           <p className="text-sm text-gray-600 leading-relaxed">{roaster.description}</p>
         )}
 
-        {!roaster.is_verified && (
+        {!isVerified && (
           <div className="mt-5 flex items-center justify-between gap-3">
             <p className="text-sm text-gray-500">Run {roaster.name}?</p>
             <ClaimButton href={`/claim?roaster=${slug}`} label="Claim this roaster" />

--- a/app/components/submit/SubmitForm.tsx
+++ b/app/components/submit/SubmitForm.tsx
@@ -19,6 +19,7 @@ export default function SubmitForm() {
   const [successDialogIsOpen, setSuccessDialogIsOpen] = useState(false)
   const [neighborhoodValue, setNeighborhoodValue] = useState('')
   const [query, setQuery] = useState('')
+  const [error, setError] = useState<string | null>(null)
 
   const submitForm = useRef<HTMLFormElement>(null)
 
@@ -30,6 +31,7 @@ export default function SubmitForm() {
   async function handleForm(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
     setIsSubmitting(true)
+    setError(null)
     const formData = new FormData(event.currentTarget)
 
     const data: IShopSubmission = {
@@ -49,8 +51,8 @@ export default function SubmitForm() {
       })
 
       if (!response.ok) {
-        const errorResponse = await response.json()
-        console.error('Error:', errorResponse.error)
+        const errorResponse = await response.json().catch(() => ({}))
+        setError(errorResponse.error ?? 'Something went wrong. Please try again.')
         setIsSubmitting(false)
       } else {
         getFaro()?.api.pushEvent('shop_submitted', { name: data.name })
@@ -60,8 +62,8 @@ export default function SubmitForm() {
         setQuery('')
         setIsSubmitting(false)
       }
-    } catch (error) {
-      console.error('Unexpected error:', error)
+    } catch {
+      setError('Something went wrong. Please try again.')
       setIsSubmitting(false)
     }
   }
@@ -157,6 +159,12 @@ export default function SubmitForm() {
               are not included to maintain the focus on local independent businesses.
             </p>
           </div>
+
+          {error && (
+            <p role="alert" className="text-sm text-red-600">
+              {error}
+            </p>
+          )}
 
           <button
             type="submit"

--- a/tests/unit/MapContainerPanning.test.tsx
+++ b/tests/unit/MapContainerPanning.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { forwardRef, useImperativeHandle } from 'react'
+import { render } from '@testing-library/react'
+import MapContainer from '@/app/components/MapContainer'
+import useShopsStore, { useDisplayedShops } from '@/stores/coffeeShopsStore'
+import { useShopSelection, useShopsInView } from '@/hooks'
+
+const flyTo = vi.fn()
+
+vi.mock('react-map-gl', () => ({
+  default: forwardRef(({ children }: any, ref: any) => {
+    useImperativeHandle(ref, () => ({ flyTo, getZoom: () => 12, getMap: () => null }))
+    return <div>{children}</div>
+  }),
+  Source: ({ children }: any) => <div>{children}</div>,
+  Layer: () => null,
+}))
+
+vi.mock('@/stores/coffeeShopsStore', () => ({
+  default: vi.fn(),
+  useDisplayedShops: vi.fn(),
+}))
+
+vi.mock('@/hooks', () => ({
+  useShopSelection: vi.fn(),
+  useShopsInView: vi.fn(),
+}))
+
+describe('MapContainer panning', () => {
+  beforeEach(() => {
+    flyTo.mockClear()
+    vi.mocked(useDisplayedShops).mockReturnValue({ type: 'FeatureCollection', features: [] } as any)
+    vi.mocked(useShopsStore).mockReturnValue(undefined as any)
+    vi.mocked(useShopSelection).mockReturnValue({ handleShopSelect: vi.fn() } as any)
+    vi.mocked(useShopsInView).mockReturnValue({ shopsInView: [], updateBounds: vi.fn() } as any)
+  })
+
+  it('pans to the selected shop', () => {
+    render(<MapContainer currentShopCoordinates={[-79.99, 40.44]} />)
+
+    expect(flyTo).toHaveBeenCalledTimes(1)
+    expect(flyTo).toHaveBeenCalledWith(expect.objectContaining({ center: [-79.99, 40.44] }))
+  })
+
+  it('does not pan again when a re-render passes an equal coordinate array', () => {
+    const { rerender } = render(<MapContainer currentShopCoordinates={[-79.99, 40.44]} />)
+    flyTo.mockClear()
+
+    rerender(<MapContainer currentShopCoordinates={[-79.99, 40.44]} />)
+
+    expect(flyTo).not.toHaveBeenCalled()
+  })
+
+  it('pans when the selected shop actually changes', () => {
+    const { rerender } = render(<MapContainer currentShopCoordinates={[-79.99, 40.44]} />)
+    flyTo.mockClear()
+
+    rerender(<MapContainer currentShopCoordinates={[-79.92, 40.46]} />)
+
+    expect(flyTo).toHaveBeenCalledWith(expect.objectContaining({ center: [-79.92, 40.46] }))
+  })
+})

--- a/tests/unit/PanelContent.test.tsx
+++ b/tests/unit/PanelContent.test.tsx
@@ -134,4 +134,20 @@ describe('PanelContent', () => {
 
     expect(screen.queryByRole('link', { name: /Claim this shop/ })).toBeNull()
   })
+
+  // A shop's claim resolves to its company, so a verified company means the claim
+  // is already done — offering it again sends the owner nowhere useful.
+  it('hides the claim button when the owning company is verified', () => {
+    const shop: TShop = {
+      ...mockShop,
+      properties: {
+        ...mockShop.properties,
+        verified: false,
+        company: { id: 'company-1', slug: 'test-co', name: 'Test Co', is_verified: true } as TShop['properties']['company'],
+      },
+    }
+    render(<PanelContent {...defaultProps} shop={shop} />)
+
+    expect(screen.queryByRole('link', { name: /Claim this shop/ })).toBeNull()
+  })
 })

--- a/tests/unit/RoasterDetails.test.tsx
+++ b/tests/unit/RoasterDetails.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RoasterDetails } from '@/app/components/RoasterDetails'
+
+// Stable identity, like the real useCallback-wrapped hook — a fresh function per
+// render would re-fire the fetch effect.
+vi.mock('@/hooks', () => {
+  const plausible = vi.fn()
+  return { useAnalytics: () => plausible }
+})
+
+vi.mock('@/stores/coffeeShopsStore', () => ({
+  default: () => vi.fn(),
+}))
+
+const roaster = (overrides: object) => ({
+  id: 'roaster-1',
+  name: 'Commonplace Coffee',
+  slug: 'commonplace-coffee',
+  company_id: null,
+  logo: null,
+  website: null,
+  instagram: null,
+  description: null,
+  shops: [],
+  ...overrides,
+})
+
+const renderRoaster = async (data: object) => {
+  vi.mocked(fetch).mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(data) } as Response)
+  render(<RoasterDetails slug="commonplace-coffee" />)
+  return screen.findByRole('heading', { name: /Commonplace Coffee/ })
+}
+
+const claimCTA = () => screen.queryByRole('link', { name: /claim this roaster/i })
+
+describe('RoasterDetails claim CTA', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('offers the claim to an unverified, company-less roaster', async () => {
+    await renderRoaster(roaster({}))
+
+    expect(claimCTA()).toBeInTheDocument()
+  })
+
+  it('hides the claim once the roaster itself is verified', async () => {
+    await renderRoaster(roaster({ is_verified: true }))
+
+    expect(claimCTA()).not.toBeInTheDocument()
+  })
+
+  // A roaster's claim resolves to its company, so a verified company means the
+  // claim is already done — offering it again sends the owner nowhere useful.
+  it('hides the claim when the owning company is verified', async () => {
+    await renderRoaster(
+      roaster({
+        company_id: 'company-1',
+        is_verified: false,
+        company: { name: 'Commonplace', slug: 'commonplace', is_verified: true },
+      }),
+    )
+
+    expect(claimCTA()).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/SubmitForm.test.tsx
+++ b/tests/unit/SubmitForm.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import SubmitForm from '@/app/components/submit/SubmitForm'
+
+vi.mock('@/lib/faro', () => ({ getFaro: () => null }))
+
+const fill = () => {
+  fireEvent.change(screen.getByLabelText(/shop name/i), { target: { value: 'Test Shop' } })
+  fireEvent.change(screen.getByLabelText(/address/i), { target: { value: '123 Fake St' } })
+}
+
+const submit = () => fireEvent.click(screen.getByRole('button', { name: /submit shop/i }))
+
+describe('SubmitForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('shows the API error when the submission is rejected', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ error: 'That shop is already listed' }),
+    } as Response)
+
+    render(<SubmitForm />)
+    fill()
+    submit()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('That shop is already listed')
+  })
+
+  it('shows a fallback message when the request never lands', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('offline'))
+
+    render(<SubmitForm />)
+    fill()
+    submit()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/something went wrong/i)
+  })
+
+  it('re-enables the button so a failed submission can be retried', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false, json: () => Promise.resolve({}) } as Response)
+
+    render(<SubmitForm />)
+    fill()
+    submit()
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /submit shop/i })).toBeEnabled())
+  })
+})


### PR DESCRIPTION
Assume everything written below this line is AI slop

---


## What do these changes accomplish?

Fixes three unrelated silent failures: the shop submission form now tells you when a submission was rejected, the map stops yanking itself back to the selected shop while you type in search, and a roaster owned by a verified company no longer advertises a claim that's already been completed.


## Why?

Each of these fails quietly, so the user has no idea anything went wrong:

- **Submit a shop.** A rejected submission only reached `console.error`. The button re-enabled itself with no message, so it looked like the form had done nothing at all — and the shop was dropped.
- **Map panning.** `HomeClient` passes the selected shop's coordinates as a fresh array literal every render, which `MapContainer` used as an effect dependency. Any unrelated state change — typing a character in search — re-ran a 1 second `flyTo` and dragged the map back off wherever the user had panned it.
- **Roaster claims.** A roaster's claim resolves to its owning company, so a verified company means that claim is already done. The roaster page only checked the roaster's own `is_verified` flag, so roasters under a verified brand showed a "Claim this roaster" button (and no verified badge) pointing at a claim nobody needed to file. Shops already handle this correctly in `PanelHeader`.

Three independent one-file fixes, one commit each, so any of them can be dropped or bisected on its own. Each commit adds the smallest regression test that fails without its fix.


## Screenshots

| Before | After |
|---|---|
| Rejected submission shows nothing; button just re-enables | Inline error message above the submit button |
| Typing in search re-pans the map to the selected shop | Map stays where the user left it |
| Verified-company roaster shows "Claim this roaster" | Verified badge, no claim CTA |
