### PR TITLE
fix(shops): apply the route-exit handoff rules to the shop panel

### DIFF
--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -12,6 +12,7 @@ import useShopsStore from '@/stores/coffeeShopsStore'
 import usePanelStore, { setPanelNavigate } from '@/stores/panelStore'
 import SearchFAB from './SearchFAB'
 import { useURLNeighborhoodSync } from '@/hooks/useURLNeighborhoodSync'
+import { isPanelOwnedRoute } from '@/app/utils/panelRoutes'
 
 export default function HomeClient() {
   const plausible = useAnalytics()
@@ -91,9 +92,7 @@ export default function HomeClient() {
   useEffect(() => {
     if (!panelContent && panelMode === 'explore') {
       const params = new URLSearchParams(window.location.search)
-      const hasContentParam = ['company', 'roaster', 'news', 'event', 'events'].some(p => params.has(p))
-      const onDetailPath = ['/shops/', '/events/', '/news/', '/roasters/', '/companies/'].some(p => pathname.startsWith(p))
-      if (!hasContentParam && !onDetailPath) {
+      if (!isPanelOwnedRoute(pathname, params)) {
         setPanelContent(<ExploreContent />, 'explore')
       }
     }

--- a/hooks/useShopRouteSync.tsx
+++ b/hooks/useShopRouteSync.tsx
@@ -1,40 +1,51 @@
 import { useEffect } from 'react'
-import { useParams, usePathname } from 'next/navigation'
+import { useParams, usePathname, useSearchParams } from 'next/navigation'
 import useShopsStore from '@/stores/coffeeShopsStore'
 import usePanelStore from '@/stores/panelStore'
 import ShopDetails from '@/app/components/ShopDetails'
 import { ExploreContent } from '@/app/components/ExploreContent'
 import { TShop } from '@/types/shop-types'
 import { buildShopSlug } from '@/app/utils/shopSlug'
+import { isPanelOwnedRoute } from '@/app/utils/panelRoutes'
 
 export const useShopRouteSync = () => {
   const { slug } = useParams<{ slug?: string }>()
   const pathname = usePathname()
+  const searchParams = useSearchParams()
 
   // `slug` is shared by every [slug] route (shops, events, news), so only act
   // when we're actually on a shop page.
   const onShopRoute = pathname.startsWith('/shops/')
+  const destinationOwnsPanel = !onShopRoute && isPanelOwnedRoute(pathname, searchParams)
 
   // Store actions are read via getState() rather than closed over so the effect
-  // depends only on `slug` and `onShopRoute` — no exhaustive-deps suppression.
+  // depends only on the values below — no exhaustive-deps suppression.
   useEffect(() => {
     const { currentShop, setCurrentShop } = useShopsStore.getState()
 
-    // Leaving a shop route: always drop the selected shop (so the map marker
-    // de-highlights) when one is set, but only reset the panel to explore when a
-    // shop panel is actually showing, so we don't clobber a company/roaster/news
-    // panel that lives on the bare `/` route.
-    const clearShopPanel = () => {
+    // Always drop the selected shop when one is set, so the map marker
+    // de-highlights.
+    const clearSelectedShop = () => {
       if (useShopsStore.getState().currentShop?.properties?.uuid) {
         setCurrentShop({} as TShop)
       }
+    }
+
+    // Only reset the panel when a shop panel is actually showing, so we don't
+    // clobber a company/roaster/news panel that lives on the bare `/` route.
+    const clearShopPanel = () => {
+      clearSelectedShop()
       if (usePanelStore.getState().panelMode === 'shop') {
         usePanelStore.getState().reset({ mode: 'explore', content: <ExploreContent /> })
       }
     }
 
     if (!onShopRoute || !slug) {
-      clearShopPanel()
+      // Leaving for a route whose own hook installs the panel (the shop panel's
+      // "Part of {company}" button, say): let it, or the reset here would wipe the
+      // history its entry is about to be pushed onto.
+      if (destinationOwnsPanel) clearSelectedShop()
+      else clearShopPanel()
       return
     }
 
@@ -67,5 +78,5 @@ export const useShopRouteSync = () => {
       })
 
     return () => controller.abort()
-  }, [slug, onShopRoute])
+  }, [slug, onShopRoute, destinationOwnsPanel])
 }

--- a/tests/unit/routeSyncPanelHistory.test.tsx
+++ b/tests/unit/routeSyncPanelHistory.test.tsx
@@ -2,8 +2,11 @@ import { describe, test, expect, beforeEach, vi } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { useCompanyRouteSync } from '@/hooks/useCompanyRouteSync'
 import { useRoasterRouteSync } from '@/hooks/useRoasterRouteSync'
+import { useShopRouteSync } from '@/hooks/useShopRouteSync'
 import usePanelStore from '@/stores/panelStore'
 import useShopsStore from '@/stores/coffeeShopsStore'
+import { buildShopSlug } from '@/app/utils/shopSlug'
+import { TShop } from '@/types/shop-types'
 
 const h = vi.hoisted(() => ({ slug: undefined as string | undefined, pathname: '/', search: '' }))
 
@@ -15,12 +18,13 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/app/components/Company', () => ({ Company: () => null }))
 vi.mock('@/app/components/RoasterDetails', () => ({ RoasterDetails: () => null }))
 vi.mock('@/app/components/ExploreContent', () => ({ ExploreContent: () => null }))
+vi.mock('@/app/components/ShopDetails', () => ({ default: () => null }))
 
-// HomeClient calls the company hook before the roaster hook, so a
-// company -> roaster navigation runs the company teardown first. It must not
-// wipe the history the roaster panel is about to be pushed onto.
+// HomeClient's order: whichever hook is leaving its route runs its teardown
+// before the destination's hook can push its panel entry.
 const renderRouteSyncs = () =>
   renderHook(() => {
+    useShopRouteSync()
     useCompanyRouteSync()
     useRoasterRouteSync()
   })
@@ -124,6 +128,26 @@ describe('route sync panel history', () => {
     rerender()
 
     expect(useShopsStore.getState().overrideShops).toBeNull()
+  })
+
+  test('keeps the shop entry when navigating to the company that owns it', () => {
+    const properties = {
+      name: 'De Fer Coffee & Tea',
+      neighborhood: 'Downtown',
+      uuid: 'abcdef12-3456-7890-abcd-ef1234567890',
+    }
+    useShopsStore.getState().setCurrentShop({ properties } as TShop)
+    usePanelStore.getState().reset({ mode: 'shop', content: null })
+
+    h.slug = buildShopSlug(properties)
+    h.pathname = `/shops/${h.slug}`
+    const { rerender } = renderRouteSyncs()
+
+    h.slug = 'de-fer-coffee-tea'
+    h.pathname = '/companies/de-fer-coffee-tea'
+    rerender()
+
+    expect(modes()).toEqual(['shop', 'company'])
   })
 
   test('leaves the panel alone when a query param owns it on /', () => {

--- a/tests/unit/useShopRouteSync.test.tsx
+++ b/tests/unit/useShopRouteSync.test.tsx
@@ -5,11 +5,16 @@ import { useShopRouteSync } from '@/hooks/useShopRouteSync'
 const h = vi.hoisted(() => ({
   slug: undefined as string | undefined,
   pathname: '/' as string,
+  search: '' as string,
   shopState: { currentShop: {} as any, setCurrentShop: vi.fn() },
   panelState: { panelMode: 'explore' as string, reset: vi.fn(), setPanelContent: vi.fn() },
 }))
 
-vi.mock('next/navigation', () => ({ useParams: () => ({ slug: h.slug }), usePathname: () => h.pathname }))
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ slug: h.slug }),
+  usePathname: () => h.pathname,
+  useSearchParams: () => new URLSearchParams(h.search),
+}))
 vi.mock('@/stores/coffeeShopsStore', () => ({ __esModule: true, default: { getState: () => h.shopState } }))
 vi.mock('@/stores/panelStore', () => ({ __esModule: true, default: { getState: () => h.panelState } }))
 vi.mock('@/app/components/ShopDetails', () => ({ __esModule: true, default: () => null }))
