### PR TITLE
Stop losing shop IDs and source URLs on Instagram captures

### DIFF
--- a/app/api/events/capture/route.ts
+++ b/app/api/events/capture/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
-import { getImageData, getShopCandidates, buildShopContext, validateShopUUID, callAnthropicVision, getRoasterID, supabase } from '@/lib/capture'
+import { getImageData, getSourceUrl, getAllShops, getAllRoasters, buildEntityContext, validateUUID, callAnthropicVision, getRoasterID, supabase } from '@/lib/capture'
 
 interface ExtractedEvent {
   shop_name: string
   shop_uuid: string | null
+  roaster_uuid: string | null
   title: string
   description: string
   event_date: string | null
@@ -12,18 +13,19 @@ interface ExtractedEvent {
   type: string
 }
 
-function buildPrompt(shopContext: string): string {
+function buildPrompt(entityContext: string): string {
   const year = new Date().getFullYear()
-  return `This is an Instagram post from a Pittsburgh coffee shop announcing a specific event (class, tasting, pop-up, live music, etc.). Extract details and respond ONLY with valid JSON, no other text:
+  return `This is an Instagram post from a Pittsburgh coffee shop or roaster announcing a specific event (class, tasting, pop-up, live music, etc.). Extract details and respond ONLY with valid JSON, no other text:
 {
   "shop_name": "coffee shop name shown or implied in the post",
-  "shop_uuid": "uuid of the best matching shop from the list below, or null if no match",
+  "shop_uuid": "uuid from the SHOPS list of the shop where the event physically takes place. This is the venue, which is not always the account that posted — a throwdown posted by one shop is often held at another. If a brand has several locations and the post does not say which one, return null rather than guessing a branch.",
+  "roaster_uuid": "uuid from the ROASTERS list of the roaster hosting or presenting the event. Null if a roaster is only mentioned in passing, such as whose coffee will be served.",
   "title": "concise event title (e.g. Latte Art Class, Decaf Tasting, Holiday Pop-Up)",
   "description": "post body text, cleaned up and readable. Replace any first-person language (we, I, our, my) with the shop's name",
   "event_date": "YYYY-MM-DD if a date is mentioned. If no year is shown, assume ${year}. Null if no date is mentioned.",
   "external_url": "any ticket or registration link visible in the post, otherwise null",
   "type": "pick the single most relevant from: class, community event, event, market, pop-up, special event, talk / lecture, tasting, throwdown, workshop"
-}${shopContext}`
+}${entityContext}`
 }
 
 export async function POST(request: Request) {
@@ -41,12 +43,12 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'No image provided' }, { status: 400 })
   }
 
-  const shopCandidates = await getShopCandidates(imageData.base64Image, imageData.mediaType)
+  const [shops, roasters] = await Promise.all([getAllShops(), getAllRoasters()])
 
   let extracted: ExtractedEvent
   try {
     extracted = await callAnthropicVision<ExtractedEvent>(
-      buildPrompt(buildShopContext(shopCandidates)),
+      buildPrompt(buildEntityContext(shops, roasters)),
       imageData.base64Image,
       imageData.mediaType,
     )
@@ -55,15 +57,17 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Failed to analyze image' }, { status: 500 })
   }
 
