### PR TITLE
refactor: share server Supabase client

### DIFF
--- a/app/api/companies/[company]/news/route.ts
+++ b/app/api/companies/[company]/news/route.ts
@@ -1,14 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { getCompanyBySlug } from '@/app/utils/companies'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 const getCompanyNews = async (companyId: string) => {
-  const { data, error } = await supabase
+  const { data, error } = await getClient()
     .from('updates')
     .select('*, shop:shops!inner(*, company:company_id(*))')
     .eq('shops.company_id', companyId)

--- a/app/api/companies/[company]/route.ts
+++ b/app/api/companies/[company]/route.ts
@@ -1,17 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { publicCacheHeaders, SHOP_DATA_TTL } from '@/lib/cacheHeaders'
 import { getCompanyBySlug } from '@/app/utils/companies'
 import { SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
-
-// Supabase configuration
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 const getCompanyShops = async (companyId: string) => {
-  const { data, error } = await supabase
+  const { data, error } = await getClient()
     .from('shops')
     .select(SHOP_WITH_ROASTER_SELECT)
     .eq('company_id', companyId)
@@ -25,7 +20,7 @@ const getCompanyShops = async (companyId: string) => {
 }
 
 const getCompanyRoaster = async (companyId: string) => {
-  const { data, error } = await supabase
+  const { data, error } = await getClient()
     .from('roaster')
     .select('name, slug')
     .eq('company_id', companyId)

--- a/app/api/curated-lists/route.ts
+++ b/app/api/curated-lists/route.ts
@@ -1,14 +1,9 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { DbShop, TShop } from '@/types/shop-types'
 import { formatDBShopAsFeature } from '@/app/utils/utils'
 import { logger } from '@/lib/logger'
 import { publicCacheHeaders, SHOP_DATA_TTL } from '@/lib/cacheHeaders'
-
-// Supabase configuration
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 const mapDbShopToTShop = (s: DbShop): TShop | null => {
   if (s.latitude == null || s.longitude == null) return null
@@ -16,7 +11,7 @@ const mapDbShopToTShop = (s: DbShop): TShop | null => {
 }
 
 const fetchCuratedLists = async () => {
-  const { data, error } = await supabase
+  const { data, error } = await getClient()
     .from('curated_lists_with_shops')
     .select('*')
     .order('title', { ascending: true })

--- a/app/api/events/capture/route.ts
+++ b/app/api/events/capture/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
-import { getImageData, getShopCandidates, buildShopContext, validateShopUUID, callAnthropicVision, getRoasterID, supabase } from '@/lib/capture'
+import { getImageData, getShopCandidates, buildShopContext, validateShopUUID, callAnthropicVision, getRoasterID } from '@/lib/capture'
+import { getClient } from '@/lib/supabase/server-client'
 
 interface ExtractedEvent {
   shop_name: string
@@ -57,6 +58,7 @@ export async function POST(request: Request) {
 
   const shop = validateShopUUID(shopCandidates, extracted.shop_uuid)
   const roasterId = shop ? await getRoasterID(shop.uuid) : null
+  const supabase = getClient()
 
   const { error: insertError } = await supabase
     .from('events')

--- a/app/api/featured-shop/route.ts
+++ b/app/api/featured-shop/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import crypto from 'crypto'
 import { formatDBShopAsFeature, SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
 import { DbShop } from '@/types/shop-types'
+import { getClient } from '@/lib/supabase/server-client'
 
 // Disable Next's fixed ISR window; we'll control TTL via Cache-Control
 export const revalidate = 0
@@ -56,7 +56,7 @@ function secondsUntilNextMidnightTz(now = new Date(), tz = TZ) {
 }
 
 export async function GET() {
-  const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!)
+  const supabase = getClient()
 
   const { data: uuids, error: uuidErr } = await supabase.from('shops').select('uuid')
 

--- a/app/api/roasters/[slug]/route.ts
+++ b/app/api/roasters/[slug]/route.ts
@@ -1,18 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { publicCacheHeaders, SHOP_DATA_TTL } from '@/lib/cacheHeaders'
 import { getRoasterBySlug } from '@/app/utils/roasters'
 import { SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 // Shops that serve this roaster's coffee (joined via shops.roaster_id), so the
 // roaster page can show where to drink it. Mirrors getCompanyShops.
 const getRoasterShops = async (roasterId: string) => {
-  const { data, error } = await supabase
+  const { data, error } = await getClient()
     .from('shops')
     .select(SHOP_WITH_ROASTER_SELECT)
     .eq('roaster_id', roasterId)

--- a/app/api/shops/batch/route.ts
+++ b/app/api/shops/batch/route.ts
@@ -1,15 +1,10 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { formatDataToGeoJSON, SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
 import { logger } from '@/lib/logger'
-
-// Supabase configuration
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 const fetchShopsByIds = async (ids: string[]) => {
-  const { data, error } = await supabase
+  const { data, error } = await getClient()
     .from('shops')
     .select(SHOP_WITH_ROASTER_SELECT)
     .in('uuid', ids)

--- a/app/api/shops/claim/route.ts
+++ b/app/api/shops/claim/route.ts
@@ -1,12 +1,8 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { metrics } from '@/lib/metrics'
 import { isRealSupabaseError } from '@/lib/supabaseErrors'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -41,6 +37,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid target id' }, { status: 400 })
   }
 
+  const supabase = getClient()
   const selectColumns = claim_type === 'company' ? target.idColumn : `${target.idColumn}, company_id`
   const { data: entity, error: entityError } = await supabase
     .from(target.table)

--- a/app/api/shops/geojson/route.ts
+++ b/app/api/shops/geojson/route.ts
@@ -1,17 +1,12 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { formatDataToGeoJSON, SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
 import { logger } from '@/lib/logger'
 import { withMetrics } from '@/lib/withMetrics'
 import { publicCacheHeaders, SHOP_DATA_TTL } from '@/lib/cacheHeaders'
-
-// Supabase configuration
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 const fetchShops = async () => {
-  const { data, error } = await supabase
+  const { data, error } = await getClient()
     .from('shops')
     .select(SHOP_WITH_ROASTER_SELECT)
     .order('name', { ascending: true })

--- a/app/api/shops/hours/[uuid]/route.ts
+++ b/app/api/shops/hours/[uuid]/route.ts
@@ -1,12 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { withMetrics } from '@/lib/withMetrics'
 import { publicCacheHeaders, SHOP_DATA_TTL } from '@/lib/cacheHeaders'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 // A present day-row means open
 // A missing day means closed
@@ -16,7 +12,7 @@ export const GET = withMetrics(
   async (_req: NextRequest, props: { params: Promise<{ uuid: string }> }) => {
     const { uuid } = await props.params
 
-    const { data, error } = await supabase
+    const { data, error } = await getClient()
       .from('shop_hours')
       .select('day_of_week, opens_at, closes_at, spans_midnight')
       .eq('shop_uuid', uuid)

--- a/app/api/shops/report-amenities/route.ts
+++ b/app/api/shops/report-amenities/route.ts
@@ -1,13 +1,9 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { metrics } from '@/lib/metrics'
 import { AMENITY_KEYS } from '@/lib/amenityKeys'
 import { isRealSupabaseError } from '@/lib/supabaseErrors'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 export async function POST(request: Request) {
   const { shop_id, amenities } = await request.json()
@@ -20,6 +16,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid amenity value' }, { status: 400 })
   }
 
+  const supabase = getClient()
   const { data: shop, error: shopError } = await supabase
     .from('shops')
     .select('uuid')

--- a/app/api/shops/report/route.ts
+++ b/app/api/shops/report/route.ts
@@ -1,13 +1,9 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { metrics } from '@/lib/metrics'
 import { REPORT_TYPES, isReportType } from '@/lib/reportTypes'
 import { isRealSupabaseError } from '@/lib/supabaseErrors'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 export async function POST(request: Request) {
   const body = await request.json()
@@ -27,6 +23,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: `Missing ${required}` }, { status: 400 })
   }
 
+  const supabase = getClient()
   // Validate that the shop exists
   const { data: shop, error: shopError } = await supabase
     .from('shops')

--- a/app/api/shops/route.ts
+++ b/app/api/shops/route.ts
@@ -1,16 +1,11 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { withMetrics } from '@/lib/withMetrics'
 import { SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
-
-// Supabase configuration
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 const fetchShops = async (neighborhood?: string) => {
-  let query = supabase.from('shops').select(SHOP_WITH_ROASTER_SELECT).order('name', { ascending: true })
+  let query = getClient().from('shops').select(SHOP_WITH_ROASTER_SELECT).order('name', { ascending: true })
 
   if (neighborhood) {
     query = query.eq('neighborhood', neighborhood)

--- a/app/api/shops/submit/route.ts
+++ b/app/api/shops/submit/route.ts
@@ -1,11 +1,7 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { metrics } from '@/lib/metrics'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 export async function POST(request: Request) {
   const { name, address, neighborhood, website } = await request.json()
@@ -14,7 +10,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
   }
 
-  const { data, error } = await supabase
+  const { data, error } = await getClient()
     .from('moderation')
     .insert([{ name, address, neighborhood, website }])
 

--- a/app/api/updates/capture/route.ts
+++ b/app/api/updates/capture/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { logger } from '@/lib/logger'
-import { getImageData, getShopCandidates, buildShopContext, validateShopUUID, callAnthropicVision, getRoasterID, supabase } from '@/lib/capture'
+import { getImageData, getShopCandidates, buildShopContext, validateShopUUID, callAnthropicVision, getRoasterID } from '@/lib/capture'
+import { getClient } from '@/lib/supabase/server-client'
 
 interface ExtractedUpdate {
   shop_name: string
@@ -59,6 +60,7 @@ export async function POST(request: Request) {
 
   const shop = validateShopUUID(shopCandidates, extracted.shop_uuid)
   const roasterId = shop ? await getRoasterID(shop.uuid) : null
+  const supabase = getClient()
 
   const { error: insertError } = await supabase
     .from('updates')

--- a/app/api/updates/route.ts
+++ b/app/api/updates/route.ts
@@ -1,14 +1,10 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { UPDATE_SELECT } from '@/app/utils/updates'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 const fetchUpdates = async (shopID?: string) => {
-  let query = supabase
+  let query = getClient()
     .from('updates')
     .select(UPDATE_SELECT)
     .order('post_date', { ascending: false })

--- a/app/u/[id]/opengraph-image.tsx
+++ b/app/u/[id]/opengraph-image.tsx
@@ -1,17 +1,13 @@
 import { ImageResponse } from 'next/og'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import { getPublicProfile } from '@/app/utils/profiles'
 import { computeStats } from '@/app/utils/visitStats'
 import { OG_COLORS, OG_IMAGE_SIZE, OG_CONTENT_TYPE, getOgLogoSrc, OG_NO_PHOTO_BACKGROUND, getOgWatermarkSrc } from '@/app/utils/ogTheme'
+import { getClient } from '@/lib/supabase/server-client'
 
 export const size = OG_IMAGE_SIZE
 export const contentType = OG_CONTENT_TYPE
 export const alt = 'pgh.coffee passport'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
 function Stat({ value, label, valueSize = 64 }: { value: string; label: string; valueSize?: number }) {
   return (
@@ -79,6 +75,7 @@ function Card({ children }: { children: React.ReactNode }) {
 
 export default async function Image({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+  const supabase = getClient()
   const [profile, { data: shops, error: shopsError }] = await Promise.all([
     getPublicProfile(id),
     supabase.from('shops').select('neighborhood'),

--- a/app/utils/claims.ts
+++ b/app/utils/claims.ts
@@ -1,12 +1,8 @@
-import { createClient } from '@supabase/supabase-js'
 import { getShopByUuidPrefix } from './shops'
 import { getCompanyBySlug } from './companies'
 import { getRoasterBySlug } from './roasters'
 import type { ClaimType } from '@/types/claim-types'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 export interface ClaimTarget {
   type: ClaimType
@@ -24,6 +20,7 @@ export interface ClaimTarget {
 // company_id only — a shop's roaster_id is "serves this coffee", not ownership.
 // @TODO why are we making DB calls here?
 async function companyTarget(id: string, name: string, logo?: string | null): Promise<ClaimTarget> {
+  const supabase = getClient()
   const [{ count, error: countError }, { data: roasters, error: roasterError }] = await Promise.all([
     supabase.from('shops').select('uuid', { count: 'exact', head: true }).eq('company_id', id),
     supabase.from('roaster').select('id').eq('company_id', id).limit(1),

--- a/app/utils/companies.ts
+++ b/app/utils/companies.ts
@@ -1,9 +1,5 @@
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 /**
  * Resolves a company from a `/companies/{slug}` identifier. Companies carry their
@@ -12,7 +8,7 @@ const supabase = createClient(supabaseUrl, supabaseAnonKey)
  * route so both agree on the lookup.
  */
 export const getCompanyBySlug = async (slug: string) => {
-  const { data, error } = await supabase
+  const { data, error } = await getClient()
     .from('companies')
     .select('*')
     .eq('slug', slug)

--- a/app/utils/events.ts
+++ b/app/utils/events.ts
@@ -1,14 +1,10 @@
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 const EVENT_SELECT = '*, shop:shop_id(*, company:company_id(*)), roaster:roaster_id(*)'
 
 export const visibleEvents = (select: string = EVENT_SELECT) =>
-  supabase.from('events').select(select).eq('is_hidden', false)
+  getClient().from('events').select(select).eq('is_hidden', false)
 
 /**
  * Resolves an event from a `/events/{slug}` identifier's id prefix. The `id`

--- a/app/utils/profiles.ts
+++ b/app/utils/profiles.ts
@@ -1,16 +1,11 @@
 import { cache } from 'react'
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
 import type { Visit } from '@/app/utils/visitStats'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
+import { getClient } from '@/lib/supabase/server-client'
 
 // Anonymous client: queries run as the `anon` Postgres role, so RLS only ever
 // returns public profiles and their visits. This is what guarantees the public
 // path can never read private data or any auth.users field (email, etc.).
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
-
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export interface PublicProfile {
@@ -24,6 +19,7 @@ export const getPublicProfile = cache(async (id: string): Promise<PublicProfile 
   // it to Postgres raises a uuid-syntax error we'd log at error level. Skip it.
   if (!UUID_RE.test(id)) return null
 
+  const supabase = getClient()
   const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('user_id, display_name, avatar_url')

--- a/app/utils/roasters.ts
+++ b/app/utils/roasters.ts
@@ -1,9 +1,5 @@
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 /**
  * Resolves a roaster from a `/roasters/{slug}` identifier. Roasters carry their
@@ -12,7 +8,7 @@ const supabase = createClient(supabaseUrl, supabaseAnonKey)
  * route so both agree on the query.
  */
 export const getRoasterBySlug = async (slug: string) => {
-  const { data, error } = await supabase
+  const { data, error } = await getClient()
     .from('roaster')
     .select('*, company:company_id(*)')
     .eq('slug', slug)

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -1,17 +1,15 @@
 import { cache } from 'react'
-import { createClient } from '@supabase/supabase-js'
 import type { Metadata } from 'next'
 import type { CafeOrCoffeeShopLeaf, CollectionPageLeaf, OrganizationLeaf, WebSite, WithContext } from 'schema-dts'
 import { DbShop } from '@/types/shop-types'
 import { logger } from '@/lib/logger'
 import { buildShopSlug, extractUuidPrefix } from '@/app/utils/shopSlug'
 import { getShopByUuidPrefix } from '@/app/utils/shops'
+import { getClient } from '@/lib/supabase/server-client'
 
 export const SITE_URL = 'https://pgh.coffee'
 export const SITE_NAME = 'pgh.coffee'
 
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
 
 /** The shop fields needed to build a `/shops/{slug}` identifier. */
 export type ShopSlugInput = { name: string; neighborhood: string; uuid: string }
@@ -59,10 +57,6 @@ export function jsonLdToString(data: unknown): string {
   return JSON.stringify(data).replace(/</g, '\\u003c')
 }
 
-function getSupabase() {
-  return createClient(supabaseUrl, supabaseAnonKey)
-}
-
 /**
  * Resolves the shop for a `/shops/{slug}` page from its uuid prefix, or null if
  * the slug has no prefix / matches nothing. Wrapped in React's cache() so
@@ -85,7 +79,7 @@ export interface ShopListEntry {
  * `/shops/{slug}` URL (the uuid suffix keeps same-name locations distinct).
  */
 export const getAllShopsForSeo = cache(async (): Promise<ShopListEntry[]> => {
-  const supabase = getSupabase()
+  const supabase = getClient()
   const { data, error } = await supabase
     .from('shops')
     .select('name, neighborhood, uuid')

--- a/app/utils/shops.ts
+++ b/app/utils/shops.ts
@@ -1,18 +1,14 @@
-import { createClient } from '@supabase/supabase-js'
 import { DbShop } from '@/types/shop-types'
 import { logger } from '@/lib/logger'
 import { SHOP_WITH_ROASTER_SELECT } from '@/app/utils/utils'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 export const getShopByUuidPrefix = async (prefix: string): Promise<DbShop | null> => {
   // The `uuid` column is a Postgres `uuid` type, which has no LIKE operator, so
   // we can't prefix-match it as text. The 8-char prefix is exactly the first
   // group of the uuid, so a range bounded by the all-zero and all-f completions
   // matches every uuid sharing that prefix while still using the uuid index.
-  const { data, error } = await supabase
+  const { data, error } = await getClient()
     .from('shops')
     .select(SHOP_WITH_ROASTER_SELECT)
     .gte('uuid', `${prefix}-0000-0000-0000-000000000000`)

--- a/app/utils/updates.ts
+++ b/app/utils/updates.ts
@@ -1,9 +1,5 @@
-import { createClient } from '@supabase/supabase-js'
 import { logger } from '@/lib/logger'
-
-const supabaseUrl = process.env.SUPABASE_URL as string
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { getClient } from '@/lib/supabase/server-client'
 
 export const UPDATE_SELECT = '*, shop:shops(*, company:company_id(*)), roaster:roaster_id(id, name, slug)'
 
@@ -15,7 +11,7 @@ export const UPDATE_SELECT = '*, shop:shops(*, company:company_id(*)), roaster:r
  * falls within its own prefix range.
  */
 export const getUpdateByIdPrefix = async (prefix: string) => {
-  const { data, error } = await supabase
+  const { data, error } = await getClient()
     .from('updates')
     .select(UPDATE_SELECT)
     .gte('id', `${prefix}-0000-0000-0000-000000000000`)

--- a/lib/capture.ts
+++ b/lib/capture.ts
@@ -1,15 +1,10 @@
-import { createClient } from '@supabase/supabase-js'
+import { getClient } from '@/lib/supabase/server-client'
 
 export interface Shop {
   uuid: string
   name: string
   neighborhood: string
 }
-
-export const supabase = createClient(
-  process.env.SUPABASE_URL as string,
-  process.env.SUPABASE_ANON_KEY as string
-)
 
 export async function getImageData(request: Request): Promise<{ base64Image: string; mediaType: string } | null> {
   const contentType = request.headers.get('content-type') ?? ''
@@ -90,7 +85,7 @@ export async function getShopCandidates(base64Image: string, mediaType: string):
   const shopName = result.content[0].text.trim()
   console.log(`[capture] shop name from first pass: "${shopName}"`)
 
-  const { data } = await supabase
+  const { data } = await getClient()
     .from('shops')
     .select('uuid, name, neighborhood')
     .ilike('name', `%${shopName}%`)
@@ -111,7 +106,7 @@ export function validateShopUUID(candidates: Shop[], uuid: string | null): Shop 
 }
 
 export async function getRoasterID(shopUuid: string): Promise<string | null> {
-  const { data: shop } = await supabase
+  const { data: shop } = await getClient()
     .from('shops')
     .select('company_id')
     .eq('uuid', shopUuid)
@@ -119,7 +114,7 @@ export async function getRoasterID(shopUuid: string): Promise<string | null> {
 
   if (!shop?.company_id) return null
 
-  const { data: roaster } = await supabase
+  const { data: roaster } = await getClient()
     .from('roaster')
     .select('id')
     .eq('company_id', shop.company_id)

--- a/lib/supabase/env.ts
+++ b/lib/supabase/env.ts
@@ -10,3 +10,16 @@ export function getSupabaseEnv() {
 
   return { supabaseUrl, supabaseAnonKey }
 }
+
+export function getServerSupabaseEnv() {
+  const supabaseUrl = process.env.SUPABASE_URL
+  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error(
+      'Missing Supabase server environment variables. Please set SUPABASE_URL and SUPABASE_ANON_KEY.'
+    )
+  }
+
+  return { supabaseUrl, supabaseAnonKey }
+}

--- a/lib/supabase/server-client.ts
+++ b/lib/supabase/server-client.ts
@@ -1,0 +1,14 @@
+import { createClient as createSupabaseClient, type SupabaseClient } from '@supabase/supabase-js'
+import { getServerSupabaseEnv } from './env'
+
+let client: SupabaseClient | undefined
+
+/** Returns the shared, cookie-free Supabase client used by public server reads. */
+export function getClient() {
+  if (!client) {
+    const { supabaseUrl, supabaseAnonKey } = getServerSupabaseEnv()
+    client = createSupabaseClient(supabaseUrl, supabaseAnonKey)
+  }
+
+  return client
+}

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,5 +1,8 @@
 import '@testing-library/jest-dom'
 
+process.env.SUPABASE_URL ??= 'https://example.supabase.co'
+process.env.SUPABASE_ANON_KEY ??= 'test-anon-key'
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: vi.fn().mockImplementation(query => ({


### PR DESCRIPTION
Closes #382

## What do these changes accomplish?

Replaces the ~25 hand-rolled, module-scope Supabase clients across API routes and utils with one shared, lazily-created server client.

## Why?

Every file that talked to the database built its own Supabase client the moment it was imported. That meant importing a file just to grab a constant spun up a client nobody used, and because the env vars were cast with `as string`, a missing `SUPABASE_URL` didn't surface until a query failed at request time rather than at startup.

No behavior change for users.
