### PR TITLE
fix(map): stop re-panning the map on every parent render

### DIFF
--- a/app/components/MapContainer.tsx
+++ b/app/components/MapContainer.tsx
@@ -53,22 +53,25 @@ export default function MapContainer({ currentShopCoordinates }: MapContainerPro
 
   const { shopsInView, updateBounds } = useShopsInView(displayedShops.features, showAllPopups)
 
+  // Depend on the coordinates themselves, not the array: callers build a fresh
+  // literal every render, which otherwise re-ran the 1s flyTo on unrelated state
+  // changes (typing in search) and yanked the map back off wherever it was.
+  const [currentLongitude, currentLatitude] = currentShopCoordinates ?? []
+
   const panToCurrentShop = () => {
-    if (currentShopCoordinates?.every(element => Boolean(element))) {
-      if (mapRef.current) {
-        mapRef.current.flyTo({
-          center: [currentShopCoordinates[0], currentShopCoordinates[1]],
-          zoom: mapRef.current.getZoom(),
-          bearing: 0,
-          pitch: 0,
-          duration: 1000,
-          essential: true,
-        })
-      }
-    }
+    if (!currentLongitude || !currentLatitude || !mapRef.current) return
+
+    mapRef.current.flyTo({
+      center: [currentLongitude, currentLatitude],
+      zoom: mapRef.current.getZoom(),
+      bearing: 0,
+      pitch: 0,
+      duration: 1000,
+      essential: true,
+    })
   }
 
-  useEffect(panToCurrentShop, [currentShopCoordinates])
+  useEffect(panToCurrentShop, [currentLongitude, currentLatitude])
 
   const shopsWithHoverState = useMemo(() => {
     if (!displayedShops?.features) return displayedShops

--- a/tests/unit/MapContainerPanning.test.tsx
+++ b/tests/unit/MapContainerPanning.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { forwardRef, useImperativeHandle } from 'react'
+import { render } from '@testing-library/react'
+import MapContainer from '@/app/components/MapContainer'
+import useShopsStore, { useDisplayedShops } from '@/stores/coffeeShopsStore'
+import { useShopSelection, useShopsInView } from '@/hooks'
+
+const flyTo = vi.fn()
+
+vi.mock('react-map-gl', () => ({
+  default: forwardRef(({ children }: any, ref: any) => {
+    useImperativeHandle(ref, () => ({ flyTo, getZoom: () => 12, getMap: () => null }))
+    return <div>{children}</div>
+  }),
+  Source: ({ children }: any) => <div>{children}</div>,
+  Layer: () => null,
+}))
+
+vi.mock('@/stores/coffeeShopsStore', () => ({
+  default: vi.fn(),
+  useDisplayedShops: vi.fn(),
+}))
+
+vi.mock('@/hooks', () => ({
+  useShopSelection: vi.fn(),
+  useShopsInView: vi.fn(),
+}))
+
+describe('MapContainer panning', () => {
+  beforeEach(() => {
+    flyTo.mockClear()
+    vi.mocked(useDisplayedShops).mockReturnValue({ type: 'FeatureCollection', features: [] } as any)
+    vi.mocked(useShopsStore).mockReturnValue(undefined as any)
+    vi.mocked(useShopSelection).mockReturnValue({ handleShopSelect: vi.fn() } as any)
+    vi.mocked(useShopsInView).mockReturnValue({ shopsInView: [], updateBounds: vi.fn() } as any)
+  })
+
+  it('pans to the selected shop', () => {
+    render(<MapContainer currentShopCoordinates={[-79.99, 40.44]} />)
+
+    expect(flyTo).toHaveBeenCalledTimes(1)
+    expect(flyTo).toHaveBeenCalledWith(expect.objectContaining({ center: [-79.99, 40.44] }))
+  })
+
+  it('does not pan again when a re-render passes an equal coordinate array', () => {
+    const { rerender } = render(<MapContainer currentShopCoordinates={[-79.99, 40.44]} />)
+    flyTo.mockClear()
+
+    rerender(<MapContainer currentShopCoordinates={[-79.99, 40.44]} />)
+
+    expect(flyTo).not.toHaveBeenCalled()
+  })
+
+  it('pans when the selected shop actually changes', () => {
+    const { rerender } = render(<MapContainer currentShopCoordinates={[-79.99, 40.44]} />)
+    flyTo.mockClear()
+
+    rerender(<MapContainer currentShopCoordinates={[-79.92, 40.46]} />)
+
+    expect(flyTo).toHaveBeenCalledWith(expect.objectContaining({ center: [-79.92, 40.46] }))
+  })
+})


### PR DESCRIPTION
Assume everything written below this line is AI slop

---


## What do these changes accomplish?

The map only pans to the selected shop when the selected shop actually changes, instead of re-panning on every unrelated re-render.


## Why?

`HomeClient` builds the selected shop's coordinates as a fresh array literal on each render, so the pan effect's dependency changed identity every time the parent re-rendered — including on every keystroke in search. With a shop selected, typing kicked off the 1-second `flyTo` again and again, yanking the map back to the selected shop mid-pan while the user was trying to look around. The effect now depends on the longitude and latitude values rather than the array that holds them.


## Screenshots

The bug is motion, not a static difference, so a still frame doesn't capture it. To see it: select a shop, drag the map away, then type in the search box — before this change the map snaps back on each keystroke; after, it stays where you left it.
