### PR TITLE
chore: drop unused imports, variables, and parameters

### DIFF
--- a/app/components/Company.tsx
+++ b/app/components/Company.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ArrowTopRightOnSquareIcon, BuildingStorefrontIcon, ChevronRightIcon, MapPinIcon } from '@heroicons/react/24/outline'
+import { ArrowTopRightOnSquareIcon, BuildingStorefrontIcon, ChevronRightIcon } from '@heroicons/react/24/outline'
 import { Flame, Instagram } from 'lucide-react'
 import Link from 'next/link'
 import LocationList from '@/app/components/LocationList'

--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { useRouter, usePathname } from 'next/navigation'
-import { useAnalytics, useShopRouteSync, useEventRouteSync, useNewsRouteSync, useRoasterRouteSync, useCompanyRouteSync, useMediaQuery } from '@/hooks'
+import { useShopRouteSync, useEventRouteSync, useNewsRouteSync, useRoasterRouteSync, useCompanyRouteSync, useMediaQuery } from '@/hooks'
 import { TShop } from '@/types/shop-types'
 import Panel from '@/app/components/Panel'
 import ShopSearch from './ShopSearch'
@@ -14,8 +14,6 @@ import SearchFAB from './SearchFAB'
 import { useURLNeighborhoodSync } from '@/hooks/useURLNeighborhoodSync'
 
 export default function HomeClient() {
-  const plausible = useAnalytics()
-  const allShops = useShopsStore(s => s.allShops)
   const fetchCoffeeShops = useShopsStore(s => s.fetchCoffeeShops)
   const currentShop = useShopsStore(s => s.currentShop)
   const setCurrentShop = useShopsStore(s => s.setCurrentShop)

--- a/app/components/NearbyShops.tsx
+++ b/app/components/NearbyShops.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useState, useEffect } from 'react'
-import { useAnalytics } from '@/hooks'
 import { TShop } from '@/types/shop-types'
 import {
   DEFAULT_UNITS,
@@ -29,7 +28,6 @@ interface ISortedShopsResults {
 const MILES_CONVERSION_FACTOR = 0.000621371
 
 export default function NearbyShops({ shop }: IProps) {
-  const plausible = useAnalytics()
   const allShops = useShopsStore(s => s.allShops)
 
   const [units, setUnits] = useState<TUnits>(DEFAULT_UNITS)

--- a/app/components/about/Footer.tsx
+++ b/app/components/about/Footer.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link'
-
 export default function Footer() {
   return (
     <footer className="py-12 px-6 border-t border-slate-200">

--- a/stores/panelStore.ts
+++ b/stores/panelStore.ts
@@ -132,12 +132,12 @@ interface PanelState {
 
 const usePanelStore = create<PanelState>()(
   devtools(
-    (set, get) => ({
+    set => ({
       panelMode: 'explore',
       panelContent: null,
       history: [],
 
-      setPanelContent: (content, mode, opts) =>
+      setPanelContent: (content, mode) =>
         set(state => {
           const next: PanelEntry = { mode, content }
 

--- a/tests/unit/PanelHeader.test.tsx
+++ b/tests/unit/PanelHeader.test.tsx
@@ -33,7 +33,6 @@ describe.skip('PanelHeader', () => {
   })
 
   it('renders shop photo in a dialog when clicked', () => {
-    const plausibleMock = usePlausible()
     render(<PanelHeader shop={mockShop} />)
 
     const panelHeader = screen.getByTestId('header')

--- a/tests/unit/ShopCard.test.tsx
+++ b/tests/unit/ShopCard.test.tsx
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { describe, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import ShopCard, { roundDistance, generateDistanceText } from '@/app/components/ShopCard'
 import type { TShop } from '@/types/shop-types'

--- a/tests/unit/ShopPanel.test.tsx
+++ b/tests/unit/ShopPanel.test.tsx
@@ -40,7 +40,7 @@ vi.mock('@/stores/coffeeShopsStore', () => ({
 
 // Mock SearchBar component
 vi.mock('@/app/components/SearchBar', () => ({
-  default: ({ onClose }: any) => <div data-testid="search-bar">Search Bar</div>
+  default: () => <div data-testid="search-bar">Search Bar</div>
 }))
 
 beforeAll(() => {


### PR DESCRIPTION
## What do these changes accomplish?

Clears every `no-unused-vars` warning oxlint reports, taking the lint output from 35 warnings to 25.

## Why?

Dead identifiers make the lint output noisy enough that the warnings worth acting on get lost in it. These ten were all genuinely unreferenced — no behaviour changes, and the test suite is unchanged at 369 passing.

Removed:

| File | What |
|---|---|
| `HomeClient.tsx` | `plausible`, `allShops` (and the now-unused `useAnalytics` import) |
| `NearbyShops.tsx` | `plausible` (and its `useAnalytics` import) |
| `Company.tsx` | `MapPinIcon` import |
| `about/Footer.tsx` | `Link` import |
| `stores/panelStore.ts` | unused `get` and `opts` parameters |
| `ShopCard.test.tsx` | `test` import (the file uses `it`) |
| `ShopPanel.test.tsx` | `onClose` in a mock that ignores its props |
| `PanelHeader.test.tsx` | one dead `plausibleMock` |

Both removed parameters were trailing, so no call site changes.

Deliberately left alone — these are judgment calls, not easy wins, and each wants its own PR:

- `next(no-img-element)` (15 warnings) — swapping `<img>` for `next/image` needs `remotePatterns` config for the Supabase bucket and changes rendering.
- `react-hooks(exhaustive-deps)` (2) — adding the missing deps in `HomeClient` could change effect timing.
- `jsx-a11y` role/alt warnings (6) — real accessibility fixes worth doing properly rather than mechanically.

Two `plausibleMock` declarations exist in `PanelHeader.test.tsx`; only the one on line 36 was dead — the other is asserted against and stayed.

## Screenshots

No visual change — nothing removed was referenced.

| Before | After |
|---|---|
| `npm run lint` → 35 warnings, 10 of them `no-unused-vars` | `npm run lint` → 25 warnings, 0 `no-unused-vars` |
