### PR TITLE
fix(companies,roasters): don't render an API failure as a claimable brand

### DIFF
--- a/app/components/Company.tsx
+++ b/app/components/Company.tsx
@@ -4,6 +4,7 @@ import { ArrowTopRightOnSquareIcon, BuildingStorefrontIcon, ChevronRightIcon, Ma
 import { Flame, Instagram } from 'lucide-react'
 import Link from 'next/link'
 import LocationList from '@/app/components/LocationList'
+import CompanySkeleton from '@/app/components/CompanySkeleton'
 import VerifiedBadge from '@/app/components/VerifiedBadge'
 import ClaimButton from '@/app/components/ClaimButton'
 import { useState, useEffect } from 'react'
@@ -28,27 +29,6 @@ const groupByNeighborhood = (features: TShop[]): [string, TShop[]][] => {
     (a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0])
   )
 }
-
-const CompanySkeleton = () => (
-  <div className="flex h-full flex-col overflow-y-auto animate-pulse">
-    <div className="h-56 sm:h-64 bg-gray-200 shrink-0" />
-    <div className="px-6 lg:px-4 py-6 flex flex-col">
-      <div className="flex gap-2 mb-4">
-        <div className="h-8 w-24 bg-gray-200 rounded-full" />
-        <div className="h-8 w-24 bg-gray-200 rounded-full" />
-      </div>
-      <div className="space-y-2 mb-6">
-        <div className="h-4 bg-gray-200 rounded w-full" />
-        <div className="h-4 bg-gray-200 rounded w-3/4" />
-      </div>
-      <div className="space-y-3">
-        {[1, 2, 3].map(i => (
-          <div key={i} className="h-28 bg-gray-200 rounded" />
-        ))}
-      </div>
-    </div>
-  </div>
-)
 
 async function fetchCompany(slug: string, signal: AbortSignal) {
   const res = await fetch(`/api/companies/${slug}`, { signal })

--- a/app/components/Company.tsx
+++ b/app/components/Company.tsx
@@ -29,27 +29,62 @@ const groupByNeighborhood = (features: TShop[]): [string, TShop[]][] => {
   )
 }
 
