### PR TITLE
fix(auth): constrain OAuth callback next param to our own origin

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,10 +1,11 @@
 import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
+import { safeNextPath } from './safeNextPath'
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
-  const next = searchParams.get('next') ?? '/'
+  const next = safeNextPath(searchParams.get('next'))
 
   if (code) {
     const supabase = await createClient()

--- a/app/auth/callback/safeNextPath.ts
+++ b/app/auth/callback/safeNextPath.ts
@@ -1,0 +1,14 @@
+/**
+ * Constrains the OAuth callback's `next` parameter to a path on our own origin.
+ *
+ * The callback builds its redirect as `${origin}${next}`, and `origin` carries no
+ * trailing slash — so an unchecked `next` escapes the host entirely: `@evil.com`
+ * parses as userinfo plus host `evil.com`, and `.evil.com` yields
+ * `pgh.coffee.evil.com`. Since the OAuth `redirect_to` is chosen by whoever
+ * builds the sign-in link, that turns a genuine Google sign-in into a redirect
+ * to an attacker's page. Only a single-slash-rooted path is safe to append.
+ */
+export function safeNextPath(next: string | null): string {
+  if (!next?.startsWith('/') || next.startsWith('//')) return '/'
+  return next
+}

--- a/tests/unit/authCallbackRoute.test.ts
+++ b/tests/unit/authCallbackRoute.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
+import { safeNextPath } from '@/app/auth/callback/safeNextPath'
 
 const mockExchangeCodeForSession = vi.fn()
 
@@ -57,5 +58,40 @@ describe('Auth Callback API Route - GET', () => {
 
     expect(response.headers.get('location')).toBe('http://localhost:3000/sign-in?error=auth_failed')
     expect(mockExchangeCodeForSession).not.toHaveBeenCalled()
+  })
+})
+
+// `origin` has no trailing slash, so these `next` values would otherwise be
+// concatenated into a URL whose host is no longer ours — an attacker-chosen
+// landing page reached straight after a real Google sign-in.
+describe('safeNextPath', () => {
+  test.each([
+    ['@evil.com', 'userinfo separator makes evil.com the host'],
+    ['.evil.com', 'suffixes our host into pgh.coffee.evil.com'],
+    ['//evil.com', 'protocol-relative'],
+    ['https://evil.com', 'absolute URL'],
+    [' //evil.com', 'leading space'],
+  ])('rejects %j (%s)', (next) => {
+    expect(safeNextPath(next)).toBe('/')
+    expect(new URL(`https://pgh.coffee${safeNextPath(next)}`).host).toBe('pgh.coffee')
+  })
+
+  test('keeps a rooted internal path', () => {
+    expect(safeNextPath('/account/favorites')).toBe('/account/favorites')
+  })
+
+  test('falls back to the root when absent', () => {
+    expect(safeNextPath(null)).toBe('/')
+  })
+})
+
+describe('Auth Callback API Route - open redirect', () => {
+  test('redirects to the site root instead of an off-site next', async () => {
+    mockExchangeCodeForSession.mockResolvedValueOnce({ error: null })
+
+    const request = new Request('http://localhost:3000/auth/callback?code=abc123&next=@evil.com')
+    const response = await (await import('@/app/auth/callback/route')).GET(request)
+
+    expect(new URL(response.headers.get('location')!).host).toBe('localhost:3000')
   })
 })


### PR DESCRIPTION
## What do these changes accomplish?

Stops the OAuth callback from redirecting signed-in users to an attacker-chosen website.

## Why?

`/auth/callback` built its redirect as `` `${origin}${next}` `` with no check on `next`. Because `origin` carries no trailing slash, certain values escape our host entirely:

| `?next=` | resulting host |
|---|---|
| `//evil.com` | `pgh.coffee` (already safe) |
| `.evil.com` | **`pgh.coffee.evil.com`** |
| `@evil.com` | **`evil.com`** |

The Supabase OAuth `redirect_to` is chosen by whoever builds the sign-in link, so an attacker could send someone a link that runs a completely genuine Google sign-in and then drops them on an attacker-controlled page — a good setup for a fake "session expired, sign in again" prompt, since the victim just did sign in successfully.

`next` is now constrained to a single-slash-rooted path; anything else falls back to `/`. Found during a security audit of the repo.

## Screenshots

No visual change — the redirect target is the only thing that moves, and only for values that were never legitimate.

| Before | After |
|---|---|
| `?next=@evil.com` → `https://evil.com` | `?next=@evil.com` → `https://pgh.coffee/` |
