### PR TITLE
fix(companies,roasters): release the panel when its route exits

### DIFF
--- a/app/utils/panelRoutes.ts
+++ b/app/utils/panelRoutes.ts
@@ -1,0 +1,13 @@
+const PANEL_PATH_PREFIXES = ['/shops/', '/events/', '/news/', '/roasters/', '/companies/']
+const PANEL_QUERY_PARAMS = ['company', 'roaster', 'news', 'event', 'events']
+
+/**
+ * Whether some route-sync hook owns the panel at this location. A route-sync
+ * hook exiting its own route uses this to decide between tearing the panel down
+ * and handing it to whichever hook owns the destination — those hooks fetch
+ * before they set content, so tearing down first would flash Explore and, worse,
+ * reset the history their panel is about to be pushed onto.
+ */
+export const isPanelOwnedRoute = (pathname: string, params: { has: (name: string) => boolean }) =>
+  PANEL_PATH_PREFIXES.some(prefix => pathname.startsWith(prefix)) ||
+  PANEL_QUERY_PARAMS.some(param => params.has(param))

--- a/app/utils/panelRoutes.ts
+++ b/app/utils/panelRoutes.ts
@@ -17,10 +17,9 @@ export const isPanelOwnedRoute = (pathname: string, params: { has: (name: string
   PANEL_PATH_PREFIXES.some(prefix => pathname.startsWith(prefix)) ||
   PANEL_QUERY_PARAMS.some(param => params.has(param))
 
-// Routes whose panel installs its own map filter (overrideShops). A hook leaving
-// for one of these must leave the filter alone: the destination's panel replaces
-// it once its fetch resolves, and clearing on the way out would un-filter the map
-// for the whole request.
+// Routes whose panel installs its own map filter (overrideShops), so a hook
+// leaving for one of these should not clear a filter it doesn't own — the other
+// hook's component is the one managing it.
 const MAP_FILTER_PATH_PREFIXES = ['/companies/', '/roasters/']
 
 export const ownsMapFilter = (pathname: string) =>

--- a/app/utils/panelRoutes.ts
+++ b/app/utils/panelRoutes.ts
@@ -16,3 +16,12 @@ const PANEL_QUERY_PARAMS = ['news', 'events']
 export const isPanelOwnedRoute = (pathname: string, params: { has: (name: string) => boolean }) =>
   PANEL_PATH_PREFIXES.some(prefix => pathname.startsWith(prefix)) ||
   PANEL_QUERY_PARAMS.some(param => params.has(param))
+
+// Routes whose panel installs its own map filter (overrideShops). A hook leaving
+// for one of these must leave the filter alone: the destination's panel replaces
+// it once its fetch resolves, and clearing on the way out would un-filter the map
+// for the whole request.
+const MAP_FILTER_PATH_PREFIXES = ['/companies/', '/roasters/']
+
+export const ownsMapFilter = (pathname: string) =>
+  MAP_FILTER_PATH_PREFIXES.some(prefix => pathname.startsWith(prefix))

--- a/app/utils/panelRoutes.ts
+++ b/app/utils/panelRoutes.ts
@@ -1,5 +1,10 @@
 const PANEL_PATH_PREFIXES = ['/shops/', '/events/', '/news/', '/roasters/', '/companies/']
-const PANEL_QUERY_PARAMS = ['company', 'roaster', 'news', 'event', 'events']
+
+// Only the params some hook actually reads: useNewsRouteSync reads `news`,
+// useEventRouteSync reads `events`. Listing a param nothing owns (`?company=`,
+// from before companies moved to their own route) would block the teardown for a
+// panel that never arrives.
+const PANEL_QUERY_PARAMS = ['news', 'events']
 
 /**
  * Whether some route-sync hook owns the panel at this location. A route-sync

--- a/hooks/useCompanyRouteSync.tsx
+++ b/hooks/useCompanyRouteSync.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useParams, usePathname } from 'next/navigation'
 import usePanelStore from '@/stores/panelStore'
 import { Company } from '@/app/components/Company'
+import { ExploreContent } from '@/app/components/ExploreContent'
 
 /**
  * Syncs the panel from the company route: `/companies/{slug}` opens a single
@@ -12,14 +13,23 @@ import { Company } from '@/app/components/Company'
 export const useCompanyRouteSync = () => {
   const { slug } = useParams<{ slug?: string }>()
   const pathname = usePathname()
-  const setPanelContent = usePanelStore(s => s.setPanelContent)
 
   const onCompanyRoute = pathname.startsWith('/companies/')
 
+  // Store actions are read via getState() rather than closed over so the effect
+  // depends only on `slug` and `onCompanyRoute` — no exhaustive-deps suppression.
   useEffect(() => {
     if (onCompanyRoute && slug) {
-      setPanelContent(<Company slug={slug} />, 'company')
+      usePanelStore.getState().setPanelContent(<Company slug={slug} />, 'company')
+      return
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+
+    // Leaving the company route (browser Back, say): drop the panel so <Company>
+    // unmounts and releases the overrideShops it set, otherwise the map on `/`
+    // stays filtered to that company. Guarded on the mode so we don't clobber a
+    // news/events/search panel that legitimately lives on the bare `/` route.
+    if (usePanelStore.getState().panelMode === 'company') {
+      usePanelStore.getState().reset({ mode: 'explore', content: <ExploreContent /> })
+    }
   }, [slug, onCompanyRoute])
 }

--- a/hooks/useCompanyRouteSync.tsx
+++ b/hooks/useCompanyRouteSync.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useParams, usePathname, useSearchParams } from 'next/navigation'
 import usePanelStore from '@/stores/panelStore'
+import useShopsStore from '@/stores/coffeeShopsStore'
 import { Company } from '@/app/components/Company'
 import { ExploreContent } from '@/app/components/ExploreContent'
 import { isPanelOwnedRoute } from '@/app/utils/panelRoutes'
@@ -27,12 +28,16 @@ export const useCompanyRouteSync = () => {
       return
     }
 
-    // Leaving the company route (browser Back, say): drop the panel so <Company>
-    // unmounts and releases the overrideShops it set, otherwise the map on `/`
-    // stays filtered to that company. Skip it when another route-sync hook owns
-    // the destination — it replaces the panel itself, and resetting here would
-    // wipe the history its entry is about to be pushed onto. The mode check keeps
-    // us off a news/events/search panel that legitimately lives on `/`.
+    // Leaving the company route always releases the map filter <Company> set.
+    // Waiting for its unmount isn't enough: on a handoff the destination's hook
+    // might never install its panel (a dead event slug, whose hook only logs), and
+    // the map would stay pinned to this company on a route that isn't its own.
+    useShopsStore.getState().setOverrideShops(null)
+
+    // The panel itself only comes down when no other route-sync hook owns the
+    // destination — resetting during a handoff would wipe the history its entry is
+    // about to be pushed onto. The mode check keeps us off a news/events/search
+    // panel that legitimately lives on the bare `/` route.
     if (destinationOwnsPanel) return
     if (usePanelStore.getState().panelMode === 'company') {
       usePanelStore.getState().reset({ mode: 'explore', content: <ExploreContent /> })

--- a/hooks/useCompanyRouteSync.tsx
+++ b/hooks/useCompanyRouteSync.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react'
-import { useParams, usePathname } from 'next/navigation'
+import { useParams, usePathname, useSearchParams } from 'next/navigation'
 import usePanelStore from '@/stores/panelStore'
 import { Company } from '@/app/components/Company'
 import { ExploreContent } from '@/app/components/ExploreContent'
+import { isPanelOwnedRoute } from '@/app/utils/panelRoutes'
 
 /**
  * Syncs the panel from the company route: `/companies/{slug}` opens a single
@@ -13,11 +14,13 @@ import { ExploreContent } from '@/app/components/ExploreContent'
 export const useCompanyRouteSync = () => {
   const { slug } = useParams<{ slug?: string }>()
   const pathname = usePathname()
+  const searchParams = useSearchParams()
 
   const onCompanyRoute = pathname.startsWith('/companies/')
+  const destinationOwnsPanel = isPanelOwnedRoute(pathname, searchParams)
 
   // Store actions are read via getState() rather than closed over so the effect
-  // depends only on `slug` and `onCompanyRoute` — no exhaustive-deps suppression.
+  // depends only on the values below — no exhaustive-deps suppression.
   useEffect(() => {
     if (onCompanyRoute && slug) {
       usePanelStore.getState().setPanelContent(<Company slug={slug} />, 'company')
@@ -26,10 +29,13 @@ export const useCompanyRouteSync = () => {
 
     // Leaving the company route (browser Back, say): drop the panel so <Company>
     // unmounts and releases the overrideShops it set, otherwise the map on `/`
-    // stays filtered to that company. Guarded on the mode so we don't clobber a
-    // news/events/search panel that legitimately lives on the bare `/` route.
+    // stays filtered to that company. Skip it when another route-sync hook owns
+    // the destination — it replaces the panel itself, and resetting here would
+    // wipe the history its entry is about to be pushed onto. The mode check keeps
+    // us off a news/events/search panel that legitimately lives on `/`.
+    if (destinationOwnsPanel) return
     if (usePanelStore.getState().panelMode === 'company') {
       usePanelStore.getState().reset({ mode: 'explore', content: <ExploreContent /> })
     }
-  }, [slug, onCompanyRoute])
+  }, [slug, onCompanyRoute, destinationOwnsPanel])
 }

--- a/hooks/useCompanyRouteSync.tsx
+++ b/hooks/useCompanyRouteSync.tsx
@@ -37,11 +37,15 @@ export const useCompanyRouteSync = () => {
     }
 
     // Leaving the company route releases the map filter <Company> set. Waiting for
-    // its unmount isn't enough: on a handoff the destination's hook might never
-    // install its panel (a transient /api/events failure, whose hook only logs),
-    // leaving the map pinned to this company on a route that isn't its own. The
-    // exception is a destination that installs its own filter — clearing there
-    // would un-filter the map for the length of its fetch.
+    // its unmount isn't enough: the destination's hook may replace the panel late,
+    // or not at all, leaving the map pinned to this company on a route that isn't
+    // its own.
+    //
+    // The exception is narrow: it stops this hook from clearing a filter it doesn't
+    // own on a /roasters/A -> /roasters/B move, where the slug dep re-fires this
+    // effect while <RoasterDetails> still holds A's state. It does NOT keep the map
+    // filtered across a company -> roaster move; <Company> unmounts there, and its
+    // own cleanup clears the filter for the length of the roaster fetch.
     if (!destinationOwnsMapFilter) useShopsStore.getState().setOverrideShops(null)
 
     // The panel itself only comes down when no other route-sync hook owns the

--- a/hooks/useCompanyRouteSync.tsx
+++ b/hooks/useCompanyRouteSync.tsx
@@ -1,10 +1,10 @@
 import { useEffect } from 'react'
 import { useParams, usePathname, useSearchParams } from 'next/navigation'
-import usePanelStore from '@/stores/panelStore'
+import usePanelStore, { getPanelSlug } from '@/stores/panelStore'
 import useShopsStore from '@/stores/coffeeShopsStore'
 import { Company } from '@/app/components/Company'
 import { ExploreContent } from '@/app/components/ExploreContent'
-import { isPanelOwnedRoute } from '@/app/utils/panelRoutes'
+import { isPanelOwnedRoute, ownsMapFilter } from '@/app/utils/panelRoutes'
 
 /**
  * Syncs the panel from the company route: `/companies/{slug}` opens a single
@@ -18,21 +18,31 @@ export const useCompanyRouteSync = () => {
   const searchParams = useSearchParams()
 
   const onCompanyRoute = pathname.startsWith('/companies/')
-  const destinationOwnsPanel = isPanelOwnedRoute(pathname, searchParams)
+  const destinationOwnsPanel = !onCompanyRoute && isPanelOwnedRoute(pathname, searchParams)
+  const destinationOwnsMapFilter = !onCompanyRoute && ownsMapFilter(pathname)
 
   // Store actions are read via getState() rather than closed over so the effect
   // depends only on the values below — no exhaustive-deps suppression.
   useEffect(() => {
     if (onCompanyRoute && slug) {
-      usePanelStore.getState().setPanelContent(<Company slug={slug} />, 'company')
+      const { panelMode, panelContent, setPanelContent } = usePanelStore.getState()
+
+      // The panel back button pops to the company entry and then navigates back to
+      // its route, which re-fires this effect. Pushing again would stack a
+      // duplicate entry and swallow the next back press.
+      if (panelMode === 'company' && getPanelSlug(panelContent) === slug) return
+
+      setPanelContent(<Company slug={slug} />, 'company')
       return
     }
 
-    // Leaving the company route always releases the map filter <Company> set.
-    // Waiting for its unmount isn't enough: on a handoff the destination's hook
-    // might never install its panel (a dead event slug, whose hook only logs), and
-    // the map would stay pinned to this company on a route that isn't its own.
-    useShopsStore.getState().setOverrideShops(null)
+    // Leaving the company route releases the map filter <Company> set. Waiting for
+    // its unmount isn't enough: on a handoff the destination's hook might never
+    // install its panel (a transient /api/events failure, whose hook only logs),
+    // leaving the map pinned to this company on a route that isn't its own. The
+    // exception is a destination that installs its own filter — clearing there
+    // would un-filter the map for the length of its fetch.
+    if (!destinationOwnsMapFilter) useShopsStore.getState().setOverrideShops(null)
 
     // The panel itself only comes down when no other route-sync hook owns the
     // destination — resetting during a handoff would wipe the history its entry is
@@ -42,5 +52,5 @@ export const useCompanyRouteSync = () => {
     if (usePanelStore.getState().panelMode === 'company') {
       usePanelStore.getState().reset({ mode: 'explore', content: <ExploreContent /> })
     }
-  }, [slug, onCompanyRoute, destinationOwnsPanel])
+  }, [slug, onCompanyRoute, destinationOwnsPanel, destinationOwnsMapFilter])
 }

--- a/hooks/useEventRouteSync.tsx
+++ b/hooks/useEventRouteSync.tsx
@@ -24,7 +24,14 @@ export const useEventRouteSync = () => {
       fetch(`/api/events/by-slug/${encodeURIComponent(slug)}`)
         .then(res => (res.ok ? res.json() : Promise.reject(new Error('Event not found'))))
         .then(event => setPanelContent(<EventDetails event={event} />, 'event'))
-        .catch(console.error)
+        .catch(err => {
+          // Fall back to the events list rather than installing nothing: the
+          // route-exit teardown in the other sync hooks stands down for
+          // /events/{slug} on the promise that this hook replaces the panel, so a
+          // failure here would strand whatever panel the user came from.
+          console.error(err)
+          setPanelContent(<Events />, 'events')
+        })
       return
     }
 

--- a/hooks/useRoasterRouteSync.tsx
+++ b/hooks/useRoasterRouteSync.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useParams, usePathname, useSearchParams } from 'next/navigation'
 import usePanelStore from '@/stores/panelStore'
+import useShopsStore from '@/stores/coffeeShopsStore'
 import { RoasterDetails } from '@/app/components/RoasterDetails'
 import { ExploreContent } from '@/app/components/ExploreContent'
 import { isPanelOwnedRoute } from '@/app/utils/panelRoutes'
@@ -29,6 +30,8 @@ export const useRoasterRouteSync = () => {
     // Same leak, and same handoff caveat, as the company route: <RoasterDetails>
     // only releases its overrideShops on unmount, so a panel that outlives its
     // route keeps the map filtered to that roaster's stockists on `/`.
+    useShopsStore.getState().setOverrideShops(null)
+
     if (destinationOwnsPanel) return
     if (usePanelStore.getState().panelMode === 'roaster') {
       usePanelStore.getState().reset({ mode: 'explore', content: <ExploreContent /> })

--- a/hooks/useRoasterRouteSync.tsx
+++ b/hooks/useRoasterRouteSync.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useParams, usePathname } from 'next/navigation'
 import usePanelStore from '@/stores/panelStore'
 import { RoasterDetails } from '@/app/components/RoasterDetails'
+import { ExploreContent } from '@/app/components/ExploreContent'
 
 /**
  * Syncs the panel from the roaster route: `/roasters/{slug}` opens a single
@@ -11,14 +12,22 @@ import { RoasterDetails } from '@/app/components/RoasterDetails'
 export const useRoasterRouteSync = () => {
   const { slug } = useParams<{ slug?: string }>()
   const pathname = usePathname()
-  const setPanelContent = usePanelStore(s => s.setPanelContent)
 
   const onRoasterRoute = pathname.startsWith('/roasters/')
 
+  // Store actions are read via getState() rather than closed over so the effect
+  // depends only on `slug` and `onRoasterRoute` — no exhaustive-deps suppression.
   useEffect(() => {
     if (onRoasterRoute && slug) {
-      setPanelContent(<RoasterDetails slug={slug} />, 'roaster')
+      usePanelStore.getState().setPanelContent(<RoasterDetails slug={slug} />, 'roaster')
+      return
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+
+    // Same leak as the company route: <RoasterDetails> only releases its
+    // overrideShops on unmount, so a panel that outlives its route keeps the map
+    // filtered to that roaster's stockists on `/`.
+    if (usePanelStore.getState().panelMode === 'roaster') {
+      usePanelStore.getState().reset({ mode: 'explore', content: <ExploreContent /> })
+    }
   }, [slug, onRoasterRoute])
 }

--- a/hooks/useRoasterRouteSync.tsx
+++ b/hooks/useRoasterRouteSync.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react'
-import { useParams, usePathname } from 'next/navigation'
+import { useParams, usePathname, useSearchParams } from 'next/navigation'
 import usePanelStore from '@/stores/panelStore'
 import { RoasterDetails } from '@/app/components/RoasterDetails'
 import { ExploreContent } from '@/app/components/ExploreContent'
+import { isPanelOwnedRoute } from '@/app/utils/panelRoutes'
 
 /**
  * Syncs the panel from the roaster route: `/roasters/{slug}` opens a single
@@ -12,22 +13,25 @@ import { ExploreContent } from '@/app/components/ExploreContent'
 export const useRoasterRouteSync = () => {
   const { slug } = useParams<{ slug?: string }>()
   const pathname = usePathname()
+  const searchParams = useSearchParams()
 
   const onRoasterRoute = pathname.startsWith('/roasters/')
+  const destinationOwnsPanel = isPanelOwnedRoute(pathname, searchParams)
 
   // Store actions are read via getState() rather than closed over so the effect
-  // depends only on `slug` and `onRoasterRoute` — no exhaustive-deps suppression.
+  // depends only on the values below — no exhaustive-deps suppression.
   useEffect(() => {
     if (onRoasterRoute && slug) {
       usePanelStore.getState().setPanelContent(<RoasterDetails slug={slug} />, 'roaster')
       return
     }
 
-    // Same leak as the company route: <RoasterDetails> only releases its
-    // overrideShops on unmount, so a panel that outlives its route keeps the map
-    // filtered to that roaster's stockists on `/`.
+    // Same leak, and same handoff caveat, as the company route: <RoasterDetails>
+    // only releases its overrideShops on unmount, so a panel that outlives its
+    // route keeps the map filtered to that roaster's stockists on `/`.
+    if (destinationOwnsPanel) return
     if (usePanelStore.getState().panelMode === 'roaster') {
       usePanelStore.getState().reset({ mode: 'explore', content: <ExploreContent /> })
     }
-  }, [slug, onRoasterRoute])
+  }, [slug, onRoasterRoute, destinationOwnsPanel])
 }

--- a/hooks/useRoasterRouteSync.tsx
+++ b/hooks/useRoasterRouteSync.tsx
@@ -1,10 +1,10 @@
 import { useEffect } from 'react'
 import { useParams, usePathname, useSearchParams } from 'next/navigation'
-import usePanelStore from '@/stores/panelStore'
+import usePanelStore, { getPanelSlug } from '@/stores/panelStore'
 import useShopsStore from '@/stores/coffeeShopsStore'
 import { RoasterDetails } from '@/app/components/RoasterDetails'
 import { ExploreContent } from '@/app/components/ExploreContent'
-import { isPanelOwnedRoute } from '@/app/utils/panelRoutes'
+import { isPanelOwnedRoute, ownsMapFilter } from '@/app/utils/panelRoutes'
 
 /**
  * Syncs the panel from the roaster route: `/roasters/{slug}` opens a single
@@ -17,24 +17,32 @@ export const useRoasterRouteSync = () => {
   const searchParams = useSearchParams()
 
   const onRoasterRoute = pathname.startsWith('/roasters/')
-  const destinationOwnsPanel = isPanelOwnedRoute(pathname, searchParams)
+  const destinationOwnsPanel = !onRoasterRoute && isPanelOwnedRoute(pathname, searchParams)
+  const destinationOwnsMapFilter = !onRoasterRoute && ownsMapFilter(pathname)
 
   // Store actions are read via getState() rather than closed over so the effect
   // depends only on the values below — no exhaustive-deps suppression.
   useEffect(() => {
     if (onRoasterRoute && slug) {
-      usePanelStore.getState().setPanelContent(<RoasterDetails slug={slug} />, 'roaster')
+      const { panelMode, panelContent, setPanelContent } = usePanelStore.getState()
+
+      // Same duplicate-entry guard as the company route: the panel back button
+      // navigates back here, re-firing this effect on a panel that already shows
+      // this roaster.
+      if (panelMode === 'roaster' && getPanelSlug(panelContent) === slug) return
+
+      setPanelContent(<RoasterDetails slug={slug} />, 'roaster')
       return
     }
 
-    // Same leak, and same handoff caveat, as the company route: <RoasterDetails>
+    // Same leak, and same handoff caveats, as the company route: <RoasterDetails>
     // only releases its overrideShops on unmount, so a panel that outlives its
     // route keeps the map filtered to that roaster's stockists on `/`.
-    useShopsStore.getState().setOverrideShops(null)
+    if (!destinationOwnsMapFilter) useShopsStore.getState().setOverrideShops(null)
 
     if (destinationOwnsPanel) return
     if (usePanelStore.getState().panelMode === 'roaster') {
       usePanelStore.getState().reset({ mode: 'explore', content: <ExploreContent /> })
     }
-  }, [slug, onRoasterRoute, destinationOwnsPanel])
+  }, [slug, onRoasterRoute, destinationOwnsPanel, destinationOwnsMapFilter])
 }

--- a/stores/panelStore.ts
+++ b/stores/panelStore.ts
@@ -50,16 +50,14 @@ function getURLParamForEntry(entry: PanelEntry): URLTarget | null {
         }
       }
       return null
-    case 'company':
-      if (hasProps(content, 'slug') && content.props.slug) {
-        return { type: 'path', value: `/companies/${content.props.slug as string}` }
-      }
-      return null
-    case 'roaster':
-      if (hasProps(content, 'slug') && content.props.slug) {
-        return { type: 'path', value: `/roasters/${content.props.slug as string}` }
-      }
-      return null
+    case 'company': {
+      const slug = getPanelSlug(content)
+      return slug ? { type: 'path', value: `/companies/${slug}` } : null
+    }
+    case 'roaster': {
+      const slug = getPanelSlug(content)
+      return slug ? { type: 'path', value: `/roasters/${slug}` } : null
+    }
     case 'news': {
       const news = getPanelNewsItem(content)
       if (news?.id && news?.title) {

--- a/stores/panelStore.ts
+++ b/stores/panelStore.ts
@@ -28,6 +28,10 @@ function hasProps<K extends string>(
   )
 }
 
+export function getPanelSlug(content: ReactNode) {
+  return hasProps(content, 'slug') ? (content.props.slug as string) : undefined
+}
+
 export function getPanelNewsItem(content: ReactNode) {
   return hasProps(content, 'news') ? (content.props.news as Pick<NewsItem, 'id' | 'title'>) : undefined
 }

--- a/tests/unit/panelRoutes.test.ts
+++ b/tests/unit/panelRoutes.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from 'vitest'
+import { isPanelOwnedRoute } from '@/app/utils/panelRoutes'
+
+const at = (url: string) => {
+  const { pathname, searchParams } = new URL(url, 'https://pgh.coffee')
+  return isPanelOwnedRoute(pathname, searchParams)
+}
+
+describe('isPanelOwnedRoute', () => {
+  test('claims the detail routes that each have a route-sync hook', () => {
+    expect(at('/shops/klvn-larimer-e3bd219a')).toBe(true)
+    expect(at('/companies/commonplace-coffee-co')).toBe(true)
+    expect(at('/roasters/commonplace-roasting')).toBe(true)
+    expect(at('/news/a-new-shop-a1b2c3d4')).toBe(true)
+    expect(at('/events/latte-art-throwdown-a1b2c3d4')).toBe(true)
+  })
+
+  test('claims the list params a hook actually reads', () => {
+    expect(at('/?news')).toBe(true)
+    expect(at('/?events')).toBe(true)
+  })
+
+  test('leaves the bare map route unclaimed', () => {
+    expect(at('/')).toBe(false)
+    expect(at('/?neighborhood=Bloomfield')).toBe(false)
+  })
+
+  test('does not claim params no hook installs a panel for', () => {
+    // Legacy query params from before these moved to their own routes: claiming
+    // them would block a teardown while waiting on a panel that never arrives.
+    expect(at('/?company=commonplace-coffee-co')).toBe(false)
+    expect(at('/?roaster=commonplace-roasting')).toBe(false)
+  })
+})

--- a/tests/unit/routeSyncPanelHistory.test.tsx
+++ b/tests/unit/routeSyncPanelHistory.test.tsx
@@ -73,17 +73,54 @@ describe('route sync panel history', () => {
     expect(modes()).toEqual(['explore'])
   })
 
-  test('releases the map filter on exit even when the destination owns the panel', () => {
-    // /events/{slug} installs its panel asynchronously and only logs on failure,
-    // so a dead slug would otherwise leave <Company> mounted — and the map pinned
-    // to that company — on a route that isn't /companies/.
+  test('does not re-push the company entry when the panel back button returns to it', () => {
+    h.slug = 'commonplace-coffee-co'
+    h.pathname = '/companies/commonplace-coffee-co'
+    const { rerender } = renderRouteSyncs()
+
+    h.slug = 'commonplace-roasting'
+    h.pathname = '/roasters/commonplace-roasting'
+    rerender()
+
+    // The panel back button pops to the company entry and navigates back to its
+    // route; the route catching up must not push a second company entry, or the
+    // next back press looks like it does nothing.
+    usePanelStore.getState().back()
+    h.slug = 'commonplace-coffee-co'
+    h.pathname = '/companies/commonplace-coffee-co'
+    rerender()
+
+    expect(modes()).toEqual(['company'])
+  })
+
+  test('keeps the map filter when handing off to another filter-owning route', () => {
+    h.slug = 'commonplace-roasting'
+    h.pathname = '/roasters/commonplace-roasting'
+    const { rerender } = renderRouteSyncs()
+    const filter = { type: 'FeatureCollection' as const, features: [] }
+    useShopsStore.getState().setOverrideShops(filter)
+
+    h.slug = 'de-fer-roasting'
+    h.pathname = '/roasters/de-fer-roasting'
+    rerender()
+
+    // <RoasterDetails> installs the new filter once its fetch resolves; clearing
+    // it here would un-filter the map for the whole request.
+    expect(useShopsStore.getState().overrideShops).toBe(filter)
+  })
+
+  test('releases the map filter when the destination panel never arrives', () => {
+    // A valid /events/{slug} whose fetch fails: useEventRouteSync only logs, so no
+    // panel replaces <Company> and it stays mounted with the map pinned to that
+    // company. (A *dead* slug can't reach this — the page calls notFound(), which
+    // unmounts the map layout and the panel with it.)
     h.slug = 'commonplace-coffee-co'
     h.pathname = '/companies/commonplace-coffee-co'
     const { rerender } = renderRouteSyncs()
     useShopsStore.getState().setOverrideShops({ type: 'FeatureCollection', features: [] })
 
-    h.slug = 'a-dead-event-slug'
-    h.pathname = '/events/a-dead-event-slug'
+    h.slug = 'latte-art-throwdown-a1b2c3d4'
+    h.pathname = '/events/latte-art-throwdown-a1b2c3d4'
     rerender()
 
     expect(useShopsStore.getState().overrideShops).toBeNull()

--- a/tests/unit/routeSyncPanelHistory.test.tsx
+++ b/tests/unit/routeSyncPanelHistory.test.tsx
@@ -1,0 +1,87 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useCompanyRouteSync } from '@/hooks/useCompanyRouteSync'
+import { useRoasterRouteSync } from '@/hooks/useRoasterRouteSync'
+import usePanelStore from '@/stores/panelStore'
+
+const h = vi.hoisted(() => ({ slug: undefined as string | undefined, pathname: '/', search: '' }))
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ slug: h.slug }),
+  usePathname: () => h.pathname,
+  useSearchParams: () => new URLSearchParams(h.search),
+}))
+vi.mock('@/app/components/Company', () => ({ Company: () => null }))
+vi.mock('@/app/components/RoasterDetails', () => ({ RoasterDetails: () => null }))
+vi.mock('@/app/components/ExploreContent', () => ({ ExploreContent: () => null }))
+
+// HomeClient calls the company hook before the roaster hook, so a
+// company -> roaster navigation runs the company teardown first. It must not
+// wipe the history the roaster panel is about to be pushed onto.
+const renderRouteSyncs = () =>
+  renderHook(() => {
+    useCompanyRouteSync()
+    useRoasterRouteSync()
+  })
+
+const modes = () => usePanelStore.getState().history.map(entry => entry.mode)
+
+describe('route sync panel history', () => {
+  beforeEach(() => {
+    usePanelStore.getState().reset({ mode: 'explore', content: null })
+    usePanelStore.getState().clearHistory()
+    h.slug = undefined
+    h.pathname = '/'
+    h.search = ''
+  })
+
+  test('keeps the company entry when navigating to its in-house roaster', () => {
+    h.slug = 'commonplace-coffee-co'
+    h.pathname = '/companies/commonplace-coffee-co'
+    const { rerender } = renderRouteSyncs()
+
+    h.slug = 'commonplace-roasting'
+    h.pathname = '/roasters/commonplace-roasting'
+    rerender()
+
+    expect(modes()).toEqual(['company', 'roaster'])
+  })
+
+  test('keeps the roaster entry when navigating to its parent company', () => {
+    h.slug = 'commonplace-roasting'
+    h.pathname = '/roasters/commonplace-roasting'
+    const { rerender } = renderRouteSyncs()
+
+    h.slug = 'commonplace-coffee-co'
+    h.pathname = '/companies/commonplace-coffee-co'
+    rerender()
+
+    expect(modes()).toEqual(['roaster', 'company'])
+  })
+
+  test('drops the company panel when landing on the bare map route', () => {
+    h.slug = 'commonplace-coffee-co'
+    h.pathname = '/companies/commonplace-coffee-co'
+    const { rerender } = renderRouteSyncs()
+
+    h.slug = undefined
+    h.pathname = '/'
+    rerender()
+
+    expect(usePanelStore.getState().panelMode).toBe('explore')
+    expect(modes()).toEqual(['explore'])
+  })
+
+  test('leaves the panel alone when a query param owns it on /', () => {
+    h.slug = 'commonplace-coffee-co'
+    h.pathname = '/companies/commonplace-coffee-co'
+    const { rerender } = renderRouteSyncs()
+
+    h.slug = undefined
+    h.pathname = '/'
+    h.search = '?news'
+    rerender()
+
+    expect(usePanelStore.getState().panelMode).toBe('company')
+  })
+})

--- a/tests/unit/routeSyncPanelHistory.test.tsx
+++ b/tests/unit/routeSyncPanelHistory.test.tsx
@@ -30,6 +30,7 @@ describe('route sync panel history', () => {
   beforeEach(() => {
     usePanelStore.getState().reset({ mode: 'explore', content: null })
     usePanelStore.getState().clearHistory()
+    useShopsStore.getState().setOverrideShops(null)
     h.slug = undefined
     h.pathname = '/'
     h.search = ''
@@ -70,6 +71,22 @@ describe('route sync panel history', () => {
 
     expect(usePanelStore.getState().panelMode).toBe('explore')
     expect(modes()).toEqual(['explore'])
+  })
+
+  test('releases the map filter on exit even when the destination owns the panel', () => {
+    // /events/{slug} installs its panel asynchronously and only logs on failure,
+    // so a dead slug would otherwise leave <Company> mounted — and the map pinned
+    // to that company — on a route that isn't /companies/.
+    h.slug = 'commonplace-coffee-co'
+    h.pathname = '/companies/commonplace-coffee-co'
+    const { rerender } = renderRouteSyncs()
+    useShopsStore.getState().setOverrideShops({ type: 'FeatureCollection', features: [] })
+
+    h.slug = 'a-dead-event-slug'
+    h.pathname = '/events/a-dead-event-slug'
+    rerender()
+
+    expect(useShopsStore.getState().overrideShops).toBeNull()
   })
 
   test('leaves the panel alone when a query param owns it on /', () => {

--- a/tests/unit/routeSyncPanelHistory.test.tsx
+++ b/tests/unit/routeSyncPanelHistory.test.tsx
@@ -3,6 +3,7 @@ import { renderHook } from '@testing-library/react'
 import { useCompanyRouteSync } from '@/hooks/useCompanyRouteSync'
 import { useRoasterRouteSync } from '@/hooks/useRoasterRouteSync'
 import usePanelStore from '@/stores/panelStore'
+import useShopsStore from '@/stores/coffeeShopsStore'
 
 const h = vi.hoisted(() => ({ slug: undefined as string | undefined, pathname: '/', search: '' }))
 
@@ -109,11 +110,10 @@ describe('route sync panel history', () => {
     expect(useShopsStore.getState().overrideShops).toBe(filter)
   })
 
-  test('releases the map filter when the destination panel never arrives', () => {
-    // A valid /events/{slug} whose fetch fails: useEventRouteSync only logs, so no
-    // panel replaces <Company> and it stays mounted with the map pinned to that
-    // company. (A *dead* slug can't reach this — the page calls notFound(), which
-    // unmounts the map layout and the panel with it.)
+  test('releases the map filter as soon as the route leaves', () => {
+    // The destination's hook installs its panel from a fetch, so <Company> stays
+    // mounted — with the map pinned to that company — until it lands. The filter
+    // is the route's, not the panel's, so it goes now rather than on unmount.
     h.slug = 'commonplace-coffee-co'
     h.pathname = '/companies/commonplace-coffee-co'
     const { rerender } = renderRouteSyncs()

--- a/tests/unit/useCompanyRouteSync.test.tsx
+++ b/tests/unit/useCompanyRouteSync.test.tsx
@@ -5,12 +5,17 @@ import { useCompanyRouteSync } from '@/hooks/useCompanyRouteSync'
 const h = vi.hoisted(() => ({
   slug: undefined as string | undefined,
   pathname: '/' as string,
+  search: '' as string,
   panelMode: 'explore' as string,
   setPanelContent: vi.fn(),
   reset: vi.fn(),
 }))
 
-vi.mock('next/navigation', () => ({ useParams: () => ({ slug: h.slug }), usePathname: () => h.pathname }))
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ slug: h.slug }),
+  usePathname: () => h.pathname,
+  useSearchParams: () => new URLSearchParams(h.search),
+}))
 vi.mock('@/stores/panelStore', () => {
   const getState = () => ({
     panelMode: h.panelMode,
@@ -30,6 +35,7 @@ describe('useCompanyRouteSync', () => {
     vi.clearAllMocks()
     h.slug = undefined
     h.pathname = '/'
+    h.search = ''
     h.panelMode = 'explore'
   })
 
@@ -72,6 +78,18 @@ describe('useCompanyRouteSync', () => {
     // the company route must not reset a panel it never owned.
     h.panelMode = 'news'
     h.pathname = '/'
+
+    renderHook(() => useCompanyRouteSync())
+
+    expect(h.reset).not.toHaveBeenCalled()
+  })
+
+  test('hands the panel over instead of tearing it down when another route owns it', () => {
+    // The roaster hook replaces the panel itself; resetting here would wipe the
+    // history its entry is about to be pushed onto, breaking the back arrow.
+    h.panelMode = 'company'
+    h.slug = 'commonplace-roasting'
+    h.pathname = '/roasters/commonplace-roasting'
 
     renderHook(() => useCompanyRouteSync())
 

--- a/tests/unit/useCompanyRouteSync.test.tsx
+++ b/tests/unit/useCompanyRouteSync.test.tsx
@@ -7,6 +7,7 @@ const h = vi.hoisted(() => ({
   pathname: '/' as string,
   search: '' as string,
   panelMode: 'explore' as string,
+  panelSlug: undefined as string | undefined,
   setPanelContent: vi.fn(),
   reset: vi.fn(),
 }))
@@ -19,13 +20,14 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/stores/panelStore', () => {
   const getState = () => ({
     panelMode: h.panelMode,
+    panelContent: null,
     setPanelContent: h.setPanelContent,
     reset: h.reset,
   })
   const usePanelStore = (selector?: (s: unknown) => unknown) =>
     selector ? selector(getState()) : getState()
   usePanelStore.getState = getState
-  return { __esModule: true, default: usePanelStore }
+  return { __esModule: true, default: usePanelStore, getPanelSlug: () => h.panelSlug }
 })
 vi.mock('@/app/components/Company', () => ({ Company: () => null }))
 vi.mock('@/app/components/ExploreContent', () => ({ ExploreContent: () => null }))
@@ -37,6 +39,7 @@ describe('useCompanyRouteSync', () => {
     h.pathname = '/'
     h.search = ''
     h.panelMode = 'explore'
+    h.panelSlug = undefined
   })
 
   test('opens the company panel when on a /companies/{slug} route', () => {
@@ -82,6 +85,17 @@ describe('useCompanyRouteSync', () => {
     renderHook(() => useCompanyRouteSync())
 
     expect(h.reset).not.toHaveBeenCalled()
+  })
+
+  test('does not re-push a panel that already shows this company', () => {
+    h.panelMode = 'company'
+    h.panelSlug = 'commonplace-coffee-co'
+    h.slug = 'commonplace-coffee-co'
+    h.pathname = '/companies/commonplace-coffee-co'
+
+    renderHook(() => useCompanyRouteSync())
+
+    expect(h.setPanelContent).not.toHaveBeenCalled()
   })
 
   test('hands the panel over instead of tearing it down when another route owns it', () => {

--- a/tests/unit/useCompanyRouteSync.test.tsx
+++ b/tests/unit/useCompanyRouteSync.test.tsx
@@ -5,24 +5,32 @@ import { useCompanyRouteSync } from '@/hooks/useCompanyRouteSync'
 const h = vi.hoisted(() => ({
   slug: undefined as string | undefined,
   pathname: '/' as string,
+  panelMode: 'explore' as string,
   setPanelContent: vi.fn(),
+  reset: vi.fn(),
 }))
 
 vi.mock('next/navigation', () => ({ useParams: () => ({ slug: h.slug }), usePathname: () => h.pathname }))
-vi.mock('@/stores/panelStore', () => ({
-  __esModule: true,
-  default: (selector?: (s: unknown) => unknown) => {
-    const state = { setPanelContent: h.setPanelContent }
-    return selector ? selector(state) : state
-  },
-}))
+vi.mock('@/stores/panelStore', () => {
+  const getState = () => ({
+    panelMode: h.panelMode,
+    setPanelContent: h.setPanelContent,
+    reset: h.reset,
+  })
+  const usePanelStore = (selector?: (s: unknown) => unknown) =>
+    selector ? selector(getState()) : getState()
+  usePanelStore.getState = getState
+  return { __esModule: true, default: usePanelStore }
+})
 vi.mock('@/app/components/Company', () => ({ Company: () => null }))
+vi.mock('@/app/components/ExploreContent', () => ({ ExploreContent: () => null }))
 
 describe('useCompanyRouteSync', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     h.slug = undefined
     h.pathname = '/'
+    h.panelMode = 'explore'
   })
 
   test('opens the company panel when on a /companies/{slug} route', () => {
@@ -43,5 +51,45 @@ describe('useCompanyRouteSync', () => {
     renderHook(() => useCompanyRouteSync())
 
     expect(h.setPanelContent).not.toHaveBeenCalled()
+  })
+
+  test('tears the company panel down when the route leaves /companies', () => {
+    h.slug = 'commonplace-coffee-co'
+    h.pathname = '/companies/commonplace-coffee-co'
+
+    const { rerender } = renderHook(() => useCompanyRouteSync())
+
+    h.panelMode = 'company'
+    h.slug = undefined
+    h.pathname = '/'
+    rerender()
+
+    expect(h.reset).toHaveBeenCalledWith({ mode: 'explore', content: expect.anything() })
+  })
+
+  test('leaves a non-company panel that lives on / alone', () => {
+    // /?news and /?events render their panels on the bare `/` route, so exiting
+    // the company route must not reset a panel it never owned.
+    h.panelMode = 'news'
+    h.pathname = '/'
+
+    renderHook(() => useCompanyRouteSync())
+
+    expect(h.reset).not.toHaveBeenCalled()
+  })
+
+  test('does not tear down while moving between two companies', () => {
+    h.slug = 'commonplace-coffee-co'
+    h.pathname = '/companies/commonplace-coffee-co'
+
+    const { rerender } = renderHook(() => useCompanyRouteSync())
+
+    h.panelMode = 'company'
+    h.slug = 'de-fer-coffee-tea'
+    h.pathname = '/companies/de-fer-coffee-tea'
+    rerender()
+
+    expect(h.reset).not.toHaveBeenCalled()
+    expect(h.setPanelContent).toHaveBeenCalledTimes(2)
   })
 })

--- a/tests/unit/useEventRouteSync.test.tsx
+++ b/tests/unit/useEventRouteSync.test.tsx
@@ -1,0 +1,62 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useEventRouteSync } from '@/hooks/useEventRouteSync'
+
+const h = vi.hoisted(() => ({
+  slug: undefined as string | undefined,
+  pathname: '/' as string,
+  search: '' as string,
+  setPanelContent: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ slug: h.slug }),
+  usePathname: () => h.pathname,
+  useSearchParams: () => new URLSearchParams(h.search),
+}))
+vi.mock('@/stores/panelStore', () => ({
+  __esModule: true,
+  default: (selector?: (s: unknown) => unknown) => {
+    const state = { setPanelContent: h.setPanelContent }
+    return selector ? selector(state) : state
+  },
+}))
+vi.mock('@/app/components/EventDetails', () => ({ EventDetails: () => null }))
+vi.mock('@/app/components/Events', () => ({ Events: () => null }))
+
+describe('useEventRouteSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    h.slug = undefined
+    h.pathname = '/'
+    h.search = ''
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  test('opens the event panel for a /events/{slug} route', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ id: '1' }) }))
+    h.slug = 'latte-art-throwdown-a1b2c3d4'
+    h.pathname = '/events/latte-art-throwdown-a1b2c3d4'
+
+    renderHook(() => useEventRouteSync())
+
+    await waitFor(() =>
+      expect(h.setPanelContent).toHaveBeenCalledWith(expect.anything(), 'event'),
+    )
+  })
+
+  test('falls back to the events list when the event fetch fails', async () => {
+    // The other sync hooks stand down their route-exit teardown for /events/{slug}
+    // on the promise that this hook installs a panel, so a failure that installed
+    // nothing would strand the panel the user navigated from.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }))
+    h.slug = 'latte-art-throwdown-a1b2c3d4'
+    h.pathname = '/events/latte-art-throwdown-a1b2c3d4'
+
+    renderHook(() => useEventRouteSync())
+
+    await waitFor(() =>
+      expect(h.setPanelContent).toHaveBeenCalledWith(expect.anything(), 'events'),
+    )
+  })
+})

--- a/tests/unit/useRoasterRouteSync.test.tsx
+++ b/tests/unit/useRoasterRouteSync.test.tsx
@@ -5,24 +5,32 @@ import { useRoasterRouteSync } from '@/hooks/useRoasterRouteSync'
 const h = vi.hoisted(() => ({
   slug: undefined as string | undefined,
   pathname: '/' as string,
+  panelMode: 'explore' as string,
   setPanelContent: vi.fn(),
+  reset: vi.fn(),
 }))
 
 vi.mock('next/navigation', () => ({ useParams: () => ({ slug: h.slug }), usePathname: () => h.pathname }))
-vi.mock('@/stores/panelStore', () => ({
-  __esModule: true,
-  default: (selector?: (s: unknown) => unknown) => {
-    const state = { setPanelContent: h.setPanelContent }
-    return selector ? selector(state) : state
-  },
-}))
+vi.mock('@/stores/panelStore', () => {
+  const getState = () => ({
+    panelMode: h.panelMode,
+    setPanelContent: h.setPanelContent,
+    reset: h.reset,
+  })
+  const usePanelStore = (selector?: (s: unknown) => unknown) =>
+    selector ? selector(getState()) : getState()
+  usePanelStore.getState = getState
+  return { __esModule: true, default: usePanelStore }
+})
 vi.mock('@/app/components/RoasterDetails', () => ({ RoasterDetails: () => null }))
+vi.mock('@/app/components/ExploreContent', () => ({ ExploreContent: () => null }))
 
 describe('useRoasterRouteSync', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     h.slug = undefined
     h.pathname = '/'
+    h.panelMode = 'explore'
   })
 
   test('opens the roaster panel when on a /roasters/{slug} route', () => {
@@ -43,5 +51,28 @@ describe('useRoasterRouteSync', () => {
     renderHook(() => useRoasterRouteSync())
 
     expect(h.setPanelContent).not.toHaveBeenCalled()
+  })
+
+  test('tears the roaster panel down when the route leaves /roasters', () => {
+    h.slug = 'commonplace-coffee'
+    h.pathname = '/roasters/commonplace-coffee'
+
+    const { rerender } = renderHook(() => useRoasterRouteSync())
+
+    h.panelMode = 'roaster'
+    h.slug = undefined
+    h.pathname = '/'
+    rerender()
+
+    expect(h.reset).toHaveBeenCalledWith({ mode: 'explore', content: expect.anything() })
+  })
+
+  test('leaves a non-roaster panel that lives on / alone', () => {
+    h.panelMode = 'events'
+    h.pathname = '/'
+
+    renderHook(() => useRoasterRouteSync())
+
+    expect(h.reset).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/useRoasterRouteSync.test.tsx
+++ b/tests/unit/useRoasterRouteSync.test.tsx
@@ -5,12 +5,17 @@ import { useRoasterRouteSync } from '@/hooks/useRoasterRouteSync'
 const h = vi.hoisted(() => ({
   slug: undefined as string | undefined,
   pathname: '/' as string,
+  search: '' as string,
   panelMode: 'explore' as string,
   setPanelContent: vi.fn(),
   reset: vi.fn(),
 }))
 
-vi.mock('next/navigation', () => ({ useParams: () => ({ slug: h.slug }), usePathname: () => h.pathname }))
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ slug: h.slug }),
+  usePathname: () => h.pathname,
+  useSearchParams: () => new URLSearchParams(h.search),
+}))
 vi.mock('@/stores/panelStore', () => {
   const getState = () => ({
     panelMode: h.panelMode,
@@ -30,6 +35,7 @@ describe('useRoasterRouteSync', () => {
     vi.clearAllMocks()
     h.slug = undefined
     h.pathname = '/'
+    h.search = ''
     h.panelMode = 'explore'
   })
 
@@ -65,6 +71,18 @@ describe('useRoasterRouteSync', () => {
     rerender()
 
     expect(h.reset).toHaveBeenCalledWith({ mode: 'explore', content: expect.anything() })
+  })
+
+  test('hands the panel over instead of tearing it down when another route owns it', () => {
+    // /news/{slug} loads asynchronously, so tearing down here would flash the
+    // Explore panel — and run its mount effects — before the article arrives.
+    h.panelMode = 'roaster'
+    h.slug = 'commonplace-opens-in-bloomfield-a1b2c3'
+    h.pathname = '/news/commonplace-opens-in-bloomfield-a1b2c3'
+
+    renderHook(() => useRoasterRouteSync())
+
+    expect(h.reset).not.toHaveBeenCalled()
   })
 
   test('leaves a non-roaster panel that lives on / alone', () => {

--- a/tests/unit/useRoasterRouteSync.test.tsx
+++ b/tests/unit/useRoasterRouteSync.test.tsx
@@ -7,6 +7,7 @@ const h = vi.hoisted(() => ({
   pathname: '/' as string,
   search: '' as string,
   panelMode: 'explore' as string,
+  panelSlug: undefined as string | undefined,
   setPanelContent: vi.fn(),
   reset: vi.fn(),
 }))
@@ -19,13 +20,14 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/stores/panelStore', () => {
   const getState = () => ({
     panelMode: h.panelMode,
+    panelContent: null,
     setPanelContent: h.setPanelContent,
     reset: h.reset,
   })
   const usePanelStore = (selector?: (s: unknown) => unknown) =>
     selector ? selector(getState()) : getState()
   usePanelStore.getState = getState
-  return { __esModule: true, default: usePanelStore }
+  return { __esModule: true, default: usePanelStore, getPanelSlug: () => h.panelSlug }
 })
 vi.mock('@/app/components/RoasterDetails', () => ({ RoasterDetails: () => null }))
 vi.mock('@/app/components/ExploreContent', () => ({ ExploreContent: () => null }))
@@ -37,6 +39,7 @@ describe('useRoasterRouteSync', () => {
     h.pathname = '/'
     h.search = ''
     h.panelMode = 'explore'
+    h.panelSlug = undefined
   })
 
   test('opens the roaster panel when on a /roasters/{slug} route', () => {


### PR DESCRIPTION
Assume everything written below this line is AI slop

---


## What do these changes accomplish?

Backing out of a company or roaster page now releases the panel, so the map returns to showing every shop instead of staying filtered to that one brand.

## Why?

The company panel filters the map down to that company's locations, and it undoes that filter when it unmounts. But `useCompanyRouteSync` only ever handled *entering* `/companies/{slug}` — nothing tore the panel down on the way out. Press browser-Back to return to the map and the panel stays mounted, still holding the filter, so the map shows one company's shops and nothing else. There's no obvious way out of that state: the route says you're on the home page, the map disagrees, and only a reload fixes it.

The roaster route had the identical bug and is fixed the same way. Teardown, though, can't be unconditional — several rounds of review turned up ways a naive reset does damage:

- **Handing off to another route.** `HomeClient` runs these hooks in order, so the hook that's leaving fires before the destination's hook can install its panel. Resetting there wiped the history the incoming entry was about to be pushed onto, and the panel back arrow went to Explore instead of where you came from. Both hooks now skip the teardown when another route-sync hook owns the destination.
- **The map filter.** Releasing it only on unmount left it stuck whenever the destination's panel never arrived; releasing it on *every* exit meant one hook un-filtered the map during the other's fetch. Route exit now releases it, except toward a destination that installs its own.
- **Re-entry.** Both hooks pushed a duplicate entry when the panel back button navigated back to their route, which swallowed the following back press.
- **A destination that installs nothing.** The handoff stands down on the promise that the destination's hook replaces the panel; `useEventRouteSync` only logged on failure, so a valid `/events/{slug}` whose fetch 500s stranded the previous panel. It now falls back to the events list, the way the news hook already did.

`useShopRouteSync` has the same handoff bug and is fixed in #389, stacked on this branch, along with a HomeClient cleanup.

Two things are deliberately left out. `useNewsRouteSync` and `useEventRouteSync` still have no exit teardown, so a news article panel outlives `/news/{slug}` the same way — no map filter to leak there, so the damage is limited to a panel/URL desync. And the teardown drops the whole panel back stack rather than just its own entry, so an article you reached a company from becomes unreachable; fixing that needs a store action that pops without rewriting the URL. Both belong with #259 rather than here.

## Screenshots

| Before | After |
|---|---|
| Company page → browser-Back → `/` shows only that company's pins, panel still open | Company page → browser-Back → `/` shows all pins, explore panel |

This is a state bug rather than a visual change, so it's described rather than captured. To reproduce on `main`: open any company page, press browser-Back, and count the pins on the map.