+const CompanySkeleton = () => (
+  <div className="flex h-full flex-col overflow-y-auto animate-pulse">
+    <div className="h-56 sm:h-64 bg-gray-200 shrink-0" />
+    <div className="px-6 lg:px-4 py-6 flex flex-col">
+      <div className="flex gap-2 mb-4">
+        <div className="h-8 w-24 bg-gray-200 rounded-full" />
+        <div className="h-8 w-24 bg-gray-200 rounded-full" />
+      </div>
+      <div className="space-y-2 mb-6">
+        <div className="h-4 bg-gray-200 rounded w-full" />
+        <div className="h-4 bg-gray-200 rounded w-3/4" />
+      </div>
+      <div className="space-y-3">
+        {[1, 2, 3].map(i => (
+          <div key={i} className="h-28 bg-gray-200 rounded" />
+        ))}
+      </div>
+    </div>
+  </div>
+)
+
+async function fetchCompany(slug: string, signal: AbortSignal) {
+  const res = await fetch(`/api/companies/${slug}`, { signal })
+  if (res.status === 404) return null
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json() as Promise<TCompany>
+}
+
 export const Company = ({ slug }: { slug: string }) => {
   const setOverrideShops = useShopsStore(s => s.setOverrideShops)
   const setSearchValue = useShopsStore(s => s.setSearchValue)
   const plausible = useAnalytics()
   const router = useRouter()
   const [company, setCompany] = useState<TCompany | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [status, setStatus] = useState<'loading' | 'ready' | 'failed'>('loading')
 
   useEffect(() => {
     setCompany(null)
-    setLoading(true)
-    const fetchCompany = async () => {
-      try {
-        const response = await fetch(`/api/companies/${slug}`)
-        const data = await response.json()
+    setStatus('loading')
+
+    const controller = new AbortController()
+    fetchCompany(slug, controller.signal)
+      // abort() can't un-settle a request that already resolved, so this guards
+      // against a previous slug's response landing after a newer one took over.
+      .then(data => {
+        if (controller.signal.aborted) return
         setCompany(data)
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchCompany()
+        setStatus('ready')
+      })
+      .catch(err => {
+        if (err.name === 'AbortError') return
+        console.error('Error fetching company:', err)
+        setStatus('failed')
+      })
+
+    return () => controller.abort()
   }, [slug])
 
   useEffect(() => {
@@ -68,28 +103,8 @@ export const Company = ({ slug }: { slug: string }) => {
     setSearchValue(neighborhood)
   }
 
-  if (loading) {
-    return (
-      <div className="flex h-full flex-col overflow-y-auto animate-pulse">
-        <div className="h-56 sm:h-64 bg-gray-200 shrink-0" />
-        <div className="px-6 lg:px-4 py-6 flex flex-col">
-          <div className="flex gap-2 mb-4">
-            <div className="h-8 w-24 bg-gray-200 rounded-full" />
-            <div className="h-8 w-24 bg-gray-200 rounded-full" />
-          </div>
-          <div className="space-y-2 mb-6">
-            <div className="h-4 bg-gray-200 rounded w-full" />
-            <div className="h-4 bg-gray-200 rounded w-3/4" />
-          </div>
-          <div className="space-y-3">
-            {[1, 2, 3].map(i => (
-              <div key={i} className="h-28 bg-gray-200 rounded" />
-            ))}
-          </div>
-        </div>
-      </div>
-    )
-  }
+  if (status === 'loading') return <CompanySkeleton />
+  if (status === 'failed') return <p>Couldn&apos;t load this company. Try again in a moment.</p>
   if (!company) return <p>Company not found</p>
 
   const { features } = formatDataToGeoJSON(company.shops || [])

--- a/app/components/Company.tsx
+++ b/app/components/Company.tsx
@@ -51,8 +51,6 @@ export const Company = ({ slug }: { slug: string }) => {
 
     const controller = new AbortController()
     fetchCompany(slug, controller.signal)
-      // abort() can't un-settle a request that already resolved, so this guards
-      // against a previous slug's response landing after a newer one took over.
       .then(data => {
         if (controller.signal.aborted) return
         setCompany(data)

--- a/app/components/CompanySkeleton.tsx
+++ b/app/components/CompanySkeleton.tsx
@@ -1,0 +1,22 @@
+export default function CompanySkeleton() {
+  return (
+    <div className="flex h-full flex-col overflow-y-auto animate-pulse">
+      <div className="h-56 sm:h-64 bg-gray-200 shrink-0" />
+      <div className="px-6 lg:px-4 py-6 flex flex-col">
+        <div className="flex gap-2 mb-4">
+          <div className="h-8 w-24 bg-gray-200 rounded-full" />
+          <div className="h-8 w-24 bg-gray-200 rounded-full" />
+        </div>
+        <div className="space-y-2 mb-6">
+          <div className="h-4 bg-gray-200 rounded w-full" />
+          <div className="h-4 bg-gray-200 rounded w-3/4" />
+        </div>
+        <div className="space-y-3">
+          {[1, 2, 3].map(i => (
+            <div key={i} className="h-28 bg-gray-200 rounded" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/RoasterDetails.tsx
+++ b/app/components/RoasterDetails.tsx
@@ -49,8 +49,6 @@ export const RoasterDetails = ({ slug }: { slug: string }) => {
 
     const controller = new AbortController()
     fetchRoaster(slug, controller.signal)
-      // abort() can't un-settle a request that already resolved, so this guards
-      // against a previous slug's response landing after a newer one took over.
       .then(data => {
         if (controller.signal.aborted) return
         setRoaster(data)

--- a/app/components/RoasterDetails.tsx
+++ b/app/components/RoasterDetails.tsx
@@ -29,26 +29,56 @@ interface TRoaster {
   shops?: DbShop[]
 }
 
+const RoasterSkeleton = () => (
+  <div className="flex h-full flex-col overflow-y-auto animate-pulse">
+    <div className="h-56 sm:h-64 bg-gray-200 shrink-0" />
+    <div className="px-6 lg:px-4 py-6 flex flex-col">
+      <div className="flex gap-2 mb-4">
+        <div className="h-8 w-24 bg-gray-200 rounded-full" />
+        <div className="h-8 w-24 bg-gray-200 rounded-full" />
+      </div>
+      <div className="space-y-2">
+        <div className="h-4 bg-gray-200 rounded w-full" />
+        <div className="h-4 bg-gray-200 rounded w-3/4" />
+      </div>
+    </div>
+  </div>
+)
+
+async function fetchRoaster(slug: string, signal: AbortSignal) {
+  const res = await fetch(`/api/roasters/${slug}`, { signal })
+  if (res.status === 404) return null
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json() as Promise<TRoaster>
+}
+
 export const RoasterDetails = ({ slug }: { slug: string }) => {
   const setOverrideShops = useShopsStore(s => s.setOverrideShops)
   const [roaster, setRoaster] = useState<TRoaster | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [status, setStatus] = useState<'loading' | 'ready' | 'failed'>('loading')
   const plausible = useAnalytics()
 
   useEffect(() => {
-    const fetchRoaster = async () => {
-      try {
-        const response = await fetch(`/api/roasters/${slug}`)
-        const data = await response.json()
+    setRoaster(null)
+    setStatus('loading')
+
+    const controller = new AbortController()
+    fetchRoaster(slug, controller.signal)
+      // abort() can't un-settle a request that already resolved, so this guards
+      // against a previous slug's response landing after a newer one took over.
+      .then(data => {
+        if (controller.signal.aborted) return
         setRoaster(data)
-        plausible('RoasterView', {
-          props: { roasterName: data.name, roasterSlug: slug },
-        })
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchRoaster()
+        setStatus('ready')
+        if (data) plausible('RoasterView', { props: { roasterName: data.name, roasterSlug: slug } })
+      })
+      .catch(err => {
+        if (err.name === 'AbortError') return
+        console.error('Error fetching roaster:', err)
+        setStatus('failed')
+      })
+
+    return () => controller.abort()
   }, [slug, plausible])
 
   useEffect(() => {
@@ -58,24 +88,14 @@ export const RoasterDetails = ({ slug }: { slug: string }) => {
     return () => setOverrideShops(null)
   }, [roaster, setOverrideShops])
 
-  if (loading) {
+  if (status === 'loading') return <RoasterSkeleton />
+  if (status === 'failed') {
     return (
-      <div className="flex h-full flex-col overflow-y-auto animate-pulse">
-        <div className="h-56 sm:h-64 bg-gray-200 shrink-0" />
-        <div className="px-6 lg:px-4 py-6 flex flex-col">
-          <div className="flex gap-2 mb-4">
-            <div className="h-8 w-24 bg-gray-200 rounded-full" />
-            <div className="h-8 w-24 bg-gray-200 rounded-full" />
-          </div>
-          <div className="space-y-2">
-            <div className="h-4 bg-gray-200 rounded w-full" />
-            <div className="h-4 bg-gray-200 rounded w-3/4" />
-          </div>
-        </div>
-      </div>
+      <p className="px-6 lg:px-4 mt-24 lg:mt-16">
+        Couldn&apos;t load this roaster. Try again in a moment.
+      </p>
     )
   }
-
   if (!roaster) return <p className="px-6 lg:px-4 mt-24 lg:mt-16">Roaster not found</p>
 
   return (

--- a/app/components/RoasterDetails.tsx
+++ b/app/components/RoasterDetails.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { useState, useEffect } from 'react'
 import { useAnalytics } from '@/hooks'
 import LocationList from '@/app/components/LocationList'
+import RoasterSkeleton from '@/app/components/RoasterSkeleton'
 import VerifiedBadge from '@/app/components/VerifiedBadge'
 import ClaimButton from '@/app/components/ClaimButton'
 import useShopsStore from '@/stores/coffeeShopsStore'
@@ -28,22 +29,6 @@ interface TRoaster {
   }
   shops?: DbShop[]
 }
-
-const RoasterSkeleton = () => (
-  <div className="flex h-full flex-col overflow-y-auto animate-pulse">
-    <div className="h-56 sm:h-64 bg-gray-200 shrink-0" />
-    <div className="px-6 lg:px-4 py-6 flex flex-col">
-      <div className="flex gap-2 mb-4">
-        <div className="h-8 w-24 bg-gray-200 rounded-full" />
-        <div className="h-8 w-24 bg-gray-200 rounded-full" />
-      </div>
-      <div className="space-y-2">
-        <div className="h-4 bg-gray-200 rounded w-full" />
-        <div className="h-4 bg-gray-200 rounded w-3/4" />
-      </div>
-    </div>
-  </div>
-)
 
 async function fetchRoaster(slug: string, signal: AbortSignal) {
   const res = await fetch(`/api/roasters/${slug}`, { signal })

--- a/app/components/RoasterSkeleton.tsx
+++ b/app/components/RoasterSkeleton.tsx
@@ -1,0 +1,17 @@
+export default function RoasterSkeleton() {
+  return (
+    <div className="flex h-full flex-col overflow-y-auto animate-pulse">
+      <div className="h-56 sm:h-64 bg-gray-200 shrink-0" />
+      <div className="px-6 lg:px-4 py-6 flex flex-col">
+        <div className="flex gap-2 mb-4">
+          <div className="h-8 w-24 bg-gray-200 rounded-full" />
+          <div className="h-8 w-24 bg-gray-200 rounded-full" />
+        </div>
+        <div className="space-y-2">
+          <div className="h-4 bg-gray-200 rounded w-full" />
+          <div className="h-4 bg-gray-200 rounded w-3/4" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/tests/unit/Company.test.tsx
+++ b/tests/unit/Company.test.tsx
@@ -1,0 +1,102 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { Company } from '@/app/components/Company'
+
+vi.mock('@/app/components/LocationList', () => ({
+  default: () => <div data-testid="location-list" />,
+}))
+
+vi.mock('@/stores/coffeeShopsStore', () => ({
+  default: (selector: (state: unknown) => unknown) =>
+    selector({ setOverrideShops: vi.fn(), setSearchValue: vi.fn() }),
+}))
+
+vi.mock('@/hooks', () => ({ useAnalytics: () => vi.fn() }))
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+
+const company = (overrides = {}) => ({
+  id: 'company-1',
+  name: 'Commonplace Coffee',
+  slug: 'commonplace-coffee',
+  is_verified: false,
+  shops: [],
+  ...overrides,
+})
+
+describe('Company', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('renders the company and offers a claim when it is unverified', async () => {
+    ;(fetch as any).mockResolvedValueOnce({ ok: true, status: 200, json: async () => company() })
+
+    render(<Company slug="commonplace-coffee" />)
+
+    await waitFor(() => expect(screen.getByText('Commonplace Coffee')).toBeInTheDocument())
+    expect(screen.getByText('Claim this brand')).toBeInTheDocument()
+  })
+
+  test('does not render a claimable empty company when the API 500s', async () => {
+    ;(fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'Error fetching company shops' }),
+    })
+
+    render(<Company slug="commonplace-coffee" />)
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load this company/)).toBeInTheDocument(),
+    )
+    expect(screen.queryByText('Claim this brand')).not.toBeInTheDocument()
+    expect(screen.queryByText('0 locations')).not.toBeInTheDocument()
+  })
+
+  test('reports a missing company as not found rather than as a failure', async () => {
+    ;(fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({ message: 'Company not found' }),
+    })
+
+    render(<Company slug="nope" />)
+
+    await waitFor(() => expect(screen.getByText('Company not found')).toBeInTheDocument())
+    expect(screen.queryByText('Claim this brand')).not.toBeInTheDocument()
+  })
+
+  test('survives a rejected fetch without leaving the panel on the skeleton', async () => {
+    ;(fetch as any).mockRejectedValueOnce(new Error('network down'))
+
+    render(<Company slug="commonplace-coffee" />)
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load this company/)).toBeInTheDocument(),
+    )
+  })
+
+  test('ignores a stale response that resolves after the slug already changed', async () => {
+    let resolveFirst: (value: unknown) => void = () => {}
+    ;(fetch as any).mockImplementationOnce(
+      () => new Promise(resolve => { resolveFirst = resolve }),
+    )
+
+    const { rerender } = render(<Company slug="commonplace-coffee" />)
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+
+    ;(fetch as any).mockImplementationOnce(() => new Promise(() => {}))
+    rerender(<Company slug="de-fer" />)
+
+    resolveFirst({ ok: true, status: 200, json: async () => company() })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(screen.queryByText('Commonplace Coffee')).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/RoasterDetails.test.tsx
+++ b/tests/unit/RoasterDetails.test.tsx
@@ -1,0 +1,112 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { RoasterDetails } from '@/app/components/RoasterDetails'
+
+vi.mock('@/app/components/LocationList', () => ({
+  default: () => <div data-testid="location-list" />,
+}))
+
+vi.mock('@/stores/coffeeShopsStore', () => ({
+  default: (selector: (state: unknown) => unknown) => selector({ setOverrideShops: vi.fn() }),
+}))
+
+// Stable identity, like the real useCallback-wrapped hook: a fresh function each
+// render would re-fire the fetch effect on every render.
+const plausible = vi.hoisted(() => vi.fn())
+vi.mock('@/hooks', () => ({ useAnalytics: () => plausible }))
+
+const roaster = (overrides = {}) => ({
+  id: 'roaster-1',
+  name: 'Allegheny Coffee Roasters',
+  slug: 'allegheny-coffee-roasters',
+  company_id: null,
+  logo: null,
+  website: null,
+  instagram: null,
+  description: null,
+  is_verified: false,
+  shops: [],
+  ...overrides,
+})
+
+describe('RoasterDetails', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('renders the roaster and offers a claim when it is unverified', async () => {
+    ;(fetch as any).mockResolvedValueOnce({ ok: true, status: 200, json: async () => roaster() })
+
+    render(<RoasterDetails slug="allegheny-coffee-roasters" />)
+
+    await waitFor(() =>
+      expect(screen.getByText('Allegheny Coffee Roasters')).toBeInTheDocument(),
+    )
+    expect(screen.getByText('Claim this roaster')).toBeInTheDocument()
+  })
+
+  test('does not render a claimable empty roaster when the API 500s', async () => {
+    ;(fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'Error fetching roaster shops' }),
+    })
+
+    render(<RoasterDetails slug="allegheny-coffee-roasters" />)
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load this roaster/)).toBeInTheDocument(),
+    )
+    expect(screen.queryByText('Claim this roaster')).not.toBeInTheDocument()
+  })
+
+  test('reports a missing roaster as not found rather than as a failure', async () => {
+    ;(fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({ message: 'Roaster not found' }),
+    })
+
+    render(<RoasterDetails slug="nope" />)
+
+    await waitFor(() => expect(screen.getByText('Roaster not found')).toBeInTheDocument())
+    expect(screen.queryByText('Claim this roaster')).not.toBeInTheDocument()
+  })
+
+  test('clears the previous roaster on slug change, before the new fetch settles', async () => {
+    ;(fetch as any).mockResolvedValueOnce({ ok: true, status: 200, json: async () => roaster() })
+
+    const { rerender } = render(<RoasterDetails slug="allegheny-coffee-roasters" />)
+    await waitFor(() =>
+      expect(screen.getByText('Allegheny Coffee Roasters')).toBeInTheDocument(),
+    )
+
+    ;(fetch as any).mockImplementationOnce(() => new Promise(() => {}))
+    rerender(<RoasterDetails slug="de-fer-roasting" />)
+
+    expect(screen.queryByText('Allegheny Coffee Roasters')).not.toBeInTheDocument()
+  })
+
+  test('ignores a stale response that resolves after the slug already changed', async () => {
+    let resolveFirst: (value: unknown) => void = () => {}
+    ;(fetch as any).mockImplementationOnce(
+      () => new Promise(resolve => { resolveFirst = resolve }),
+    )
+
+    const { rerender } = render(<RoasterDetails slug="allegheny-coffee-roasters" />)
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+
+    ;(fetch as any).mockImplementationOnce(() => new Promise(() => {}))
+    rerender(<RoasterDetails slug="de-fer-roasting" />)
+
+    resolveFirst({ ok: true, status: 200, json: async () => roaster() })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(screen.queryByText('Allegheny Coffee Roasters')).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/RoasterDetails.test.tsx
+++ b/tests/unit/RoasterDetails.test.tsx
@@ -10,8 +10,6 @@ vi.mock('@/stores/coffeeShopsStore', () => ({
   default: (selector: (state: unknown) => unknown) => selector({ setOverrideShops: vi.fn() }),
 }))
 
-// Stable identity, like the real useCallback-wrapped hook: a fresh function each
-// render would re-fire the fetch effect on every render.
 const plausible = vi.hoisted(() => vi.fn())
 vi.mock('@/hooks', () => ({ useAnalytics: () => plausible }))
 


### PR DESCRIPTION
Assume everything written below this line is AI slop

---


## What do these changes accomplish?

When the company or roaster API fails, the panel says so instead of rendering a blank-but-plausible brand with a "Claim this brand" button on it.

## Why?

Neither page checked whether its fetch actually succeeded. A 500 returns a JSON body like `{ "error": "Error fetching company shops" }`, and that body was stored as the company — truthy, so the page rendered a full brand page around it: an empty name in the hero, "0 locations · 0 neighborhoods", and, because the error body has no `is_verified` field, an invitation to claim a business that had not failed to exist, only failed to load. A 404 did the same thing. Someone could have submitted an ownership claim against a page built entirely out of an error message.

Neither fetch had a `catch` either, so a dropped connection left the panel stuck on the loading skeleton with an unhandled rejection in the console.

Separately, the roaster page never cleared its state when the slug changed. Clicking from one roaster to another kept the previous roaster on screen — name, description, claim button — until the new request came back, so for a moment the page showed the wrong business.

The two pages now handle a 404 as "not found", any other failed response as "couldn't load", and clear their state on navigation. Both also abort the in-flight request, so a slow response for a roaster you already navigated away from can't repaint the panel with it.

## Screenshots

| Before | After |
|---|---|
| <img width="1428" height="849" alt="image" src="https://github.com/user-attachments/assets/6c85342f-7503-4492-bbb4-344aca064072" />| <img width="1433" height="859" alt="image" src="https://github.com/user-attachments/assets/2178a48a-0a39-4df6-9c8d-a16543e9cbde" /> |
