### PR TITLE
Fix 404 page rendering under the map layout

### DIFF
--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -23,6 +23,7 @@ export default function HomeClient() {
   const panelContent = usePanelStore(s => s.panelContent)
   const clearHistory = usePanelStore(s => s.clearHistory)
   const panelMode = usePanelStore(s => s.panelMode)
+  const hidden = usePanelStore(s => s.hidden)
   const setPanelContent = usePanelStore(s => s.setPanelContent)
 
   const largeViewport = useMediaQuery('(min-width: 1024px)')
@@ -129,6 +130,9 @@ export default function HomeClient() {
       document.title = 'PGH Coffee'
     }
   }, [currentShop])
+
+  // A 404 renders inside this layout, so the map and panel step aside for it.
+  if (hidden) return null
 
   return (
     <div className="relative w-full h-full">

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+import { Coffee } from 'lucide-react'
+
+export default function NotFound() {
+  return (
+    <div className="min-h-[60vh] flex flex-col items-center justify-center text-center px-4">
+      <Coffee className="h-12 w-12 text-gray-300 mb-4" />
+      <h2 className="text-lg font-medium text-gray-900 mb-2">Page not found</h2>
+      <p className="text-gray-500 max-w-sm mb-6">
+        We couldn&apos;t find that one. It may have moved or closed up shop.
+      </p>
+      <Link
+        href="/"
+        className="inline-flex items-center gap-2 rounded-lg py-3 px-4 text-sm font-semibold text-black bg-yellow-300 hover:bg-yellow-400"
+      >
+        Go home
+      </Link>
+    </div>
+  )
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -10,13 +10,15 @@ export default function NotFound() {
 
   // A 404 under /shops, /roasters, /companies, /news or /events renders inside
   // the map layout, so HomeClient would otherwise mount the map and panel too.
+  // This effect only runs after hydration; the opaque overlay below covers the
+  // server-rendered panel until then.
   useEffect(() => {
     setHidden(true)
     return () => setHidden(false)
   }, [setHidden])
 
   return (
-    <div className="min-h-[60vh] flex flex-col items-center justify-center text-center px-4">
+    <div className="fixed inset-x-0 top-16 bottom-0 z-50 bg-gray-50 flex flex-col items-center justify-center text-center px-4">
       <Coffee className="h-12 w-12 text-gray-300 mb-4" />
       <h2 className="text-lg font-medium text-gray-900 mb-2">Page not found</h2>
       <p className="text-gray-500 max-w-sm mb-6">

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,7 +1,20 @@
+'use client'
+
+import { useEffect } from 'react'
 import Link from 'next/link'
 import { Coffee } from 'lucide-react'
+import usePanelStore from '@/stores/panelStore'
 
 export default function NotFound() {
+  const setHidden = usePanelStore(s => s.setHidden)
+
+  // A 404 under /shops, /roasters, /companies, /news or /events renders inside
+  // the map layout, so HomeClient would otherwise mount the map and panel too.
+  useEffect(() => {
+    setHidden(true)
+    return () => setHidden(false)
+  }, [setHidden])
+
   return (
     <div className="min-h-[60vh] flex flex-col items-center justify-center text-center px-4">
       <Coffee className="h-12 w-12 text-gray-300 mb-4" />

--- a/hooks/clearOwnPanel.tsx
+++ b/hooks/clearOwnPanel.tsx
@@ -1,0 +1,15 @@
+import usePanelStore, { PanelMode } from '@/stores/panelStore'
+import { ExploreContent } from '@/app/components/ExploreContent'
+
+/**
+ * A route-sync hook owns the panel only while its own route is showing. Leaving
+ * that route through a bare `/` link — the 404's "Go home", the account pages —
+ * never goes through `handleClose`, so without this the panel outlives its
+ * route. The mode check keeps a hook from clobbering a panel that another
+ * route's hook set in the same pass.
+ */
+export const clearOwnPanel = (...modes: PanelMode[]) => {
+  const { panelMode, reset } = usePanelStore.getState()
+  if (!panelMode || !modes.includes(panelMode)) return
+  reset({ mode: 'explore', content: <ExploreContent /> })
+}

--- a/hooks/useCompanyRouteSync.tsx
+++ b/hooks/useCompanyRouteSync.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useParams, usePathname } from 'next/navigation'
 import usePanelStore from '@/stores/panelStore'
 import { Company } from '@/app/components/Company'
+import { clearOwnPanel } from './clearOwnPanel'
 
 /**
  * Syncs the panel from the company route: `/companies/{slug}` opens a single
@@ -17,9 +18,12 @@ export const useCompanyRouteSync = () => {
   const onCompanyRoute = pathname.startsWith('/companies/')
 
   useEffect(() => {
-    if (onCompanyRoute && slug) {
-      setPanelContent(<Company slug={slug} />, 'company')
+    if (!onCompanyRoute || !slug) {
+      clearOwnPanel('company')
+      return
     }
+
+    setPanelContent(<Company slug={slug} />, 'company')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [slug, onCompanyRoute])
 }

--- a/hooks/useEventRouteSync.tsx
+++ b/hooks/useEventRouteSync.tsx
@@ -3,6 +3,7 @@ import { useParams, usePathname, useSearchParams } from 'next/navigation'
 import usePanelStore from '@/stores/panelStore'
 import { EventDetails } from '@/app/components/EventDetails'
 import { Events } from '@/app/components/Events'
+import { clearOwnPanel } from './clearOwnPanel'
 
 /**
  * Syncs the panel from the events routes: `/events/{slug}` opens a single event,
@@ -30,7 +31,10 @@ export const useEventRouteSync = () => {
 
     if (hasEventsList) {
       setPanelContent(<Events />, 'events')
+      return
     }
+
+    clearOwnPanel('event', 'events')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [slug, onEventRoute, hasEventsList])
 }

--- a/hooks/useNewsRouteSync.tsx
+++ b/hooks/useNewsRouteSync.tsx
@@ -4,6 +4,7 @@ import usePanelStore, { getPanelNewsItem } from '@/stores/panelStore'
 import { NewsDetails } from '@/app/components/NewsDetails'
 import { News } from '@/app/components/News'
 import { buildContentSlug } from '@/app/utils/slug'
+import { clearOwnPanel } from './clearOwnPanel'
 
 const isSameNewsSlug = (content: ReactNode, slug: string) => {
   const news = getPanelNewsItem(content)
@@ -44,6 +45,9 @@ export const useNewsRouteSync = () => {
 
     if (hasNewsList) {
       usePanelStore.getState().setPanelContent(<News />, 'news')
+      return
     }
+
+    clearOwnPanel('news')
   }, [slug, onNewsRoute, hasNewsList])
 }

--- a/hooks/useRoasterRouteSync.tsx
+++ b/hooks/useRoasterRouteSync.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useParams, usePathname } from 'next/navigation'
 import usePanelStore from '@/stores/panelStore'
 import { RoasterDetails } from '@/app/components/RoasterDetails'
+import { clearOwnPanel } from './clearOwnPanel'
 
 /**
  * Syncs the panel from the roaster route: `/roasters/{slug}` opens a single
@@ -16,9 +17,12 @@ export const useRoasterRouteSync = () => {
   const onRoasterRoute = pathname.startsWith('/roasters/')
 
   useEffect(() => {
-    if (onRoasterRoute && slug) {
-      setPanelContent(<RoasterDetails slug={slug} />, 'roaster')
+    if (!onRoasterRoute || !slug) {
+      clearOwnPanel('roaster')
+      return
     }
+
+    setPanelContent(<RoasterDetails slug={slug} />, 'roaster')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [slug, onRoasterRoute])
 }

--- a/stores/panelStore.ts
+++ b/stores/panelStore.ts
@@ -117,6 +117,8 @@ interface PanelState {
   panelMode: PanelMode | null
   panelContent: ReactNode | null
   history: PanelEntry[]
+  /** 404s render inside the map layout, so app/not-found.tsx hides the map and panel. */
+  hidden: boolean
 
   // setters
   /** Pushes a new panel onto the stack (default). Use opts.push=false to replace. */
@@ -128,6 +130,8 @@ interface PanelState {
 
   /** Clears the navigation history. Pass { keepCurrent: true } to keep the current panel as the only entry. */
   clearHistory: (opts?: { keepCurrent?: boolean }) => void
+
+  setHidden: (hidden: boolean) => void
 }
 
 const usePanelStore = create<PanelState>()(
@@ -136,6 +140,9 @@ const usePanelStore = create<PanelState>()(
       panelMode: 'explore',
       panelContent: null,
       history: [],
+      hidden: false,
+
+      setHidden: hidden => set({ hidden }),
 
       setPanelContent: (content, mode) =>
         set(state => {

--- a/stores/panelStore.ts
+++ b/stores/panelStore.ts
@@ -7,7 +7,7 @@ import { buildShopSlug } from '@/app/utils/shopSlug'
 import { buildContentSlug } from '@/app/utils/slug'
 import useCoffeeShopsStore from './coffeeShopsStore'
 
-type PanelMode = 'explore' | 'search' | 'shop' | 'list' | 'news' | 'events' | 'company' | 'roaster' | 'event'
+export type PanelMode = 'explore' | 'search' | 'shop' | 'list' | 'news' | 'events' | 'company' | 'roaster' | 'event'
 
 type PanelEntry = {
   mode: PanelMode

--- a/tests/unit/notFound.test.tsx
+++ b/tests/unit/notFound.test.tsx
@@ -1,12 +1,38 @@
-import { describe, it, expect } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
 import NotFound from '@/app/not-found'
+import HomeClient from '@/app/components/HomeClient'
 import usePanelStore from '@/stores/panelStore'
 
-describe('NotFound', () => {
-  it('hides the map panel while mounted and restores it on unmount', () => {
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => '/companies/does-not-exist',
+  useParams: () => ({ slug: 'does-not-exist' }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock('next-plausible', () => ({ usePlausible: () => vi.fn() }))
+
+beforeAll(() => {
+  globalThis.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })
+  globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+})
+
+afterEach(() => {
+  usePanelStore.setState({ hidden: false })
+})
+
+describe('404 under the map layout', () => {
+  it('keeps HomeClient from rendering the map and panel', () => {
     const { unmount } = render(<NotFound />)
-    expect(usePanelStore.getState().hidden).toBe(true)
+    render(<HomeClient />)
+
+    expect(screen.queryByTestId('map-placeholder')).toBeNull()
+    expect(screen.queryByTestId('shop-panel')).toBeNull()
 
     unmount()
     expect(usePanelStore.getState().hidden).toBe(false)

--- a/tests/unit/notFound.test.tsx
+++ b/tests/unit/notFound.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import NotFound from '@/app/not-found'
+import usePanelStore from '@/stores/panelStore'
+
+describe('NotFound', () => {
+  it('hides the map panel while mounted and restores it on unmount', () => {
+    const { unmount } = render(<NotFound />)
+    expect(usePanelStore.getState().hidden).toBe(true)
+
+    unmount()
+    expect(usePanelStore.getState().hidden).toBe(false)
+  })
+})

--- a/tests/unit/useCompanyRouteSync.test.tsx
+++ b/tests/unit/useCompanyRouteSync.test.tsx
@@ -6,16 +6,17 @@ const h = vi.hoisted(() => ({
   slug: undefined as string | undefined,
   pathname: '/' as string,
   setPanelContent: vi.fn(),
+  reset: vi.fn(),
+  panelMode: null as string | null,
 }))
 
 vi.mock('next/navigation', () => ({ useParams: () => ({ slug: h.slug }), usePathname: () => h.pathname }))
-vi.mock('@/stores/panelStore', () => ({
-  __esModule: true,
-  default: (selector?: (s: unknown) => unknown) => {
-    const state = { setPanelContent: h.setPanelContent }
-    return selector ? selector(state) : state
-  },
-}))
+vi.mock('@/stores/panelStore', () => {
+  const getState = () => ({ setPanelContent: h.setPanelContent, reset: h.reset, panelMode: h.panelMode })
+  const store = (selector?: (s: unknown) => unknown) => (selector ? selector(getState()) : getState())
+  store.getState = getState
+  return { __esModule: true, default: store }
+})
 vi.mock('@/app/components/Company', () => ({ Company: () => null }))
 
 describe('useCompanyRouteSync', () => {
@@ -23,6 +24,7 @@ describe('useCompanyRouteSync', () => {
     vi.clearAllMocks()
     h.slug = undefined
     h.pathname = '/'
+    h.panelMode = null
   })
 
   test('opens the company panel when on a /companies/{slug} route', () => {
@@ -43,5 +45,25 @@ describe('useCompanyRouteSync', () => {
     renderHook(() => useCompanyRouteSync())
 
     expect(h.setPanelContent).not.toHaveBeenCalled()
+  })
+
+  test('clears the company panel when the route is left with the panel still showing', () => {
+    // "Go home" from a 404 is a bare <Link href="/">, so it never runs
+    // handleClose — without this the company panel outlives its route.
+    h.pathname = '/'
+    h.panelMode = 'company'
+
+    renderHook(() => useCompanyRouteSync())
+
+    expect(h.reset).toHaveBeenCalledWith(expect.objectContaining({ mode: 'explore' }))
+  })
+
+  test('leaves a panel another route owns alone', () => {
+    h.pathname = '/roasters/commonplace-coffee'
+    h.panelMode = 'roaster'
+
+    renderHook(() => useCompanyRouteSync())
+
+    expect(h.reset).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/useRoasterRouteSync.test.tsx
+++ b/tests/unit/useRoasterRouteSync.test.tsx
@@ -6,16 +6,17 @@ const h = vi.hoisted(() => ({
   slug: undefined as string | undefined,
   pathname: '/' as string,
   setPanelContent: vi.fn(),
+  reset: vi.fn(),
+  panelMode: null as string | null,
 }))
 
 vi.mock('next/navigation', () => ({ useParams: () => ({ slug: h.slug }), usePathname: () => h.pathname }))
-vi.mock('@/stores/panelStore', () => ({
-  __esModule: true,
-  default: (selector?: (s: unknown) => unknown) => {
-    const state = { setPanelContent: h.setPanelContent }
-    return selector ? selector(state) : state
-  },
-}))
+vi.mock('@/stores/panelStore', () => {
+  const getState = () => ({ setPanelContent: h.setPanelContent, reset: h.reset, panelMode: h.panelMode })
+  const store = (selector?: (s: unknown) => unknown) => (selector ? selector(getState()) : getState())
+  store.getState = getState
+  return { __esModule: true, default: store }
+})
 vi.mock('@/app/components/RoasterDetails', () => ({ RoasterDetails: () => null }))
 
 describe('useRoasterRouteSync', () => {
@@ -23,6 +24,7 @@ describe('useRoasterRouteSync', () => {
     vi.clearAllMocks()
     h.slug = undefined
     h.pathname = '/'
+    h.panelMode = null
   })
 
   test('opens the roaster panel when on a /roasters/{slug} route', () => {


### PR DESCRIPTION
## What do these changes accomplish?

Shows a real 404 page for unknown shop, roaster, company, news, and event URLs instead of one buried under the map and panel.

## Why?

`app/not-found.tsx` renders inside the map layout, so `HomeClient` mounted the map and the panel on top of it — a bad URL looked like a broken app rather than a missing page.

## Screenshots

| Before | After |
|---|---|
| <img width="1434" height="1087" alt="image" src="https://github.com/user-attachments/assets/211380d1-2721-4440-89f6-118b2452a2e3" />| <img width="1436" height="650" alt="image" src="https://github.com/user-attachments/assets/5cefa730-5f52-445e-bbb2-f602a54726c8" /> |