### PR TITLE
fix: render nearby-shop distances again

### DIFF
--- a/app/components/NearbyShops.tsx
+++ b/app/components/NearbyShops.tsx
@@ -1,10 +1,15 @@
 import { useCallback, useMemo, useState, useEffect } from 'react'
 import { useAnalytics } from '@/hooks'
 import { TShop } from '@/types/shop-types'
-import { TUnits } from '@/types/unit-types'
+import {
+  DEFAULT_UNITS,
+  DISTANCE_UNITS,
+  DISTANCE_UNITS_STORAGE_KEY,
+  parseUnits,
+  TUnits,
+} from '@/types/unit-types'
 import useShopsStore from '@/stores/coffeeShopsStore'
 import haversineDistance from 'haversine-distance'
-import { DISTANCE_UNITS } from '@/app/settings/DistanceUnitsDialog'
 import NearbyShopList from '@/app/components/NearbyShopList'
 
 interface IProps {
@@ -27,9 +32,9 @@ export default function NearbyShops({ shop }: IProps) {
   const plausible = useAnalytics()
   const allShops = useShopsStore(s => s.allShops)
 
-  const [units, setUnits] = useState<TUnits>('miles')
+  const [units, setUnits] = useState<TUnits>(DEFAULT_UNITS)
   useEffect(() => {
-    setUnits(localStorage.getItem('distanceUnits') as TUnits)
+    setUnits(parseUnits(localStorage.getItem(DISTANCE_UNITS_STORAGE_KEY)))
   }, [])
 
   const calculateDistance = useCallback(

--- a/app/components/ShopCard.tsx
+++ b/app/components/ShopCard.tsx
@@ -3,7 +3,7 @@
 import { MapPinIcon } from '@heroicons/react/24/outline'
 import VerifiedBadge from './VerifiedBadge'
 import { TShop } from '@/types/shop-types'
-import { TUnits } from '@/types/unit-types'
+import { DISTANCE_UNITS, TUnits } from '@/types/unit-types'
 import useShopsStore from '@/stores/coffeeShopsStore'
 import { useShopSelection, useAnalytics } from '@/hooks'
 
@@ -21,12 +21,12 @@ interface IProps {
   onClick?: () => void
 }
 
-export const roundDistance = ({ units, distance }: { units: string; distance: number }) => {
-  if (units === 'Miles') return Math.round(distance * 100) / 100
-  if (units === 'Meters') return Math.round(distance)
-}
+// Total over TUnits, so there is no unmatched branch that could render
+// "undefined miles away".
+export const roundDistance = ({ units, distance }: { units: TUnits; distance: number }) =>
+  units === DISTANCE_UNITS.Miles ? Math.round(distance * 100) / 100 : Math.round(distance)
 
-export const generateDistanceText = ({ units, distance }: { units: string; distance: string }) => {
+export const generateDistanceText = ({ units, distance }: { units: TUnits; distance: string }) => {
   const parsedDistance = parseFloat(distance)
   return `${roundDistance({ units, distance: parsedDistance })} ${units.toLowerCase()} away`
 }

--- a/app/components/ShopCard.tsx
+++ b/app/components/ShopCard.tsx
@@ -21,8 +21,6 @@ interface IProps {
   onClick?: () => void
 }
 
-// Total over TUnits, so there is no unmatched branch that could render
-// "undefined miles away".
 export const roundDistance = ({ units, distance }: { units: TUnits; distance: number }) =>
   units === DISTANCE_UNITS.Miles ? Math.round(distance * 100) / 100 : Math.round(distance)
 

--- a/app/settings/DistanceUnitsDialog.tsx
+++ b/app/settings/DistanceUnitsDialog.tsx
@@ -2,18 +2,17 @@
 
 import { useEffect, useState } from 'react'
 import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react'
+import { DISTANCE_UNITS, TUnits } from '@/types/unit-types'
 
 interface IProps {
-  currentUnit: string
+  currentUnit: TUnits
   handleClose: () => void
   isOpen: boolean
-  onUnitChange: (newUnit: string) => void
+  onUnitChange: (newUnit: TUnits) => void
 }
 
-export const DISTANCE_UNITS = { Meters: 'Meters', Miles: 'Miles' }
-
 export default function DistanceUnitsDialog(props: IProps) {
-  const [selected, setSelected] = useState(props.currentUnit)
+  const [selected, setSelected] = useState<TUnits>(props.currentUnit)
 
   useEffect(() => {
     if (props.isOpen) {
@@ -24,10 +23,6 @@ export default function DistanceUnitsDialog(props: IProps) {
   const handleSave = () => {
     props.onUnitChange(selected)
     props.handleClose()
-  }
-
-  const handleUnitChange = (unit: string) => {
-    setSelected(unit)
   }
 
   return (
@@ -64,7 +59,7 @@ export default function DistanceUnitsDialog(props: IProps) {
                       name="distance-unit"
                       type="radio"
                       className="h-4 w-4 border-gray-300 text-yellow-300 focus:ring-yellow-300"
-                      onChange={() => handleUnitChange(unit)}
+                      onChange={() => setSelected(unit)}
                     />
                     <label htmlFor={unit} className="ml-3 block text-sm font-medium leading-6 text-gray-900">
                       {unit}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,50 +1,24 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { TUnits } from '@/types/unit-types'
-import DistanceUnitsDialog, { DISTANCE_UNITS } from '@/app/settings/DistanceUnitsDialog'
-
-const DISTANCE_PREFERENCE_KEY = 'distanceUnits'
-const DEFAULT_UNIT = DISTANCE_UNITS.Miles as TUnits
-
-// A storage write can throw (e.g. private browsing with storage disabled), and
-// this seed is a best-effort default, not the read path — swallow it the same
-// way handleUnitChange already does, rather than let it fail the mount effect.
-const seedDefaultUnit = () => {
-  try {
-    window.localStorage.setItem(DISTANCE_PREFERENCE_KEY, DEFAULT_UNIT)
-  } catch (error) {
-    console.error('Failed to seed default unit preference:', error)
-  }
-}
-
-// Read once and reuse the same value for both the write and the state, so a
-// first visit (nothing stored yet) can't leave localStorage and the render
-// disagreeing about what the default is. One `stored` check drives both
-// branches, so an empty string is treated as "nothing stored" everywhere,
-// not just in the write, or it would render blank forever without self-healing.
-const readStoredUnitOrSeedDefault = () => {
-  const stored = window.localStorage.getItem(DISTANCE_PREFERENCE_KEY)
-  if (stored) return stored as TUnits
-  seedDefaultUnit()
-  return DEFAULT_UNIT
-}
+import { DEFAULT_UNITS, DISTANCE_UNITS_STORAGE_KEY, parseUnits, TUnits } from '@/types/unit-types'
+import DistanceUnitsDialog from '@/app/settings/DistanceUnitsDialog'
 
 export default function Settings() {
   const [distanceUnitsDialogIsOpen, setDistanceUnitsDialogIsOpen] = useState(false)
-  const [unitFromLocalStorage, setUnitFromLocalStorage] = useState<TUnits>('miles')
+  const [unitFromLocalStorage, setUnitFromLocalStorage] = useState<TUnits>(DEFAULT_UNITS)
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
     if (typeof window === 'undefined') return
-    setUnitFromLocalStorage(readStoredUnitOrSeedDefault())
+    setUnitFromLocalStorage(parseUnits(window.localStorage.getItem(DISTANCE_UNITS_STORAGE_KEY)))
     setIsLoading(false)
   }, [])
 
-  const handleUnitChange = (newUnit: string) => {
+  const handleUnitChange = (newUnit: TUnits) => {
     try {
-      window.localStorage.setItem(DISTANCE_PREFERENCE_KEY, newUnit)
-      setUnitFromLocalStorage(newUnit as TUnits)
+      window.localStorage.setItem(DISTANCE_UNITS_STORAGE_KEY, newUnit)
+      setUnitFromLocalStorage(newUnit)
     } catch (error) {
       console.error('Failed to save unit preference:', error)
     }

--- a/tests/unit/HomeClient.test.tsx
+++ b/tests/unit/HomeClient.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react'
 import { mockAnimationsApi } from 'jsdom-testing-mocks'
 import HomeClient from '@/app/components/HomeClient'
 import useShopsStore from '@/stores/coffeeShopsStore'
-import { DISTANCE_UNITS } from '@/app/settings/DistanceUnitsDialog'
+import { DISTANCE_UNITS } from '@/types/unit-types'
 
 beforeAll(() => {
   mockAnimationsApi()

--- a/tests/unit/NearbyShopRow.test.tsx
+++ b/tests/unit/NearbyShopRow.test.tsx
@@ -2,6 +2,7 @@ import { describe, test, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import NearbyShopRow from '@/app/components/NearbyShopRow'
 import type { TShop } from '@/types/shop-types'
+import { DEFAULT_UNITS, DISTANCE_UNITS } from '@/types/unit-types'
 
 vi.mock('@/hooks', () => ({
   useShopSelection: () => ({ handleShopSelect: vi.fn() }),
@@ -42,5 +43,32 @@ describe('NearbyShopRow verified badge', () => {
   test('no badge for an unverified shop', () => {
     render(<NearbyShopRow shop={makeShop()} />)
     expect(screen.queryByText('Verified')).toBeNull()
+  })
+})
+
+// Regression for the "distances never render" bug: the units prop used to come
+// straight from localStorage, so it was `null` for anyone who had never opened
+// /settings — falsy, so this whole span was skipped. And the one value that did
+// arrive on first render ('miles', lowercase) matched no branch of
+// roundDistance, so it formatted as "undefined miles away".
+describe('NearbyShopRow distance label', () => {
+  test('renders a real distance for the default unit', () => {
+    render(<NearbyShopRow shop={makeShop()} distance="1.23456" units={DEFAULT_UNITS} />)
+
+    const label = screen.getByText(/away$/)
+    expect(label.textContent).toBe('1.23 miles away')
+  })
+
+  test('renders a real distance for meters', () => {
+    render(<NearbyShopRow shop={makeShop()} distance="1234.56" units="Meters" />)
+    expect(screen.getByText('1235 meters away')).toBeTruthy()
+  })
+
+  test('never renders undefined or NaN for any valid unit', () => {
+    for (const units of Object.values(DISTANCE_UNITS)) {
+      const { unmount } = render(<NearbyShopRow shop={makeShop()} distance="500" units={units} />)
+      expect(screen.getByText(/away$/).textContent).not.toMatch(/undefined|NaN/)
+      unmount()
+    }
   })
 })

--- a/tests/unit/NearbyShopRow.test.tsx
+++ b/tests/unit/NearbyShopRow.test.tsx
@@ -46,11 +46,6 @@ describe('NearbyShopRow verified badge', () => {
   })
 })
 
-// Regression for the "distances never render" bug: the units prop used to come
-// straight from localStorage, so it was `null` for anyone who had never opened
-// /settings — falsy, so this whole span was skipped. And the one value that did
-// arrive on first render ('miles', lowercase) matched no branch of
-// roundDistance, so it formatted as "undefined miles away".
 describe('NearbyShopRow distance label', () => {
   test('renders a real distance for the default unit', () => {
     render(<NearbyShopRow shop={makeShop()} distance="1.23456" units={DEFAULT_UNITS} />)

--- a/tests/unit/SettingsPage.test.tsx
+++ b/tests/unit/SettingsPage.test.tsx
@@ -7,10 +7,6 @@ describe('Settings page', () => {
     window.localStorage.clear()
   })
 
-  // Regression for S19: the page used to render blank on a first visit, because
-  // it read `null` from localStorage and kept it. The default is now derived on
-  // read (parseUnits), so a first visit renders it without writing anything —
-  // and a reload derives the same value from the same absent key.
   it('renders the default unit on a first visit without writing to storage', async () => {
     render(<Settings />)
 
@@ -19,7 +15,6 @@ describe('Settings page', () => {
     })
     expect(window.localStorage.getItem('distanceUnits')).toBeNull()
 
-    // A reload sees the same absent key and must resolve it identically.
     render(<Settings />)
     await waitFor(() => {
       expect(screen.getAllByText('Miles')).toHaveLength(2)
@@ -37,7 +32,7 @@ describe('Settings page', () => {
   })
 
   // An empty string is a stored-but-blank value, not "nothing stored" — it must
-  // resolve to the default rather than rendering blank forever.
+  // self-heal to the default rather than rendering blank forever.
   it('treats an empty stored value the same as nothing stored', async () => {
     window.localStorage.setItem('distanceUnits', '')
 
@@ -48,8 +43,6 @@ describe('Settings page', () => {
     })
   })
 
-  // An unrecognized value (an older build, or hand-edited storage) must not
-  // render raw — it resolves to the default like any other unusable value.
   it('falls back to the default for an unrecognized stored value', async () => {
     window.localStorage.setItem('distanceUnits', 'kilometers')
 

--- a/tests/unit/SettingsPage.test.tsx
+++ b/tests/unit/SettingsPage.test.tsx
@@ -7,17 +7,23 @@ describe('Settings page', () => {
     window.localStorage.clear()
   })
 
-  // Regression for S19: the page used to read `null` from localStorage on a
-  // first visit, write the default in, but leave state holding the `null` it
-  // had already read — so the unit rendered blank, disagreeing with what a
-  // reload would then read back from the now-seeded localStorage.
-  it('renders the same default unit on a first visit that it persists for a reload', async () => {
+  // Regression for S19: the page used to render blank on a first visit, because
+  // it read `null` from localStorage and kept it. The default is now derived on
+  // read (parseUnits), so a first visit renders it without writing anything —
+  // and a reload derives the same value from the same absent key.
+  it('renders the default unit on a first visit without writing to storage', async () => {
     render(<Settings />)
 
     await waitFor(() => {
       expect(screen.getByText('Miles')).toBeInTheDocument()
     })
-    expect(window.localStorage.getItem('distanceUnits')).toBe('Miles')
+    expect(window.localStorage.getItem('distanceUnits')).toBeNull()
+
+    // A reload sees the same absent key and must resolve it identically.
+    render(<Settings />)
+    await waitFor(() => {
+      expect(screen.getAllByText('Miles')).toHaveLength(2)
+    })
   })
 
   it('renders a previously stored unit unchanged', async () => {
@@ -31,7 +37,7 @@ describe('Settings page', () => {
   })
 
   // An empty string is a stored-but-blank value, not "nothing stored" — it must
-  // self-heal to the default rather than rendering blank forever.
+  // resolve to the default rather than rendering blank forever.
   it('treats an empty stored value the same as nothing stored', async () => {
     window.localStorage.setItem('distanceUnits', '')
 
@@ -40,6 +46,18 @@ describe('Settings page', () => {
     await waitFor(() => {
       expect(screen.getByText('Miles')).toBeInTheDocument()
     })
-    expect(window.localStorage.getItem('distanceUnits')).toBe('Miles')
+  })
+
+  // An unrecognized value (an older build, or hand-edited storage) must not
+  // render raw — it resolves to the default like any other unusable value.
+  it('falls back to the default for an unrecognized stored value', async () => {
+    window.localStorage.setItem('distanceUnits', 'kilometers')
+
+    render(<Settings />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Miles')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('kilometers')).toBeNull()
   })
 })

--- a/tests/unit/ShopCard.test.tsx
+++ b/tests/unit/ShopCard.test.tsx
@@ -74,7 +74,6 @@ describe('ShopCard', () => {
   })
 
   it('renders distance when distance and units are provided', () => {
-    // @ts-expect-error
     render(<ShopCard {...defaultProps} distance="1.23456" units="Miles" />)
 
     expect(screen.getByText('1.23 miles away')).toBeTruthy()
@@ -87,7 +86,6 @@ describe('ShopCard', () => {
     rerender(<ShopCard {...defaultProps} distance="1.23" />)
     expect(screen.queryByText(/away/)).toBeNull()
 
-    // @ts-expect-error
     rerender(<ShopCard {...defaultProps} units="Miles" />)
     expect(screen.queryByText(/away/)).toBeNull()
   })

--- a/tests/unit/unitTypes.test.ts
+++ b/tests/unit/unitTypes.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from 'vitest'
+import { DEFAULT_UNITS, DISTANCE_UNITS, parseUnits } from '@/types/unit-types'
+
+// parseUnits is the single point where an untrusted storage value becomes a
+// TUnits. Every reader depends on it never handing back something the
+// formatters can't render, which is the bug that hid the distance label.
+describe('parseUnits', () => {
+  test('passes through the two real units', () => {
+    expect(parseUnits('Miles')).toBe(DISTANCE_UNITS.Miles)
+    expect(parseUnits('Meters')).toBe(DISTANCE_UNITS.Meters)
+  })
+
+  test('defaults when nothing is stored', () => {
+    expect(parseUnits(null)).toBe(DEFAULT_UNITS)
+    expect(parseUnits(undefined)).toBe(DEFAULT_UNITS)
+  })
+
+  test('defaults for a stored-but-blank value', () => {
+    expect(parseUnits('')).toBe(DEFAULT_UNITS)
+  })
+
+  // 'kilometers' was a member of the old TUnits union that nothing ever wrote,
+  // and 'miles' was the lowercase initial state that matched no formatter branch.
+  test('defaults for legacy and unrecognized values', () => {
+    expect(parseUnits('kilometers')).toBe(DEFAULT_UNITS)
+    expect(parseUnits('miles')).toBe(DEFAULT_UNITS)
+    expect(parseUnits('MILES')).toBe(DEFAULT_UNITS)
+    expect(parseUnits('garbage')).toBe(DEFAULT_UNITS)
+  })
+
+  test('the default is one of the real units', () => {
+    expect(Object.values(DISTANCE_UNITS)).toContain(DEFAULT_UNITS)
+  })
+})

--- a/tests/unit/unitTypes.test.ts
+++ b/tests/unit/unitTypes.test.ts
@@ -1,9 +1,6 @@
 import { describe, test, expect } from 'vitest'
 import { DEFAULT_UNITS, DISTANCE_UNITS, parseUnits } from '@/types/unit-types'
 
-// parseUnits is the single point where an untrusted storage value becomes a
-// TUnits. Every reader depends on it never handing back something the
-// formatters can't render, which is the bug that hid the distance label.
 describe('parseUnits', () => {
   test('passes through the two real units', () => {
     expect(parseUnits('Miles')).toBe(DISTANCE_UNITS.Miles)
@@ -19,8 +16,6 @@ describe('parseUnits', () => {
     expect(parseUnits('')).toBe(DEFAULT_UNITS)
   })
 
-  // 'kilometers' was a member of the old TUnits union that nothing ever wrote,
-  // and 'miles' was the lowercase initial state that matched no formatter branch.
   test('defaults for legacy and unrecognized values', () => {
     expect(parseUnits('kilometers')).toBe(DEFAULT_UNITS)
     expect(parseUnits('miles')).toBe(DEFAULT_UNITS)

--- a/types/unit-types.ts
+++ b/types/unit-types.ts
@@ -1,6 +1,3 @@
-// The persisted values are capitalized because they double as the user-facing
-// labels in the settings UI, so they are the canonical spelling rather than a
-// storage detail to be normalized away.
 export const DISTANCE_UNITS = { Meters: 'Meters', Miles: 'Miles' } as const
 
 export type TUnits = (typeof DISTANCE_UNITS)[keyof typeof DISTANCE_UNITS]
@@ -9,10 +6,5 @@ export const DEFAULT_UNITS: TUnits = DISTANCE_UNITS.Miles
 
 export const DISTANCE_UNITS_STORAGE_KEY = 'distanceUnits'
 
-// Storage holds `null` (never written), `''` (stored blank), or an unrecognized
-// value from an older build. Collapsing all three to the default here is what
-// lets readers treat the preference as always present — a default written on
-// visit can be missed by a user who never opens settings, a default derived on
-// read cannot.
 export const parseUnits = (stored: string | null | undefined): TUnits =>
   stored === DISTANCE_UNITS.Miles || stored === DISTANCE_UNITS.Meters ? stored : DEFAULT_UNITS

--- a/types/unit-types.ts
+++ b/types/unit-types.ts
@@ -1,1 +1,18 @@
-export type TUnits = 'miles' | 'kilometers'
+// The persisted values are capitalized because they double as the user-facing
+// labels in the settings UI, so they are the canonical spelling rather than a
+// storage detail to be normalized away.
+export const DISTANCE_UNITS = { Meters: 'Meters', Miles: 'Miles' } as const
+
+export type TUnits = (typeof DISTANCE_UNITS)[keyof typeof DISTANCE_UNITS]
+
+export const DEFAULT_UNITS: TUnits = DISTANCE_UNITS.Miles
+
+export const DISTANCE_UNITS_STORAGE_KEY = 'distanceUnits'
+
+// Storage holds `null` (never written), `''` (stored blank), or an unrecognized
+// value from an older build. Collapsing all three to the default here is what
+// lets readers treat the preference as always present — a default written on
+// visit can be missed by a user who never opens settings, a default derived on
+// read cannot.
+export const parseUnits = (stored: string | null | undefined): TUnits =>
+  stored === DISTANCE_UNITS.Miles || stored === DISTANCE_UNITS.Meters ? stored : DEFAULT_UNITS


### PR DESCRIPTION
Assume everything written below this line is AI slop

---


## What do these changes accomplish?

Makes nearby-shop distances render again by giving the distance-units preference a single source of truth that agrees with what's actually stored on disk.


## Why?

The distance-units type said the preference was `'miles' | 'kilometers'`, but every value written to storage and shown in the settings dialog was `'Miles'` or `'Meters'`. Nothing enforced the mismatch, so the rounding helper simply fell through both of its branches and returned nothing — nearby shops rendered no distance at all, or "undefined miles away".

The mismatch was possible because the preference lived in three places at once: the type in `types/unit-types.ts`, the option labels in the settings dialog, and the storage key spelled out as a literal in each reader. This PR collapses them into one module that owns the values, the default, the storage key, and a `parseUnits` reader.

That reader is also what fixes the second half of the bug. The old settings page wrote a default into storage the first time someone opened settings — which meant anyone who never opened settings still had nothing stored, and read back `null`. Deriving the default on read instead of seeding it on visit means the preference is always present for every reader, whether or not the user has ever visited settings.

`roundDistance` is now total over the unit type, so there is no unmatched branch left to fall through.


## Screenshots

| Before | After |
|---|---|
| Nearby shops list rows with no distance / "undefined miles away" | Nearby shops list rows reading "0.42 miles away" |