@@ -24,6 +29,7 @@ describe('useShopRouteSync', () => {
     vi.clearAllMocks()
     h.slug = undefined
     h.pathname = '/'
+    h.search = ''
     h.shopState.currentShop = {}
     h.panelState.panelMode = 'explore'
     vi.stubGlobal('fetch', vi.fn())
@@ -39,6 +45,21 @@ describe('useShopRouteSync', () => {
     expect(h.shopState.setCurrentShop).toHaveBeenCalledWith({})
     expect(h.panelState.reset).toHaveBeenCalledWith(expect.objectContaining({ mode: 'explore' }))
     expect(fetch).not.toHaveBeenCalled()
+  })
+
+  test('hands the panel to the destination hook but still de-highlights the marker', () => {
+    // The shop panel's "Part of {company}" button routes to /companies/{slug};
+    // the company hook installs that panel, so resetting here would wipe the
+    // history its entry is about to be pushed onto.
+    h.slug = 'de-fer-coffee-tea'
+    h.pathname = '/companies/de-fer-coffee-tea'
+    h.shopState.currentShop = shopWithUuid
+    h.panelState.panelMode = 'shop'
+
+    renderHook(() => useShopRouteSync())
+
+    expect(h.shopState.setCurrentShop).toHaveBeenCalledWith({})
+    expect(h.panelState.reset).not.toHaveBeenCalled()
   })
 
   test('leaving a shop route does not disturb a non-shop panel (e.g. company)', () => {


### PR DESCRIPTION
Assume everything written below this line is AI slop

---

**Stacked on #388** — review that one first; this diff is only the last two commits.

## What do these changes accomplish?

Applies #388's route-exit rules to the shop panel, which had the same bug already, and points HomeClient at the shared helper instead of its own copy of the route lists.

## Why?

`useShopRouteSync` was the one hook that already tore its panel down on route exit — it's the pattern #388 copied. But it tore down unconditionally, so the shop panel's "Part of {company}" button and its roaster link reset the panel history before the destination's hook could push its own entry. The back arrow then went to Explore instead of back to the shop. This is not a regression from #388; `main` behaves the same way. It's the same defect the new helper exists to prevent, so it's fixed the same way, and the selected shop still clears unconditionally so the map marker de-highlights either way.

The second commit is cleanup: HomeClient carried its own copies of the detail-path and query-param lists that now live in `app/utils/panelRoutes.ts`, so adding a route to one would have silently skipped the other.

## Screenshots

| Before | After |
|---|---|
| Shop panel → "Part of {company}" → back arrow lands on Explore | back arrow returns to the shop |

A panel-history bug with no static difference. To reproduce on `main`: open a shop with a parent company, click "Part of …", then press the panel back arrow.