-  const shop = validateShopUUID(shopCandidates, extracted.shop_uuid)
-  const roasterId = shop ? await getRoasterID(shop.uuid) : null
+  const shop = validateUUID(shops, extracted.shop_uuid)
+  const roaster = validateUUID(roasters, extracted.roaster_uuid)
+  const roasterId = roaster?.uuid ?? (shop ? await getRoasterID(shop.uuid) : null)
 
   const { error: insertError } = await supabase
     .from('events')
     .insert([{
       title: extracted.title,
       description: extracted.description,
-      url: extracted.external_url,
+      // A ticket or registration link beats the Instagram permalink the Shortcut sends.
+      url: extracted.external_url ?? getSourceUrl(request),
       type: extracted.type,
       post_date: new Date().toISOString().split('T')[0],
       event_date: extracted.event_date,
@@ -79,6 +83,7 @@ export async function POST(request: Request) {
   return NextResponse.json({
     extracted,
     shop_matched: shop ? { name: shop.name, neighborhood: shop.neighborhood } : null,
+    roaster_matched: roaster?.name ?? null,
     message: 'Inserted into events.',
   }, { status: 201 })
 }

--- a/app/api/updates/capture/route.ts
+++ b/app/api/updates/capture/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
-import { getImageData, getShopCandidates, buildShopContext, validateShopUUID, callAnthropicVision, getRoasterID, supabase } from '@/lib/capture'
+import { getImageData, getSourceUrl, getAllShops, getAllRoasters, buildEntityContext, validateUUID, callAnthropicVision, getRoasterID, supabase } from '@/lib/capture'
 
 interface ExtractedUpdate {
   shop_name: string
   shop_uuid: string | null
+  roaster_uuid: string | null
   title: string
   description: string
   event_date: string | null
@@ -13,19 +14,20 @@ interface ExtractedUpdate {
   tags: string[]
 }
 
-function buildPrompt(shopContext: string): string {
+function buildPrompt(entityContext: string): string {
   const year = new Date().getFullYear()
   return `This is an Instagram post from a Pittsburgh coffee shop sharing a general update (new menu, hours change, opening, closure, new offering, etc.). Extract details and respond ONLY with valid JSON, no other text:
 {
   "shop_name": "coffee shop name shown or implied in the post",
-  "shop_uuid": "uuid of the best matching shop from the list below, or null if no match",
+  "shop_uuid": "uuid from the SHOPS list of the shop this update is about. If a brand has several locations and the post does not say which one, return null rather than guessing a branch.",
+  "roaster_uuid": "uuid from the ROASTERS list of the roaster this update is about. Null if a roaster is only mentioned in passing.",
   "title": "concise update title (e.g. Summer Menu Launch, New Hours, Temporary Closure)",
   "description": "post body text, cleaned up and readable. Replace any first-person language (we, I, our, my) with the shop's name",
   "event_date": "YYYY-MM-DD if a relevant date is mentioned. If no year is shown, assume ${year}. Null if no date is mentioned.",
   "external_url": "any relevant link visible in the post such as a menu or ordering link, otherwise null",
   "type": "pick the single most relevant from: opening, closure, temporary closure, coming soon, seasonal, menu, offering",
   "tags": ["pick all relevant from: opening, closure, temporary closure, coming soon, seasonal, menu, offering"]
-}${shopContext}`
+}${entityContext}`
 }
 
 export async function POST(request: Request) {
@@ -43,12 +45,12 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'No image provided' }, { status: 400 })
   }
 
-  const shopCandidates = await getShopCandidates(imageData.base64Image, imageData.mediaType)
+  const [shops, roasters] = await Promise.all([getAllShops(), getAllRoasters()])
 
   let extracted: ExtractedUpdate
   try {
     extracted = await callAnthropicVision<ExtractedUpdate>(
-      buildPrompt(buildShopContext(shopCandidates)),
+      buildPrompt(buildEntityContext(shops, roasters)),
       imageData.base64Image,
       imageData.mediaType,
     )
@@ -57,15 +59,17 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Failed to analyze image' }, { status: 500 })
   }
 
-  const shop = validateShopUUID(shopCandidates, extracted.shop_uuid)
-  const roasterId = shop ? await getRoasterID(shop.uuid) : null
+  const shop = validateUUID(shops, extracted.shop_uuid)
+  const roaster = validateUUID(roasters, extracted.roaster_uuid)
+  const roasterId = roaster?.uuid ?? (shop ? await getRoasterID(shop.uuid) : null)
 
   const { error: insertError } = await supabase
     .from('updates')
     .insert([{
       title: extracted.title,
       description: extracted.description,
-      url: extracted.external_url,
+      // A menu or ordering link beats the Instagram permalink the Shortcut sends.
+      url: extracted.external_url ?? getSourceUrl(request),
       type: extracted.type,
       tags: extracted.tags,
       event_date: extracted.event_date,
@@ -82,6 +86,7 @@ export async function POST(request: Request) {
   return NextResponse.json({
     extracted,
     shop_matched: shop ? { name: shop.name, neighborhood: shop.neighborhood } : null,
+    roaster_matched: roaster?.name ?? null,
     message: 'Inserted into updates and live immediately.',
   }, { status: 201 })
 }

--- a/lib/capture.ts
+++ b/lib/capture.ts
@@ -4,6 +4,14 @@ export interface Shop {
   uuid: string
   name: string
   neighborhood: string
+  address: string
+  instagram_handle: string | null
+}
+
+export interface Roaster {
+  uuid: string
+  name: string
+  instagram: string | null
 }
 
 export const supabase = createClient(
@@ -30,6 +38,16 @@ export async function getImageData(request: Request): Promise<{ base64Image: str
     mediaType: contentType || 'image/jpeg',
     base64Image: Buffer.from(buffer).toString('base64'),
   }
+}
+
+/**
+ * The Instagram permalink is never visible in a screenshot of the post, so the
+ * iOS Shortcut passes it as `?url=`. Query string rather than a form field so it
+ * works for both request shapes getImageData accepts.
+ */
+export function getSourceUrl(request: Request): string | null {
+  const url = new URL(request.url).searchParams.get('url')
+  return url?.startsWith('https://') ? url : null
 }
 
 export async function callAnthropicVision<T>(prompt: string, base64Image: string, mediaType: string, maxTokens = 1024): Promise<T> {
@@ -63,53 +81,53 @@ export async function callAnthropicVision<T>(prompt: string, base64Image: string
   return JSON.parse(text) as T
 }
 
-export async function getShopCandidates(base64Image: string, mediaType: string): Promise<Shop[]> {
-  const response = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'x-api-key': process.env.ANTHROPIC_API_KEY as string,
-      'anthropic-version': '2023-06-01',
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({
-      model: 'claude-haiku-4-5-20251001',
-      max_tokens: 64,
-      messages: [{
-        role: 'user',
-        content: [
-          { type: 'image', source: { type: 'base64', media_type: mediaType, data: base64Image } },
-          { type: 'text', text: 'What is the name of the coffee shop in this Instagram post? Reply with only the shop name, nothing else.' },
-        ],
-      }],
-    }),
-  })
-
-  if (!response.ok) return []
-
-  const result = await response.json()
-  const shopName = result.content[0].text.trim()
-  console.log(`[capture] shop name from first pass: "${shopName}"`)
-
+export async function getAllShops(): Promise<Shop[]> {
   const { data } = await supabase
     .from('shops')
-    .select('uuid, name, neighborhood')
-    .ilike('name', `%${shopName}%`)
-    .limit(10)
+    .select('uuid, name, neighborhood, address, company:company_id(instagram_handle)')
+    .order('name')
 
-  console.log(`[capture] candidates: ${JSON.stringify(data?.map(s => s.name) ?? [])}`)
-  return data ?? []
+  return (data ?? []).map(({ company, ...shop }) => ({
+    ...shop,
+    instagram_handle: (company as unknown as { instagram_handle: string } | null)?.instagram_handle ?? null,
+  })) as Shop[]
 }
 
-export function buildShopContext(candidates: Shop[]): string {
-  if (!candidates.length) return ''
-  return `\nThe following shops are in our database — pick the best match and return its uuid, or null if none fit:\n${candidates.map(s => `- "${s.name}" (${s.neighborhood}) — uuid: ${s.uuid}`).join('\n')}`
+/** Local roasters only: a national brand is far likelier to be mentioned in passing than to host. */
+export async function getAllRoasters(): Promise<Roaster[]> {
+  const { data } = await supabase.from('roaster').select('uuid:id, name, instagram').eq('is_local', true).order('name')
+  return (data ?? []) as unknown as Roaster[]
 }
 
-export function validateShopUUID(candidates: Shop[], uuid: string | null): Shop | null {
+const shopLine = (s: Shop) =>
+  `- "${s.name}" — ${s.neighborhood}, ${s.address}${s.instagram_handle ? ` — @${s.instagram_handle}` : ''} — uuid: ${s.uuid}`
+
+const roasterLine = (r: Roaster) =>
+  `- "${r.name}"${r.instagram ? ` — @${r.instagram}` : ''} — uuid: ${r.uuid}`
+
+/**
+ * Every shop and roaster goes in the prompt rather than a pre-filtered shortlist:
+ * name matching in SQL missed rows over an ampersand ("De Fer Coffee & Tea" vs
+ * "De Fer Coffee and Tea"), and a shortlist of same-named branches gave the model
+ * no way to tell them apart. Handles are listed because the @name at the top of
+ * the screenshot identifies the brand exactly; the address disambiguates branches.
+ */
+export function buildEntityContext(shops: Shop[], roasters: Roaster[]): string {
+  return `
+
+SHOPS — the @handle at the top of the screenshot usually matches one of these:
+${shops.map(shopLine).join('\n')}
+
+ROASTERS:
+${roasters.map(roasterLine).join('\n')}`
+}
+
+export function validateUUID<T extends { uuid: string }>(candidates: T[], uuid: string | null): T | null {
   if (!uuid) return null
-  return candidates.find(s => s.uuid === uuid) ?? null
+  return candidates.find(c => c.uuid === uuid) ?? null
 }
 
+/** The shop's own in-house roaster, used when the post names no roaster of its own. */
 export async function getRoasterID(shopUuid: string): Promise<string | null> {
   const { data: shop } = await supabase
     .from('shops')

--- a/tests/unit/captureSourceUrl.test.ts
+++ b/tests/unit/captureSourceUrl.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect, beforeAll, vi } from 'vitest'
+
+// lib/capture builds a Supabase client at import time; getSourceUrl itself
+// touches neither Supabase nor Anthropic.
+vi.stubEnv('SUPABASE_URL', 'http://localhost:54321')
+vi.stubEnv('SUPABASE_ANON_KEY', 'test-anon-key')
+
+let getSourceUrl: typeof import('@/lib/capture').getSourceUrl
+
+const requestWith = (query: string) => new Request(`http://localhost/api/events/capture${query}`)
+
+describe('getSourceUrl', () => {
+  beforeAll(async () => {
+    getSourceUrl = (await import('@/lib/capture')).getSourceUrl
+  })
+
+  test('reads the Instagram permalink the Shortcut appends', () => {
+    expect(getSourceUrl(requestWith('?url=https%3A%2F%2Fwww.instagram.com%2Fp%2FDZFeVUlurOU%2F')))
+      .toBe('https://www.instagram.com/p/DZFeVUlurOU/')
+  })
+
+  // Shortcuts builds the URL by concatenating text, so the permalink arrives raw.
+  test('reads an unencoded permalink', () => {
+    expect(getSourceUrl(requestWith('?url=https://www.instagram.com/p/DZFeVUlurOU/')))
+      .toBe('https://www.instagram.com/p/DZFeVUlurOU/')
+  })
+
+  test('is null when the Shortcut sends no url', () => {
+    expect(getSourceUrl(requestWith(''))).toBeNull()
+  })
+
+  test('rejects a non-https value rather than storing it', () => {
+    expect(getSourceUrl(requestWith('?url=javascript%3Aalert(1)'))).toBeNull()
+  })
+})

--- a/tests/unit/eventsCaptureRoute.test.ts
+++ b/tests/unit/eventsCaptureRoute.test.ts
@@ -4,9 +4,11 @@ import { describe, test, expect, beforeAll, vi } from 'vitest'
 // the route imports cleanly without touching real Supabase/Anthropic.
 vi.mock('@/lib/capture', () => ({
   getImageData: vi.fn(),
-  getShopCandidates: vi.fn(),
-  buildShopContext: vi.fn(),
-  validateShopUUID: vi.fn(),
+  getSourceUrl: vi.fn(),
+  getAllShops: vi.fn(),
+  getAllRoasters: vi.fn(),
+  buildEntityContext: vi.fn(),
+  validateUUID: vi.fn(),
   callAnthropicVision: vi.fn(),
   getRoasterID: vi.fn(),
   supabase: { from: vi.fn() },

--- a/tests/unit/updatesCaptureRoute.test.ts
+++ b/tests/unit/updatesCaptureRoute.test.ts
@@ -4,9 +4,11 @@ import { describe, test, expect, beforeAll, vi } from 'vitest'
 // the route imports cleanly without touching real Supabase/Anthropic.
 vi.mock('@/lib/capture', () => ({
   getImageData: vi.fn(),
-  getShopCandidates: vi.fn(),
-  buildShopContext: vi.fn(),
-  validateShopUUID: vi.fn(),
+  getSourceUrl: vi.fn(),
+  getAllShops: vi.fn(),
+  getAllRoasters: vi.fn(),
+  buildEntityContext: vi.fn(),
+  validateUUID: vi.fn(),
   callAnthropicVision: vi.fn(),
   getRoasterID: vi.fn(),
   supabase: { from: vi.fn() },


### PR DESCRIPTION
## What do these changes accomplish?

Instagram screenshot captures now identify the right coffee shop far more often, and keep a link back to the post they came from.

## Why?

Sending a screenshot to `/api/events/capture` was missing the shop about as often as it found it, and never captured the post's URL. Both had to be fixed by hand afterward, which defeats the point of the shortcut.

Three separate causes:

- **Shop matching.** The route made a vision call to guess a shop name, then searched the database with `ilike '%name%'`. A single character off killed it — the database has `De Fer Coffee & Tea` but the company row says `De Fer Coffee and Tea`. When it *did* match, 24 shop names are non-unique (Yinz ×8, Commonplace ×7), so the model got handed ten identical rows and picked a neighborhood at random. Now all 171 shops go into one prompt with neighborhood, address, and the company's Instagram handle — the `@name` at the top of a screenshot matches a handle exactly — and the model is told to return null rather than guess a branch. One API call instead of two.
- **The post URL.** It was never in the pixels, so no prompt could find it. The Shortcut now passes it as `?url=`, and it fills in when the post has no ticket link of its own.
- **Roaster events.** The roaster was only ever looked up *from* a matched shop, so a post from a roaster's account came out with both ids null — about half the unmatched rows. The model now picks a roaster directly, restricted to local roasters so a national brand mentioned in passing can't attach itself to an event.

`/api/updates/capture` shared all three bugs through the same helpers and gets the same fix.

Verified against posts reconstructed from rows that currently have no `shop_id`:

| Case | Result |
|---|---|
| Moonbeam live music (previously missed) | Moonbeam Café (Oakmont) |
| De Fer, no branch named | null — declined to guess |
| De Fer, "Smallman St" named | Strip District |
| Throwdown posted by Ghost, held at Trace | shop Trace Brewing, roaster Ghost Coffee Collab |
| "We'll be brewing Lavazza and Passenger" | roaster null |

Prompt context is ~6.7k tokens per capture, roughly half a cent on Haiku.

**Requires a Shortcut change** — the URL fix is inert until the phone appends `?url=`. Set the Shortcut to accept URLs from the share sheet, use `Get Latest Photos (1)` for the screenshot, and POST to `…/capture?url=[Shortcut Input]`.

## Screenshots

Backend only, no UI changes.
