### PR TITLE
fix(events): apply the is_hidden gate to every read, not just the list

### DIFF
--- a/app/api/companies/[company]/events/route.ts
+++ b/app/api/companies/[company]/events/route.ts
@@ -1,16 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { getCompanyBySlug } from '@/app/utils/companies'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { visibleEvents } from '@/app/utils/events'
 
 const getCompanyEvents = async (companyId: string) => {
-  const { data, error } = await supabase
-    .from('events')
-    .select('*, shop:shops!inner(*, company:company_id(*))')
+  const { data, error } = await visibleEvents('*, shop:shops!inner(*, company:company_id(*))')
     .eq('shops.company_id', companyId)
 
   if (error) {

--- a/app/api/events/[eventId]/route.ts
+++ b/app/api/events/[eventId]/route.ts
@@ -1,15 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { visibleEvents } from '@/app/utils/events'
 
 const getEvent = async (eventId: string) => {
-  const { data, error } = await supabase
-    .from('events')
-    .select('*, shop:shop_id(*, company:company_id(*)), roaster:roaster_id(*)')
+  const { data, error } = await visibleEvents()
     .eq('id', eventId)
     .single()
 

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,17 +1,9 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
-
-// Supabase configuration
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { visibleEvents } from '@/app/utils/events'
 
 const fetchEvents = async (shopID?: string, roasterID?: string) => {
-  let query = supabase
-    .from('events')
-    .select('*, shop:shop_id(*, company:company_id(*)), roaster:roaster_id(*)')
-    .eq('is_hidden', false)
+  let query = visibleEvents()
     .order('event_date', { ascending: false })
 
   if (shopID) {

--- a/app/utils/events.ts
+++ b/app/utils/events.ts
@@ -7,19 +7,6 @@ const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
 const EVENT_SELECT = '*, shop:shop_id(*, company:company_id(*)), roaster:roaster_id(*)'
 
-/**
- * The only sanctioned way to read `events`. `is_hidden` is the moderation gate,
- * but it lives in application code — the RLS policy is `SELECT USING (true)` —
- * so a read that forgets the filter serves hidden rows. It had been forgotten in
- * three of the four read paths, leaving hidden events fully reachable at their
- * permanent `/events/{slug}` URLs. Centralised here so the filter can't be
- * omitted by a caller, and tests/unit/hiddenEventsInvariant.test.ts fails if a
- * new caller selects from the table directly.
- *
- * The real fix is `USING (is_hidden = false)` in the RLS policy, which would
- * also close the hole for direct PostgREST reads with the public anon key; this
- * shores up the application layer in the meantime.
- */
 export const visibleEvents = (select: string = EVENT_SELECT) =>
   supabase.from('events').select(select).eq('is_hidden', false)
 

--- a/app/utils/events.ts
+++ b/app/utils/events.ts
@@ -8,6 +8,22 @@ const supabase = createClient(supabaseUrl, supabaseAnonKey)
 const EVENT_SELECT = '*, shop:shop_id(*, company:company_id(*)), roaster:roaster_id(*)'
 
 /**
+ * The only sanctioned way to read `events`. `is_hidden` is the moderation gate,
+ * but it lives in application code — the RLS policy is `SELECT USING (true)` —
+ * so a read that forgets the filter serves hidden rows. It had been forgotten in
+ * three of the four read paths, leaving hidden events fully reachable at their
+ * permanent `/events/{slug}` URLs. Centralised here so the filter can't be
+ * omitted by a caller, and tests/unit/hiddenEventsInvariant.test.ts fails if a
+ * new caller selects from the table directly.
+ *
+ * The real fix is `USING (is_hidden = false)` in the RLS policy, which would
+ * also close the hole for direct PostgREST reads with the public anon key; this
+ * shores up the application layer in the meantime.
+ */
+export const visibleEvents = (select: string = EVENT_SELECT) =>
+  supabase.from('events').select(select).eq('is_hidden', false)
+
+/**
  * Resolves an event from a `/events/{slug}` identifier's id prefix. The `id`
  * column is a Postgres `uuid`, which has no LIKE operator, so we bound a range
  * by the all-zero and all-f completions of the 8-char prefix (the uuid's first
@@ -15,9 +31,7 @@ const EVENT_SELECT = '*, shop:shop_id(*, company:company_id(*)), roaster:roaster
  * falls within its own prefix range.
  */
 export const getEventByIdPrefix = async (prefix: string) => {
-  const { data, error } = await supabase
-    .from('events')
-    .select(EVENT_SELECT)
+  const { data, error } = await visibleEvents()
     .gte('id', `${prefix}-0000-0000-0000-000000000000`)
     .lte('id', `${prefix}-ffff-ffff-ffff-ffffffffffff`)
     .limit(1)

--- a/tests/unit/eventByIdRoute.test.ts
+++ b/tests/unit/eventByIdRoute.test.ts
@@ -3,9 +3,6 @@ import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
 const mockSingleResult = vi.fn()
 const mockEq = vi.fn()
 
-// Self-returning builder (same shape as eventsRoute.test.ts) so the chain doesn't
-// have to be re-nested every time a filter is added, and `eq` calls are recorded
-// for the is_hidden assertion below.
 vi.mock('@supabase/supabase-js', () => {
   const builder: Record<string, unknown> = {
     select: vi.fn(() => builder),
@@ -58,8 +55,6 @@ describe('Event By Id API Route - GET', () => {
     expect(data.error).toBe('Event not found')
   })
 
-  // A hidden event is moderated-off content; serving it to anyone holding the
-  // direct URL defeats the gate. See tests/unit/hiddenEventsInvariant.test.ts.
   test('excludes hidden events', async () => {
     mockSingleResult.mockResolvedValueOnce({ data: null, error: null })
 

--- a/tests/unit/eventByIdRoute.test.ts
+++ b/tests/unit/eventByIdRoute.test.ts
@@ -1,18 +1,23 @@
 import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
 
 const mockSingleResult = vi.fn()
+const mockEq = vi.fn()
 
-vi.mock('@supabase/supabase-js', () => ({
-  createClient: () => ({
-    from: () => ({
-      select: () => ({
-        eq: () => ({
-          single: mockSingleResult,
-        }),
-      }),
-    }),
-  }),
-}))
+// Self-returning builder (same shape as eventsRoute.test.ts) so the chain doesn't
+// have to be re-nested every time a filter is added, and `eq` calls are recorded
+// for the is_hidden assertion below.
+vi.mock('@supabase/supabase-js', () => {
+  const builder: Record<string, unknown> = {
+    select: vi.fn(() => builder),
+    eq: (...args: unknown[]) => {
+      mockEq(...args)
+      return builder
+    },
+    single: () => mockSingleResult(),
+  }
+
+  return { createClient: () => ({ from: () => builder }) }
+})
 
 describe('Event By Id API Route - GET', () => {
   let GET: typeof import('@/app/api/events/[eventId]/route').GET
@@ -51,5 +56,17 @@ describe('Event By Id API Route - GET', () => {
 
     expect(response.status).toBe(404)
     expect(data.error).toBe('Event not found')
+  })
+
+  // A hidden event is moderated-off content; serving it to anyone holding the
+  // direct URL defeats the gate. See tests/unit/hiddenEventsInvariant.test.ts.
+  test('excludes hidden events', async () => {
+    mockSingleResult.mockResolvedValueOnce({ data: null, error: null })
+
+    await GET(new Request('http://localhost:3000/api/events/event-1') as never, {
+      params: Promise.resolve({ eventId: 'event-1' }),
+    })
+
+    expect(mockEq).toHaveBeenCalledWith('is_hidden', false)
   })
 })

--- a/tests/unit/eventBySlugRoute.test.tsx
+++ b/tests/unit/eventBySlugRoute.test.tsx
@@ -6,9 +6,7 @@ const mockEq = vi.fn()
 
 // getEventByIdPrefix prefix-matches the uuid `id` column via a bounded range
 // (.gte(...).lte(...)) rather than LIKE, because `uuid` is a Postgres uuid type
-// with no LIKE operator. The chain resolves at .limit(). Self-returning builder
-// (same shape as eventsRoute.test.ts) so `eq` calls are recorded for the
-// is_hidden assertion below.
+// with no LIKE operator. The chain resolves at .limit().
 vi.mock('@supabase/supabase-js', () => {
   const builder: Record<string, unknown> = {
     select: vi.fn(() => builder),
@@ -68,8 +66,6 @@ describe('Event by-slug API Route', () => {
     expect(response.status).toBe(404)
   })
 
-  // The bug this guards: /events/{slug} is a permanent public URL, so a hidden
-  // event stayed fully readable there after being moderated off the list.
   test('excludes hidden events', async () => {
     mockLimit.mockResolvedValueOnce({ data: [], error: null })
 

--- a/tests/unit/eventBySlugRoute.test.tsx
+++ b/tests/unit/eventBySlugRoute.test.tsx
@@ -2,23 +2,27 @@ import { describe, test, expect, vi, beforeEach, beforeAll } from 'vitest'
 import { NextRequest } from 'next/server'
 
 const mockLimit = vi.fn()
+const mockEq = vi.fn()
 
 // getEventByIdPrefix prefix-matches the uuid `id` column via a bounded range
 // (.gte(...).lte(...)) rather than LIKE, because `uuid` is a Postgres uuid type
-// with no LIKE operator. The chain resolves at .limit().
-vi.mock('@supabase/supabase-js', () => ({
-  createClient: () => ({
-    from: () => ({
-      select: () => ({
-        gte: () => ({
-          lte: () => ({
-            limit: mockLimit,
-          }),
-        }),
-      }),
-    }),
-  }),
-}))
+// with no LIKE operator. The chain resolves at .limit(). Self-returning builder
+// (same shape as eventsRoute.test.ts) so `eq` calls are recorded for the
+// is_hidden assertion below.
+vi.mock('@supabase/supabase-js', () => {
+  const builder: Record<string, unknown> = {
+    select: vi.fn(() => builder),
+    eq: (...args: unknown[]) => {
+      mockEq(...args)
+      return builder
+    },
+    gte: vi.fn(() => builder),
+    lte: vi.fn(() => builder),
+    limit: () => mockLimit(),
+  }
+
+  return { createClient: () => ({ from: () => builder }) }
+})
 
 describe('Event by-slug API Route', () => {
   let GET: typeof import('@/app/api/events/by-slug/[slug]/route').GET
@@ -62,5 +66,15 @@ describe('Event by-slug API Route', () => {
 
     const response = await callWith('whatever-12345678')
     expect(response.status).toBe(404)
+  })
+
+  // The bug this guards: /events/{slug} is a permanent public URL, so a hidden
+  // event stayed fully readable there after being moderated off the list.
+  test('excludes hidden events', async () => {
+    mockLimit.mockResolvedValueOnce({ data: [], error: null })
+
+    await callWith('latte-throwdown-12345678')
+
+    expect(mockEq).toHaveBeenCalledWith('is_hidden', false)
   })
 })

--- a/tests/unit/hiddenEventsInvariant.test.ts
+++ b/tests/unit/hiddenEventsInvariant.test.ts
@@ -2,17 +2,6 @@ import { describe, test, expect } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'fs'
 import { join } from 'path'
 
-// Guards against the bug fixed alongside this test: `events.is_hidden` is the
-// moderation gate, but the RLS policy on the table is `SELECT USING (true)`, so
-// the filter is enforced only in application code. It had been applied in one of
-// four read paths — hiding an event dropped it from the list while leaving it
-// fully readable at its permanent `/events/{slug}` URL.
-//
-// Every read now goes through `visibleEvents()` in app/utils/events.ts, which
-// applies the filter once. This test fails if a new caller selects from `events`
-// directly and re-opens the hole. Inserts are exempt: the capture pipeline
-// writes to the table and has nothing to filter.
-
 const SEARCH_DIRS = ['app', 'lib'].map(d => join(process.cwd(), d))
 const GATE = join('app', 'utils', 'events.ts')
 

--- a/tests/unit/hiddenEventsInvariant.test.ts
+++ b/tests/unit/hiddenEventsInvariant.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'fs'
+import { join } from 'path'
+
+// Guards against the bug fixed alongside this test: `events.is_hidden` is the
+// moderation gate, but the RLS policy on the table is `SELECT USING (true)`, so
+// the filter is enforced only in application code. It had been applied in one of
+// four read paths — hiding an event dropped it from the list while leaving it
+// fully readable at its permanent `/events/{slug}` URL.
+//
+// Every read now goes through `visibleEvents()` in app/utils/events.ts, which
+// applies the filter once. This test fails if a new caller selects from `events`
+// directly and re-opens the hole. Inserts are exempt: the capture pipeline
+// writes to the table and has nothing to filter.
+
+const SEARCH_DIRS = ['app', 'lib'].map(d => join(process.cwd(), d))
+const GATE = join('app', 'utils', 'events.ts')
+
+const sourceFiles = (dir: string): string[] =>
+  readdirSync(dir).flatMap(entry => {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) return sourceFiles(full)
+    return /\.tsx?$/.test(entry) ? [full] : []
+  })
+
+describe('hidden events invariant', () => {
+  test('only the shared gate selects from the events table', () => {
+    const offenders = SEARCH_DIRS.flatMap(sourceFiles)
+      .filter(file => !file.endsWith(GATE))
+      .filter(file => {
+        const src = readFileSync(file, 'utf8')
+        return /\.from\(['"]events['"]\)/.test(src) && /\.select\(/.test(src)
+      })
+
+    expect(
+      offenders,
+      `These files query the events table directly, bypassing the is_hidden ` +
+        `filter — hidden events would be served to anyone with the URL. Use ` +
+        `visibleEvents() from app/utils/events.ts instead:\n` +
+        offenders.map(f => `  - ${f.replace(process.cwd() + '/', '')}`).join('\n'),
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## What do these changes accomplish?

Makes hiding an event actually hide it — everywhere it can be read, not just in the events list.

## Why?

`events.is_hidden` is the moderation gate, but it's enforced in application code: the RLS policy on the table is `SELECT USING (true)`, so the filter only exists where a query remembers to add it. `grep -rn is_hidden app lib` returned exactly one hit, out of four read paths:

| Read path | had the filter |
|---|---|
| `/api/events` | yes |
| `/api/events/[eventId]` | no |
| `getEventByIdPrefix` — backs `/api/events/by-slug/[slug]` **and** the `/events/[slug]` page | no |
| `/api/companies/[company]/events` | no |

So hiding an event removed it from the list and left it fully readable — and crawlable — at its permanent public URL. Anyone with the link, or Google, still had it.

Rather than copy the filter into three more places, all four reads now go through one `visibleEvents()` helper, so there's a single place it can be got wrong. A new invariant test (`tests/unit/hiddenEventsInvariant.test.ts`, same shape as the existing `cdnCacheInvariant` test) fails and names the offending file if a future caller selects from the `events` table directly. Inserts are exempt — the capture pipeline writes to the table and has nothing to filter.

Net effect on the routes is a deletion: three of them no longer build their own Supabase client.

**Follow-up, not in this PR:** the durable fix is `USING (is_hidden = false)` in the RLS policy, which would also close the hole for direct PostgREST reads with the public anon key. That's a hand-applied DB change. Found during a security audit of the repo.

## Screenshots

No visual change — hidden events were never meant to be reachable.

| Before | After |
|---|---|
| `GET /events/{slug}` of a hidden event → `200`, full event | `GET /events/{slug}` of a hidden event → `404` |
